### PR TITLE
refactor: Deploy kubefed to kube-federation-system

### DIFF
--- a/services/kubefed/0.8.1/defaults/cm.yaml
+++ b/services/kubefed/0.8.1/defaults/cm.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubefed-0.8.1-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    controllermanager:
+      # override value is necessary due to a "featureGates":interface {}(nil)... spec.featureGates in body must be of type array: "null"
+      # bug found
+      featureGates:
+        CrossClusterServiceDiscovery: "Disabled"
+        FederatedIngress: "Enabled"
+        PushReconciler: "Enabled"
+        SchedulerPreferences: "Disabled"
+      controller:
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1000Mi
+      certManager:
+        enabled: true
+        rootCertificate:
+          organizations:
+            - "cert-manager"
+          dnsNames:
+            - ca.webhook.kubefed
+          commonName: ca.webhook.kubefed
+      service:
+        labels:
+          servicemonitor.kommander.mesosphere.io/path: metrics

--- a/services/kubefed/0.8.1/federatedtypeconfigs.yaml
+++ b/services/kubefed/0.8.1/federatedtypeconfigs.yaml
@@ -9,6 +9,7 @@ spec:
   interval: 1m0s
   path: ./services/kubefed/0.8.1/federatedtypeconfigs
   dependsOn:
+    - name: kube-federation-system-namespace
     - name: kubefed-release
   sourceRef:
     kind: GitRepository

--- a/services/kubefed/0.8.1/federatedtypeconfigs/federatedtypeconfigs.yaml
+++ b/services/kubefed/0.8.1/federatedtypeconfigs/federatedtypeconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: clusterrolebindings.rbac.authorization.k8s.io
-  namespace: ${releaseNamespace}
+  namespace: kube-federation-system
 spec:
   federatedType:
     group: types.kubefed.io
@@ -23,7 +23,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: limitranges
-  namespace: ${releaseNamespace}
+  namespace: kube-federation-system
 spec:
   federatedType:
     group: types.kubefed.io
@@ -42,7 +42,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: networkpolicies.networking.k8s.io
-  namespace: ${releaseNamespace}
+  namespace: kube-federation-system
 spec:
   federatedType:
     group: types.kubefed.io
@@ -62,7 +62,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: resourcequotas
-  namespace: ${releaseNamespace}
+  namespace: kube-federation-system
 spec:
   federatedType:
     group: types.kubefed.io
@@ -81,7 +81,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: roles.rbac.authorization.k8s.io
-  namespace: ${releaseNamespace}
+  namespace: kube-federation-system
 spec:
   federatedType:
     group: types.kubefed.io
@@ -101,7 +101,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: rolebindings.rbac.authorization.k8s.io
-  namespace: ${releaseNamespace}
+  namespace: kube-federation-system
 spec:
   federatedType:
     group: types.kubefed.io

--- a/services/kubefed/0.8.1/kube-federation-system-namespace.yaml
+++ b/services/kubefed/0.8.1/kube-federation-system-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  name: kube-federation-system-namespace
+  namespace: ${releaseNamespace}
+spec:
+  force: false
+  prune: false
+  interval: 1m0s
+  path: ./services/kubefed/0.8.1/kube-federation-system-namespace
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux

--- a/services/kubefed/0.8.1/kube-federation-system-namespace/kube-federation-system.yaml
+++ b/services/kubefed/0.8.1/kube-federation-system-namespace/kube-federation-system.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: kube-federation-system

--- a/services/kubefed/0.8.1/kustomization.yaml
+++ b/services/kubefed/0.8.1/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - kube-federation-system-namespace.yaml
   - release.yaml
   - federatedtypeconfigs.yaml

--- a/services/kubefed/0.8.1/release.yaml
+++ b/services/kubefed/0.8.1/release.yaml
@@ -8,6 +8,8 @@ spec:
   prune: true
   interval: 1m0s
   path: ./services/kubefed/0.8.1/release
+  dependsOn:
+    - name: kube-federation-system-namespace
   sourceRef:
     kind: GitRepository
     name: management

--- a/services/kubefed/0.8.1/release/release.yaml
+++ b/services/kubefed/0.8.1/release/release.yaml
@@ -17,42 +17,11 @@ spec:
   install:
     remediation:
       retries: 30
+  targetNamespace: kube-federation-system
   upgrade:
     remediation:
       retries: 30
   releaseName: kubefed
   valuesFrom:
     - kind: ConfigMap
-      name: kubefed-d2iq-defaults
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kubefed-d2iq-defaults
-  namespace: ${releaseNamespace}
-data:
-  values.yaml: |
-    controllermanager:
-        # override value is necessary due to a "featureGates":interface {}(nil)... spec.featureGates in body must be of type array: "null"
-        # bug found
-        featureGates:
-          CrossClusterServiceDiscovery: "Disabled"
-          FederatedIngress: "Enabled"
-          PushReconciler: "Enabled"
-          SchedulerPreferences: "Disabled"
-        controller:
-          resources:
-            limits:
-              cpu: 500m
-              memory: 1000Mi
-        certManager:
-          enabled: true
-          rootCertificate:
-            organizations:
-              - "cert-manager"
-            dnsNames:
-              - ca.webhook.kubefed
-            commonName: ca.webhook.kubefed
-        service:
-          labels:
-            servicemonitor.kommander.mesosphere.io/path: metrics
+      name: kubefed-0.8.1-d2iq-defaults


### PR DESCRIPTION
Deploy kubefed control plane to dedicated `kube-federation-system` namespace instead of deploying it to `kommander`. This is mainly done so that we are able to federate the `kommander` namespace to use it as the workspace ns. I was unable to federate that namespace until I moved the kubefed control plane out of it (looks like this is by design in kubefed https://github.com/kubernetes-sigs/kubefed/blob/master/pkg/controller/sync/accessor.go#L183-L186).

Regardless of when we get the change in to use `kommander` ns for the kommander workspace, I still think it's a good idea to deploy kubefed to a dedicated namespace, that seems to be the recommended way of doing things. And in case we ever need to federate anything to itself in the `kommander` ns, we wouldn't get blocked by this kubefed restriction.