### PR TITLE
fix: make it possible to migrate Istio from DKP 1.x

### DIFF
--- a/services/istio/1.9.1/istio.yaml
+++ b/services/istio/1.9.1/istio.yaml
@@ -8,8 +8,6 @@ spec:
   dependsOn:
     - name: kube-prometheus-stack
       namespace: ${releaseNamespace}
-    - name: cert-manager
-      namespace: ${releaseNamespace}
   chart:
     spec:
       chart: istio


### PR DESCRIPTION
This involves two changes:
- Istio is moved back into the `istio-system` NS
- hard dependency on `cert-manager` HelmRelease is removed