### PR TITLE
chore: change jaeger targetNamespace to istio-system

### DIFF
--- a/services/jaeger/2.21.0/jaeger.yaml
+++ b/services/jaeger/2.21.0/jaeger.yaml
@@ -21,6 +21,7 @@ spec:
     remediation:
       retries: 30
   releaseName: jaeger
+  targetNamespace: istio-system
   valuesFrom:
     - kind: ConfigMap
       name: jaeger-2.21.0-d2iq-defaults


### PR DESCRIPTION
Changes target namespace of the jaeger to istio-system