### PR TITLE
fix: don't retry installing Kommander

### DIFF
--- a/services/kommander/0.1.0/kommander.yaml
+++ b/services/kommander/0.1.0/kommander.yaml
@@ -19,12 +19,21 @@ spec:
         namespace: kommander-flux
       version: "${chartVersion}"
   interval: 15s
+  # Kommander is quite a big chart and it may need some more time than
+  # other charts to get ready so setting this to 10 minutes increases
+  # the chance of the installation not timing out.
   timeout: 10m
   install:
     remediation:
+      # The Kommander chart cannot be uninstalled in its current form. That's
+      # a known issue and trying to remediate an installation failure by
+      # deleting and retrying won't work so we can just as well not retry to
+      # begin with.
       retries: 0
   upgrade:
     remediation:
+      # Rolling back an upgrade will very like not work and is untested so
+      # let's disable any remediation.
       retries: 0
   releaseName: kommander
   valuesFrom:

--- a/services/kommander/0.1.0/kommander.yaml
+++ b/services/kommander/0.1.0/kommander.yaml
@@ -19,6 +19,7 @@ spec:
         namespace: kommander-flux
       version: "${chartVersion}"
   interval: 15s
+  timeout: 10m
   install:
     remediation:
       retries: 0

--- a/services/kommander/0.1.0/kommander.yaml
+++ b/services/kommander/0.1.0/kommander.yaml
@@ -21,10 +21,10 @@ spec:
   interval: 15s
   install:
     remediation:
-      retries: 30
+      retries: 0
   upgrade:
     remediation:
-      retries: 30
+      retries: 0
   releaseName: kommander
   valuesFrom:
     - kind: ConfigMap


### PR DESCRIPTION
The Kommander chart cannot be uninstalled so it isn't worth even
trying to remediate any installation failure.