### PR TITLE
fix: allow plugin for kube-prome-stack

### DIFF
--- a/services/kube-prometheus-stack/17.2.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/17.2.1/defaults/cm.yaml
@@ -381,8 +381,8 @@ data:
         pspUseAppArmor: false
       # to avoid needing to download any plugins at runtime, use a container and a shared volume
       # do not enable the plugins here, instead rebuild the mesosphere/grafana-plugins image with the new plugins
-      plugins: []
-      #  - grafana-piechart-panel
+      plugins:
+        allow_loading_unsigned_plugins: "grafana-piechart-panel"
       extraEmptyDirMounts:
         - name: plugins
           mountPath: /var/lib/grafana/plugins/

--- a/services/kube-prometheus-stack/17.2.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/17.2.1/defaults/cm.yaml
@@ -353,6 +353,8 @@ data:
           enabled: false
         users:
           auto_assign_org_role: Admin
+        plugins:
+          allow_loading_unsigned_plugins: "grafana-piechart-panel"
       service:
         type: ClusterIP
         port: 3000
@@ -381,8 +383,8 @@ data:
         pspUseAppArmor: false
       # to avoid needing to download any plugins at runtime, use a container and a shared volume
       # do not enable the plugins here, instead rebuild the mesosphere/grafana-plugins image with the new plugins
-      plugins:
-        allow_loading_unsigned_plugins: "grafana-piechart-panel"
+      plugins: []
+      #  - grafana-piechart-panel
       extraEmptyDirMounts:
         - name: plugins
           mountPath: /var/lib/grafana/plugins/


### PR DESCRIPTION
applied the same thing to the centralized grafana already but missed this one