### PR TITLE
chore: Set resource requests/limits for centralized-kubecost thanos

### DIFF
--- a/services/centralized-kubecost/0.19.0/defaults/cm.yaml
+++ b/services/centralized-kubecost/0.19.0/defaults/cm.yaml
@@ -96,6 +96,13 @@ data:
           maxConcurrent: 10
           # Name of HTTP request header used for dynamic prefixing of UI links and redirects.
           webPrefixHeader: "X-Forwarded-Prefix"
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 16Gi
+            requests:
+              cpu: 1000m
+              memory: 4Gi
           http:
             service:
               labels:


### PR DESCRIPTION
Setting some defaults for thanos query in centralized-kubecost (used recs from upstream chart)