### PR TITLE
fix: re-add gitserver URL to list of prefixes to strip

### DIFF
--- a/services/traefik/10.3.0/defaults/cm.yaml
+++ b/services/traefik/10.3.0/defaults/cm.yaml
@@ -99,6 +99,7 @@ data:
                     - /dkp/api-server
                     - /dkp/kommander/dashboard
                     - /dkp/kommander/git
+                    - /dkp/kommander/gitserver
                     - /dkp/kommander/helm-mirror
                     - /dkp/kommander/kubecost/frontend
                     - /dkp/kommander/kubecost/query


### PR DESCRIPTION
This URL is still used in chart-bootstrapped Kommander clusters so as
long as we haven't completely transitioned to the CLI for
bootstrapping Kommander we need to have both URLs for the different
Git Ingresses in here.