### PR TITLE
fix: Remove hooks and cleanup jobs from centralized-kubecost/thanos

### DIFF
--- a/services/centralized-kubecost/0.19.0/centralized-kubecost.yaml
+++ b/services/centralized-kubecost/0.19.0/centralized-kubecost.yaml
@@ -44,19 +44,11 @@ kind: ServiceAccount
 metadata:
   name: kubecost-configmap-edit
   namespace: kubecost
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kubecost-configmap-edit
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -66,10 +58,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubecost-configmap-edit
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -84,10 +72,6 @@ kind: Job
 metadata:
   name: copy-kubecost-grafana-datasource-cm
   namespace: kubecost
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "4"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:
@@ -109,8 +93,6 @@ kind: Certificate
 metadata:
   name: kommander-kubecost-thanos-client-cert
   namespace: kubecost
-  annotations:
-    "helm.sh/hook": pre-install
 spec:
   commonName: client.thanos.kubecost.localhost.localdomain
   dnsNames:
@@ -129,20 +111,12 @@ kind: ServiceAccount
 metadata:
   name: kubecost-thanos-configmap-edit
   namespace: kubecost
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kubecost-thanos-configmap-edit
   namespace: kubecost
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -153,10 +127,6 @@ kind: RoleBinding
 metadata:
   name: kubecost-thanos-configmap-edit
   namespace: kubecost
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -171,10 +141,6 @@ kind: Job
 metadata:
   name: create-kubecost-thanos-query-stores-configmap
   namespace: kubecost
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "4"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:
@@ -206,31 +172,6 @@ spec:
 
               echo "kubecost-thanos-query-stores configmap already exists - no need to create"
               EOF
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: kubecost-thanos-query-stores-configmap-cleanup
-  namespace: kubecost
-  annotations:
-    "helm.sh/hook": post-delete
-    "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  template:
-    metadata:
-      name: kubecost-thanos-query-stores-configmap-cleanup
-    spec:
-      serviceAccountName: kubecost-thanos-configmap-edit
-      containers:
-        - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.21.3}"
-          imagePullPolicy: IfNotPresent
-          command:
-            - /bin/sh
-            - -c
-            - kubectl delete configmap --ignore-not-found kubecost-thanos-query-stores
-      restartPolicy: OnFailure
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/thanos/0.4.5/thanos.yaml
+++ b/services/thanos/0.4.5/thanos.yaml
@@ -30,8 +30,6 @@ kind: Certificate
 metadata:
   name: kommander-thanos-client-cert
   namespace: ${releaseNamespace}
-  annotations:
-    "helm.sh/hook": pre-install
 spec:
   commonName: client.thanos.localhost.localdomain
   duration: 87600h
@@ -50,20 +48,12 @@ kind: ServiceAccount
 metadata:
   name: kommander-thanos-configmap-edit
   namespace: ${releaseNamespace}
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kommander-thanos-configmap-edit
   namespace: ${releaseNamespace}
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -74,10 +64,6 @@ kind: RoleBinding
 metadata:
   name: kommander-thanos-configmap-edit
   namespace: ${releaseNamespace}
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -92,10 +78,6 @@ kind: Job
 metadata:
   name: create-kommander-thanos-query-stores-configmap
   namespace: ${releaseNamespace}
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "4"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:
@@ -127,31 +109,6 @@ spec:
 
             echo "kommander-thanos-query-stores configmap already exists - no need to create"
             EOF
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: kommander-thanos-query-stores-configmap-cleanup
-  namespace: ${releaseNamespace}
-  annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": hook-succeeded
-spec:
-  template:
-    metadata:
-      name: kommander-thanos-query-stores-configmap-cleanup
-    spec:
-      serviceAccountName: kommander-thanos-configmap-edit
-      containers:
-        - name: kubectl
-          image: bitnami/kubectl:1.19.7
-          imagePullPolicy: IfNotPresent
-          command:
-            - /bin/sh
-            - -c
-            - kubectl delete configmap --ignore-not-found -n ${releaseNamespace} kommander-thanos-query-stores
-      restartPolicy: OnFailure
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Hooks are not used in flux, they are a helm construct, so they are all getting run immediately by flux, which can end up in a race for certain jobs that create and delete configmaps. This is the likely cause for the `centralized-kubecost` timeout flakes that have been happening.

To unblock the release, let's remove the cleanup job. The effect is that we leave behind 2 configmaps if those apps get disabled (centralized-kubecost and thanos) which doesn't seem like the worst outcome. Longer term, we can move the hooks into the helm charts (we already maintain a kubecost parent chart so that would be easy, but for thanos which we're directly pulling from upstream we would have to create a parent chart).