### PR TITLE
Remove trailing dots in hostnames

### DIFF
--- a/services/fluent-bit/0.16.2/defaults/cm.yaml
+++ b/services/fluent-bit/0.16.2/defaults/cm.yaml
@@ -134,7 +134,7 @@ data:
             Match audit.*
             Alias kubernetes_audit
             Labels log_source=kubernetes_audit
-            Host grafana-loki-loki-distributed-gateway.${releaseNamespace}.svc.cluster.local.
+            Host grafana-loki-loki-distributed-gateway.${releaseNamespace}.svc
             Port 80
             Retry_Limit 10
         [OUTPUT]
@@ -142,7 +142,7 @@ data:
             Match host.*
             Alias kubernetes_host
             Labels log_source=kubernetes_host
-            Host grafana-loki-loki-distributed-gateway.${releaseNamespace}.svc.cluster.local.
+            Host grafana-loki-loki-distributed-gateway.${releaseNamespace}.svc
             Port 80
             Retry_Limit 10
         [OUTPUT]
@@ -150,7 +150,7 @@ data:
             Match kernel
             Alias kubernetes_host_kernel
             Labels log_source=kubernetes_host_kernel
-            Host grafana-loki-loki-distributed-gateway.${releaseNamespace}.svc.cluster.local.
+            Host grafana-loki-loki-distributed-gateway.${releaseNamespace}.svc
             Port 80
             Retry_Limit 10
 

--- a/services/grafana-loki/0.33.1/defaults/cm.yaml
+++ b/services/grafana-loki/0.33.1/defaults/cm.yaml
@@ -63,7 +63,7 @@ data:
             cache_location: /var/loki/cache
             cache_ttl: 168h
           aws:
-            s3: "http://minio:minio123@grafana-loki-minio-hl.${releaseNamespace}.svc.cluster.local.:9000/loki"
+            s3: "http://minio:minio123@grafana-loki-minio-hl.${releaseNamespace}.svc:9000/loki"
             s3forcepathstyle: true
         chunk_store_config:
           max_look_back_period: 0s

--- a/services/kommander-flux/0.17.2/templates/apps_v1_deployment_source-controller.yaml
+++ b/services/kommander-flux/0.17.2/templates/apps_v1_deployment_source-controller.yaml
@@ -31,7 +31,7 @@ spec:
         - --log-encoding=json
         - --enable-leader-election
         - --storage-path=/data
-        - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+        - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc
         env:
         - name: RUNTIME_NAMESPACE
           valueFrom:

--- a/services/project-grafana-loki/0.33.1/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.33.1/defaults/cm.yaml
@@ -63,7 +63,7 @@ data:
             cache_location: /var/loki/cache
             cache_ttl: 168h
           aws:
-            s3: "http://minio:minio123@project-grafana-loki-minio-hl.${releaseNamespace}.svc.cluster.local.:9000/loki"
+            s3: "http://minio:minio123@project-grafana-loki-minio-hl.${releaseNamespace}.svc:9000/loki"
             s3forcepathstyle: true
         chunk_store_config:
           max_look_back_period: 0s


### PR DESCRIPTION
This change is required to make http proxing support in k20 work. 

The http libraries do not strip trailing dots when checking the `no_proxy` variable contents. This results in requests that would normally not be proxied (e.g. for `....cluster.local`) to be forwarded to http proxy. The proxy then rejects these requests 
as these addresses are local to the cluster thus resulting in breakage.

https://jira.d2iq.com/browse/D2IQ-80589