### PR TITLE
fix: user correct ordering for prefix stripping

### DIFF
--- a/services/traefik/10.3.0/defaults/cm.yaml
+++ b/services/traefik/10.3.0/defaults/cm.yaml
@@ -98,8 +98,8 @@ data:
                     - /dkp/alertmanager
                     - /dkp/api-server
                     - /dkp/kommander/dashboard
-                    - /dkp/kommander/git
                     - /dkp/kommander/gitserver
+                    - /dkp/kommander/git
                     - /dkp/kommander/helm-mirror
                     - /dkp/kommander/kubecost/frontend
                     - /dkp/kommander/kubecost/query


### PR DESCRIPTION
Traefik prefix stripping is order-sensitve - first match wins, not the longest one. 

The incomming request has format:
```
172.18.0.3 - - [05/Nov/2021:12:28:28 +0000] "GET /dkp/kommander/gitserver/repo/info/refs?service=git-upload-pack HTTP/2.0" 404 0 "-" "-" 1155 "git-repository-kommander-dkp-kommander-gitserver@kubernetes" "https://192.168.173.21:443" 1ms
```
Traefik was stripping the first matching prefix, but due to the fact that the shorter one was listed first, instead of URLs like 
```
192.168.173.26 - - [05/Nov/2021:12:29:09 +0000] "GET /repo/info/refs?service=git-upload-pack HTTP/1.1" 401 179 "-" "git/2.0 (libgit2 1.1.0)" "-
```
traefik was forwarding URLs without the `server` part stripped:
```
192.168.173.68 - git [05/Nov/2021:12:28:28 +0000] "GET /server/repo/info/refs?service=git-upload-pack HTTP/1.1" 404 5 "-" "git/2.25.1" "172.18.
0.3"
```
this in turn was leading to 404s.

After fixing this on my local cluster, git repository on the attached cluster started syncing correctly: 
```
$ k get gitrepositories -n kommander-flux management
NAME         URL                                                   READY   STATUS                                                              AGE
management   https://172.18.255.200/dkp/kommander/gitserver/repo   True    Fetched revision: master/69db6c78580fde9bdef90502a53636e7a0198c91   74m
```