### PR TITLE
fix: Typo, check cm in retry loop

### DIFF
--- a/services/centralized-grafana/17.2.1/defaults/cm.yaml
+++ b/services/centralized-grafana/17.2.1/defaults/cm.yaml
@@ -34,7 +34,7 @@ data:
           # label that the configmaps with datasources are marked with
           label: grafana_datasource_kommander
           searchNamespace: ALL
-      anontations:
+      annotations:
         configmap.reloader.stakater.com/reload: "centralized-kubecost-grafana-datasource"
       ingress:
         enabled: true

--- a/services/centralized-kubecost/0.19.0/kustomization.yaml
+++ b/services/centralized-kubecost/0.19.0/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - centralized-kubecost.yaml
+  - release.yaml
+  - post-install-jobs.yaml

--- a/services/centralized-kubecost/0.19.0/post-install-jobs.yaml
+++ b/services/centralized-kubecost/0.19.0/post-install-jobs.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  name: centralized-kubecost-post-install-jobs
+  namespace: ${releaseNamespace}
+spec:
+  force: false
+  prune: true
+  interval: 1m0s
+  path: ./services/centralized-kubecost/0.19.0/post-install-jobs
+  dependsOn:
+    - name: centralized-kubecost-release
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 60s
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: substitution-vars

--- a/services/centralized-kubecost/0.19.0/post-install-jobs/post-install-jobs.yaml
+++ b/services/centralized-kubecost/0.19.0/post-install-jobs/post-install-jobs.yaml
@@ -1,0 +1,50 @@
+# Copy grafana-datasource cm after it has been created in the release.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubecost-configmap-edit
+  namespace: kubecost
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubecost-configmap-edit
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubecost-configmap-edit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubecost-configmap-edit
+subjects:
+  - kind: ServiceAccount
+    name: kubecost-configmap-edit
+    namespace: kubecost
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: copy-kubecost-grafana-datasource-cm
+  namespace: kubecost
+spec:
+  template:
+    metadata:
+      name: copy-kubecost-grafana-datasource-cm
+    spec:
+      serviceAccountName: kubecost-configmap-edit
+      restartPolicy: OnFailure
+      containers:
+        - name: kubectl
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.21.3}"
+          command:
+            - sh
+            - -c
+            - |
+              kubectl get configmap grafana-datasource --namespace=kubecost -o yaml | sed 's/namespace: kubecost/namespace: ${releaseNamespace}/' | sed 's/name: grafana-datasource/name: centralized-kubecost-grafana-datasource/' | grep -v '^\s*uid:\s' | grep -v '^\s*resourceVersion:\s' | kubectl apply -f -

--- a/services/centralized-kubecost/0.19.0/release.yaml
+++ b/services/centralized-kubecost/0.19.0/release.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  name: centralized-kubecost-release
+  namespace: ${releaseNamespace}
+spec:
+  force: false
+  prune: true
+  interval: 1m0s
+  path: ./services/centralized-kubecost/0.19.0/release
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 60s
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: substitution-vars

--- a/services/centralized-kubecost/0.19.0/release/release.yaml
+++ b/services/centralized-kubecost/0.19.0/release/release.yaml
@@ -33,73 +33,6 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kubecost-configmap-edit
-  namespace: kubecost
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kubecost-configmap-edit
-rules:
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["get", "list", "create", "update", "patch", "delete"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kubecost-configmap-edit
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kubecost-configmap-edit
-subjects:
-  - kind: ServiceAccount
-    name: kubecost-configmap-edit
-    namespace: kubecost
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: copy-kubecost-grafana-datasource-cm
-  namespace: kubecost
-spec:
-  template:
-    metadata:
-      name: copy-kubecost-grafana-datasource-cm
-    spec:
-      serviceAccountName: kubecost-configmap-edit
-      restartPolicy: OnFailure
-      containers:
-        - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.21.3}"
-          command:
-            - sh
-            - -c
-            - |
-              kubectl get configmap grafana-datasource --namespace=kubecost -o yaml | sed 's/namespace: kubecost/namespace: ${releaseNamespace}/' | sed 's/name: grafana-datasource/name: centralized-kubecost-grafana-datasource/' | grep -v '^\s*uid:\s' | grep -v '^\s*resourceVersion:\s' | kubectl apply -f -
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: kommander-kubecost-thanos-client-cert
-  namespace: kubecost
-spec:
-  commonName: client.thanos.kubecost.localhost.localdomain
-  dnsNames:
-    - client.thanos.kubecost.localhost.localdomain
-  duration: 87600h
-  subject:
-    organizations:
-      - D2iQ
-  secretName: kommander-kubecost-thanos-client-tls
-  issuerRef:
-    name: kommander-ca
-    kind: ClusterIssuer
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
   name: kubecost-thanos-configmap-edit
   namespace: kubecost
 ---
@@ -163,6 +96,24 @@ spec:
 
               echo "kubecost-thanos-query-stores configmap already exists - no need to create"
               EOF
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kommander-kubecost-thanos-client-cert
+  namespace: kubecost
+spec:
+  commonName: client.thanos.kubecost.localhost.localdomain
+  dnsNames:
+    - client.thanos.kubecost.localhost.localdomain
+  duration: 87600h
+  subject:
+    organizations:
+      - D2iQ
+  secretName: kommander-kubecost-thanos-client-tls
+  issuerRef:
+    name: kommander-ca
+    kind: ClusterIssuer
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
- Found a typo in centralized-grafana
- At some point may have introduced a flake in the `centralized-monitoring` kuttl test (e.g. https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_Kommander2_KuttlTests/3276741?expandedTest=build%3A%28id%3A3276741%29%2Cid%3A2005&showLog=3276741_2005_118.1976.2005&logFilter=debug) https://jira.d2iq.com/browse/D2IQ-80889

```
kuttl-default.centralized-monitoring
      failed in step 0-
      resource Job:kubecost/copy-kubecost-grafana-datasource-cm: .status.succeeded: key is missing from map
```

```
           status:
          -  succeeded: 1
          +  conditions:
          +  - lastProbeTime: "2021-11-06T02:20:59Z"
          +    lastTransitionTime: "2021-11-06T02:20:59Z"
          +    message: Job has reached the specified backoff limit
          +    reason: BackoffLimitExceeded
          +    status: "True"
          +    type: Failed
          +  failed: 1
          +  startTime: "2021-11-06T02:15:00Z"
```

Strangely, the job must have succeeded though because I am able to find the `centralized-kubecost-grafana-datasource` cm that the job creates. Timestamp matches the `status.lastTransitionTime`

```
                "creationTimestamp": "2021-11-06T02:20:59Z",
                "name": "centralized-kubecost-grafana-datasource",
                "namespace": "kommander",
```

Not sure why the job status is set to `Failed` if it appears to have succeeded, but regardless I added a retry loop to the script in case the HR takes longer to deploy. Previously we were using post-install hooks to run this job, but as the helm annotations are ignored in this context (they are not defined in the centralized-kubecost chart thus does not wait for HR to complete before running) this script likely runs in parallel alongside kubecost deployment, so the cm may not yet exist.

This is being tested now on a kommander branch, this is the kuttl test run to follow along: https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_Kommander2_KuttlTests/3277642