### PR TITLE
fix: align with flux's upstream manifests

### DIFF
--- a/services/kommander-flux/0.17.2/templates/apps_v1_deployment_source-controller.yaml
+++ b/services/kommander-flux/0.17.2/templates/apps_v1_deployment_source-controller.yaml
@@ -31,7 +31,7 @@ spec:
         - --log-encoding=json
         - --enable-leader-election
         - --storage-path=/data
-        - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc
+        - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
         env:
         - name: RUNTIME_NAMESPACE
           valueFrom:


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-80649

Some of the changes that #23 introduced into the repo will be overridden by next flux update. This PR realigns the repo back with what flux uses.

The `--storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc` string  is originating from [here](https://github.com/vespian/flux2/blob/8ec5492d87c2891ddc7e8c6b691e7246b8c027a2/pkg/manifestgen/install/templates.go#L88) So we would need to remove the trailing dot here as well. The container it is running in is debian-based so this should not cause issues.

I am to just update the docs though. This is starting to be cat and mouse chase and there is no guarantee that flux people will not add new urls ending in dots as well. This is perfectly OK approach according to RFC and it is just that http proxy support does not follow it.
