### PR TITLE
chore: change Kiali's targetNamespace to istio-system

### DIFF
--- a/services/kiali/1.29.1/kiali.yaml
+++ b/services/kiali/1.29.1/kiali.yaml
@@ -29,6 +29,7 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: kiali-1.29.1-d2iq-defaults
+  targetNamespace: istio-system
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
This is needed to keep it consistent with Istio/Jaeger on 2.1
and also with Kiali on 1.x.