### PR TITLE
fix: Fix typo in centralized-grafana config

### DIFF
--- a/services/centralized-grafana/17.2.1/defaults/cm.yaml
+++ b/services/centralized-grafana/17.2.1/defaults/cm.yaml
@@ -130,7 +130,7 @@ data:
     coreDns:
       enabled: false
     kubeDns:
-      enabled: fales
+      enabled: false
     kubeEtcd:
       enabled: false
     kubeScheduler:


### PR DESCRIPTION
Happened to find a little typo in the centralized-grafana config