### PR TITLE
feat: create Ingress for Gitea

### DIFF
--- a/services/gitea/4.1.1/defaults/cm.yaml
+++ b/services/gitea/4.1.1/defaults/cm.yaml
@@ -17,14 +17,14 @@ data:
         traefik.ingress.kubernetes.io/router.tls: "true"
       hosts:
         - paths:
-          - path: /dkp/kommander/gitserver
+          - path: /dkp/kommander/git
             pathType: ImplementationSpecific
     gitea:
       admin:
         existingSecret: ${adminCredentialsSecret}
       config:
         server:
-          ROOT_URL: https://localhost/dkp/kommander/gitserver
+          ROOT_URL: https://localhost/dkp/kommander/git
           PROTOCOL: https
           CERT_FILE: /git-tls/tls.crt
           KEY_FILE: /git-tls/tls.key

--- a/services/gitea/4.1.1/defaults/cm.yaml
+++ b/services/gitea/4.1.1/defaults/cm.yaml
@@ -24,7 +24,7 @@ data:
         existingSecret: ${adminCredentialsSecret}
       config:
         server:
-          ROOT_URL: https://localhost
+          ROOT_URL: https://localhost/dkp/kommander/gitserver
           PROTOCOL: https
           CERT_FILE: /git-tls/tls.crt
           KEY_FILE: /git-tls/tls.key

--- a/services/gitea/4.1.1/defaults/cm.yaml
+++ b/services/gitea/4.1.1/defaults/cm.yaml
@@ -9,11 +9,22 @@ data:
     ---
     image:
       rootless: true
+    ingress:
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: kommander-traefik
+        traefik.ingress.kubernetes.io/router.middlewares: kommander-stripprefixes@kubernetescrd
+        traefik.ingress.kubernetes.io/router.tls: "true"
+      hosts:
+        - paths:
+          - path: /dkp/kommander/gitserver
+            pathType: ImplementationSpecific
     gitea:
       admin:
         existingSecret: ${adminCredentialsSecret}
       config:
         server:
+          ROOT_URL: https://localhost
           PROTOCOL: https
           CERT_FILE: /git-tls/tls.crt
           KEY_FILE: /git-tls/tls.key

--- a/services/traefik/10.3.0/defaults/cm.yaml
+++ b/services/traefik/10.3.0/defaults/cm.yaml
@@ -98,7 +98,7 @@ data:
                     - /dkp/alertmanager
                     - /dkp/api-server
                     - /dkp/kommander/dashboard
-                    - /dkp/kommander/gitserver
+                    - /dkp/kommander/git
                     - /dkp/kommander/helm-mirror
                     - /dkp/kommander/kubecost/frontend
                     - /dkp/kommander/kubecost/query


### PR DESCRIPTION
This is needed so that attached clusters can access the Git
repository.

All repositories are accessed through the URL

https://INGRESS_HOST/dkp/kommander/gitserver/USER|ORG/REPO

refs https://jira.d2iq.com/browse/D2IQ-80105