### PR TITLE
fix: make clean install of Istio work again

### DIFF
--- a/services/istio/1.9.1/helmrelease.yaml
+++ b/services/istio/1.9.1/helmrelease.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   force: false
   prune: true
-  interval: 1m0s
+  interval: 10s
   path: ./services/istio/1.9.1/helmrelease
   dependsOn:
     - name: istio-ca

--- a/services/istio/1.9.1/helmrelease.yaml
+++ b/services/istio/1.9.1/helmrelease.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  name: istio-helmrelease
+  namespace: ${releaseNamespace}
+spec:
+  force: false
+  prune: true
+  interval: 1m0s
+  path: ./services/istio/1.9.1/helmrelease
+  dependsOn:
+    - name: istio-ca
+    - name: istio-system-namespace
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: substitution-vars

--- a/services/istio/1.9.1/helmrelease/helmrelease.yaml
+++ b/services/istio/1.9.1/helmrelease/helmrelease.yaml
@@ -28,24 +28,3 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: istio-1.9.1-d2iq-defaults
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: istio-ca
-  namespace: istio-system
-  annotations:
-    "helm.sh/hook": pre-install
-spec:
-  isCA: true
-  commonName: istio-ca
-  dnsNames:
-  - ca.istio.io
-  duration: 87600h
-  subject:
-    organizations:
-      - D2iQ
-  secretName: istio-ca
-  issuerRef:
-    name: ${caIssuerName}
-    kind: Issuer

--- a/services/istio/1.9.1/istio-ca.yaml
+++ b/services/istio/1.9.1/istio-ca.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  name: istio-ca
+  namespace: ${releaseNamespace}
+spec:
+  force: false
+  prune: true
+  interval: 1m0s
+  path: ./services/istio/1.9.1/istio-ca
+  dependsOn:
+  - name: istio-system-namespace
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: substitution-vars

--- a/services/istio/1.9.1/istio-ca.yaml
+++ b/services/istio/1.9.1/istio-ca.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: ${releaseNamespace}
 spec:
   force: false
-  prune: true
+  prune: false
   interval: 10s
   path: ./services/istio/1.9.1/istio-ca
   dependsOn:

--- a/services/istio/1.9.1/istio-ca.yaml
+++ b/services/istio/1.9.1/istio-ca.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   force: false
   prune: true
-  interval: 1m0s
+  interval: 10s
   path: ./services/istio/1.9.1/istio-ca
   dependsOn:
   - name: istio-system-namespace

--- a/services/istio/1.9.1/istio-ca/istio-ca.yaml
+++ b/services/istio/1.9.1/istio-ca/istio-ca.yaml
@@ -3,6 +3,8 @@ kind: Certificate
 metadata:
   name: istio-ca
   namespace: istio-system
+  annotations:
+    "helm.sh/hook": pre-install
 spec:
   isCA: true
   commonName: istio-ca

--- a/services/istio/1.9.1/istio-ca/istio-ca.yaml
+++ b/services/istio/1.9.1/istio-ca/istio-ca.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: istio-ca
+  namespace: istio-system
+spec:
+  isCA: true
+  commonName: istio-ca
+  dnsNames:
+  - ca.istio.io
+  duration: 87600h
+  subject:
+    organizations:
+      - D2iQ
+  secretName: istio-ca
+  issuerRef:
+    name: ${caIssuerName}
+    kind: Issuer

--- a/services/istio/1.9.1/istio-ca/istio-ca.yaml
+++ b/services/istio/1.9.1/istio-ca/istio-ca.yaml
@@ -17,4 +17,4 @@ spec:
   secretName: istio-ca
   issuerRef:
     name: ${caIssuerName}
-    kind: Issuer
+    kind: ClusterIssuer

--- a/services/istio/1.9.1/istio-ca/istio-ca.yaml
+++ b/services/istio/1.9.1/istio-ca/istio-ca.yaml
@@ -1,3 +1,5 @@
+# Creating this correctly should be a responsibility of the Helm chart
+# - see D2IQ-80630
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/services/istio/1.9.1/istio-system-namespace.yaml
+++ b/services/istio/1.9.1/istio-system-namespace.yaml
@@ -1,3 +1,6 @@
+# After the HelmRelease becomes the only object created by Kustomizations
+# in the `istio-system` Namespace, creating this Namespace should be made
+# a responsibility of the HelmRelease (see D2IQ-80630).
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
 kind: Kustomization
 metadata:

--- a/services/istio/1.9.1/istio-system-namespace.yaml
+++ b/services/istio/1.9.1/istio-system-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  name: istio-system-namespace
+  namespace: ${releaseNamespace}
+spec:
+  force: false
+  prune: false
+  interval: 1m0s
+  path: ./services/istio/1.9.1/istio-system-namespace
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux

--- a/services/istio/1.9.1/istio-system-namespace/istio-system.yaml
+++ b/services/istio/1.9.1/istio-system-namespace/istio-system.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: istio-system

--- a/services/istio/1.9.1/istio-system-namespace/istio-system.yaml
+++ b/services/istio/1.9.1/istio-system-namespace/istio-system.yaml
@@ -1,3 +1,6 @@
+# After the HelmRelease becomes the only object created by Kustomizations
+# in the `istio-system` Namespace, creating this Namespace should be made
+# a responsibility of the HelmRelease (see D2IQ-80630).
 kind: Namespace
 apiVersion: v1
 metadata:

--- a/services/istio/1.9.1/kustomization.yaml
+++ b/services/istio/1.9.1/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - istio.yaml
+  - istio-system-namespace.yaml
+  - istio-ca.yaml
+  - helmrelease.yaml

--- a/services/jaeger/2.21.0/jaeger.yaml
+++ b/services/jaeger/2.21.0/jaeger.yaml
@@ -13,6 +13,10 @@ spec:
         name: jaegertracing-github-io
         namespace: kommander-flux
       version: "2.21.0"
+  # The main reason behind this dependency is to wait until
+  # the istio-system namespace is actually created
+  dependsOn:
+    - name: istio
   interval: 15s
   install:
     remediation:


### PR DESCRIPTION
Now that Istio is installed into the `istio-system` namespace, two more changes are needed  to make the clean install work:
 - the namespace itself needs to be created before additional objects (`istso-ca` Certificate, etc.) can be created in it
 - we have to switch to using the ClusterIssuer instead of an Issuer, as there are no Issuers in the `istio-system` NS