### PR TITLE
fix: add Traefik dependencies

### DIFF
--- a/services/dex-k8s-authenticator/1.2.8/dex-k8s-authenticator.yaml
+++ b/services/dex-k8s-authenticator/1.2.8/dex-k8s-authenticator.yaml
@@ -8,6 +8,8 @@ spec:
   dependsOn:
     - namespace: ${releaseNamespace}
       name: dex
+    - namespace: ${releaseNamespace}
+      name: traefik
   chart:
     spec:
       chart: dex-k8s-authenticator


### PR DESCRIPTION
Adding these dependencies prevents the respective apps' installations from timing out.