### PR TITLE
feat: add tooling for updating Flux

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+flux2 0.23.0
+kustomize 4.4.1
+github-cli 2.2.0

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+FROM debian:bullseye-20210902-slim
+
+RUN apt-get update && apt-get install -y \
+    bash \
+    build-essential \
+    bzip2 \
+    curl \
+    direnv \
+    git \
+    build-essential \
+    python \
+    python-dev \
+    python3 \
+    python3-pip \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG ASDF_VERSION
+RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v${ASDF_VERSION}
+RUN echo ". ${HOME}/.asdf/asdf.sh" >> ${HOME}/.bashrc
+
+# needed to be able to pull private repos, e.g. in 'go mod download'
+RUN git config --global url."git@github.com:".insteadOf "https://github.com/"
+RUN mkdir -p ~/.ssh && echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' > ~/.ssh/known_hosts

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+include make/all.mk
+
+# Versions for tools that are not managed by asdf.
+ASDF_VERSION=0.8.1
+
+# Inputs required to build the CI Docker image with a determinstic tag.
+CI_DOCKER_BUILD_ARGS=ASDF_VERSION=$(ASDF_VERSION)
+CI_DOCKER_EXTRA_FILES=.tool-versions

--- a/hack/flux/flux-update-kustomization.yaml
+++ b/hack/flux/flux-update-kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux.yaml

--- a/hack/flux/templates/networking.k8s.io_v1_networkpolicy_allow-source.yaml
+++ b/hack/flux/templates/networking.k8s.io_v1_networkpolicy_allow-source.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-source
+  namespace: kommander-flux
+spec:
+  ingress:
+  - from:
+    - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app: source-controller
+  policyTypes:
+  - Ingress

--- a/hack/flux/update-flux.sh
+++ b/hack/flux/update-flux.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+IFS=$'\n\t'
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+readonly REPO_ROOT
+LATEST_FLUX_VERSION="$(gh api -X GET "repos/fluxcd/flux2/releases" --jq '.[0].tag_name|sub("^v"; "")')"
+readonly LATEST_FLUX_VERSION
+CURRENT_FLUX_VERSION=$(find "${REPO_ROOT}/services/kommander-flux" -maxdepth 1 -regextype sed -regex '.*/[0-9]\+.[0-9]\+.[0-9]\+' -printf "%f\n" | sort -V | head -1)
+readonly CURRENT_FLUX_VERSION
+
+function update_flux() {
+    readonly BRANCH_NAME="flux-update/${LATEST_FLUX_VERSION}"
+    git checkout -b "${BRANCH_NAME}"
+
+    asdf install flux2 "${LATEST_FLUX_VERSION}"
+    asdf local flux2 "${LATEST_FLUX_VERSION}"
+
+    mkdir -p "$REPO_ROOT/services/kommander-flux/$LATEST_FLUX_VERSION"
+    pushd "$REPO_ROOT/services/kommander-flux/$LATEST_FLUX_VERSION"
+    ls ..
+    cp -a ../"$CURRENT_FLUX_VERSION"/* .
+    rm templates/*
+    flux install -n kommander-flux --export > templates/flux.yaml
+    cp "$REPO_ROOT/hack/flux/flux-update-kustomization.yaml" templates/kustomization.yaml
+    cp "$REPO_ROOT"/hack/flux/templates/* templates/
+    kustomize build --output templates templates
+    rm templates/flux.yaml templates/kustomization.yaml
+    pushd "templates"
+    kustomize create --autodetect
+
+    git add .
+
+    if [[ -z "$(git config user.email 2>/dev/null || true)" ]]; then
+        git config user.email "ci@mesosphere.com"
+        git config user.name "CI"
+    fi
+
+    readonly COMMIT_MSG="feat: Upgrade flux to ${LATEST_FLUX_VERSION}"
+
+    git commit -m "${COMMIT_MSG}"
+
+    git push --set-upstream origin "${BRANCH_NAME}"
+
+    git fetch origin main
+    gh pr create --base main --fill --head "${BRANCH_NAME}" -t "${COMMIT_MSG}" -l ready-for-review
+}
+
+if [ "${CURRENT_FLUX_VERSION}" == "${LATEST_FLUX_VERSION}" ]; then
+  echo "Flux version is up to date - nothing to do"
+  exit 0
+fi
+
+echo "Updating flux version from ${CURRENT_FLUX_VERSION} to ${LATEST_FLUX_VERSION}"
+
+update_flux

--- a/make/all.mk
+++ b/make/all.mk
@@ -1,0 +1,10 @@
+INCLUDE_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
+include $(INCLUDE_DIR)make.mk
+include $(INCLUDE_DIR)shell.mk
+include $(INCLUDE_DIR)help.mk
+include $(INCLUDE_DIR)repo.mk
+include $(INCLUDE_DIR)ci.mk
+include $(INCLUDE_DIR)docker.mk
+include $(INCLUDE_DIR)flux.mk
+include $(INCLUDE_DIR)tools.mk

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -1,0 +1,51 @@
+CI_DOCKERFILE ?= $(REPO_ROOT)/Dockerfile.ci
+
+ifneq ($(wildcard $(CI_DOCKERFILE)),)
+CI_DOCKER_TAG ?= $(shell (cat $(CI_DOCKERFILE) $(CI_DOCKER_EXTRA_FILES) \
+                         $(if $(CI_DOCKER_BUILD_ARGS),&& echo $(CI_DOCKER_BUILD_ARGS))) \
+                         | shasum | awk '{ print $$1 }')
+CI_DOCKER_IMG ?= $(GITHUB_ORG)/$(GITHUB_REPOSITORY)-ci:$(CI_DOCKER_TAG)
+
+.PHONY: ci.docker.ensure
+ci.docker.ensure: ## Ensures the docker image is locally available
+ci.docker.ensure: dockerauth ; $(info $(M) Ensuring CI Docker image is available locally)
+	(docker image inspect $(CI_DOCKER_IMG) &>/dev/null && echo '$(CI_DOCKER_IMG) already exists - skipping image build' ) || \
+		docker pull $(CI_DOCKER_IMG) || \
+		$(MAKE) ci.docker.build
+
+.PHONY: ci.docker.build
+ci.docker.build: ## Builds the CI Docker image
+ci.docker.build: dockerauth ; $(info $(M) Building CI Docker image)
+	DOCKER_BUILDKIT=1 docker build \
+		--tag $(CI_DOCKER_IMG) \
+		$(if $(CI_DOCKER_BUILD_ARGS),$(addprefix --build-arg ,$(CI_DOCKER_BUILD_ARGS))) \
+		-f $(CI_DOCKERFILE) .
+
+.PHONY: ci.docker.push
+ci.docker.push: ## Pushes the CI Docker image
+ci.docker.push: ci.docker.ensure ; $(info $(M) Pushes the CI Docker image)
+	docker push $(CI_DOCKER_IMG)
+
+.PHONY: ci.docker.run
+ci.docker.run: ## Runs the build in the CI Docker image.
+ci.docker.run: RUN_WHAT ?=
+ci.docker.run: ci.docker.ensure ; $(info $(M) Runs the build in the CI Docker image)
+	docker run --rm -i$(if $(RUN_WHAT),,$(if $(INTERACTIVE),t)) \
+		-v $(REPO_ROOT):$(REPO_ROOT) \
+		-w $(REPO_ROOT) \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v /etc/docker/certs.d:/etc/docker/certs.d \
+		$(if $(GORELEASER_DEBUG),-e GORELEASER_DEBUG=$(GORELEASER_DEBUG)) \
+		$(if $(DOCKER_USERNAME),-e DOCKER_USERNAME=$(DOCKER_USERNAME)) \
+		$(if $(DOCKER_PASSWORD),-e DOCKER_PASSWORD=$(DOCKER_PASSWORD)) \
+		$(if $(AWS_ACCESS_KEY_ID),-e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID)) \
+		$(if $(AWS_SECRET_ACCESS_KEY),-e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY)) \
+		$(if $(AWS_SESSION_TOKEN),-e AWS_SESSION_TOKEN=$(AWS_SESSION_TOKEN)) \
+		$(if $(SSH_AUTH_SOCK),-v $(SSH_AUTH_SOCK):$(SSH_AUTH_SOCK) -e SSH_AUTH_SOCK=$(SSH_AUTH_SOCK)) \
+		$(if $(GITHUB_USER_TOKEN),-e GITHUB_USER_TOKEN=$(GITHUB_USER_TOKEN) -e GITHUB_TOKEN=$(GITHUB_USER_TOKEN),$(if $(GITHUB_TOKEN),-e GITHUB_TOKEN=$(GITHUB_TOKEN))) \
+		$(if $(NOTARIZE_DARWIN_BINARY),--env-file <(env | grep NOTARIZE_) ) \
+		--net=host \
+		$(CI_DOCKER_IMG) \
+		$(if $(RUN_WHAT),bash -ec ". ~/.asdf/asdf.sh && $(RUN_WHAT)")
+
+endif

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -1,0 +1,8 @@
+.PHONY: dockerauth
+dockerauth:
+ifdef DOCKER_USERNAME
+ifdef DOCKER_PASSWORD
+	$(info $(M) Logging in to Docker Hub)
+	echo -n $(DOCKER_PASSWORD) | docker login -u $(DOCKER_USERNAME) --password-stdin
+endif
+endif

--- a/make/flux.mk
+++ b/make/flux.mk
@@ -1,0 +1,5 @@
+.PHONY: flux-update
+flux-update: ## Updates flux manifests
+flux-update: install-tool.flux2 install-tool.kustomize install-tool.github-cli
+flux-update: ; $(info $(M) updating flux manifests)
+	$(REPO_ROOT)/hack/flux/update-flux.sh

--- a/make/help.mk
+++ b/make/help.mk
@@ -1,0 +1,16 @@
+.DEFAULT_GOAL := help
+
+ifndef VERBOSE
+.SILENT:
+endif
+
+INTERACTIVE := $(shell [ -t 0 ] && echo 1)
+ifeq ($(INTERACTIVE),1)
+M := $(shell printf "\033[34;1m▶\033[0m")
+else
+M := =>
+endif
+
+.PHONY: help
+help: ## Shows this help message
+	awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_\-.]+:.*?##/ { printf "  \033[36m%-15s\033[0m\t %s\n", $$1, $$2 }' $(MAKEFILE_LIST)

--- a/make/make.mk
+++ b/make/make.mk
@@ -1,0 +1,2 @@
+MAKEFLAGS += --no-builtin-rules
+MAKEFLAGS += --no-builtin-variables

--- a/make/repo.mk
+++ b/make/repo.mk
@@ -1,0 +1,25 @@
+REPO_ROOT := $(CURDIR)
+
+LOCAL_DIR := $(REPO_ROOT)/.local
+
+GIT_COMMIT := $(shell git rev-parse "HEAD^{commit}")
+export GIT_TAG ?= $(shell git describe --tags "$(GIT_COMMIT)^{commit}" --match v* --abbrev=0 2>/dev/null)
+export GIT_CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+
+export GITHUB_ORG ?= mesosphere
+export GITHUB_REPOSITORY ?= kommander-applications
+
+ifneq ($(shell git status --porcelain 2>/dev/null; echo $$?), 0)
+	export GIT_TREE_STATE := dirty
+else
+	export GIT_TREE_STATE :=
+endif
+
+.PHONY: repo.dev.tag
+repo.dev.tag: ## Returns development tag
+repo.dev.tag:
+ifneq (,$(findstring -next,$(GIT_TAG)))
+	echo "$(GIT_TAG)"
+else
+	echo "$(addsuffix "-next",$(GIT_TAG))"
+endif

--- a/make/shell.mk
+++ b/make/shell.mk
@@ -1,0 +1,9 @@
+SHELL := /bin/bash
+.SHELLFLAGS = -euo pipefail -c
+
+# We need to explicitly get the bash version via shell command here because the user could be
+# running a different shell and hence BASH_VERSION var will not be set in the Make environment.
+# BASH_VERSION := $(shell echo $${BASH_VERSION})
+# ifneq (5, $(word 1, $(sort 5 $(BASH_VERSION))))
+#   $(error Only bash >= 5 is supported (current version: $(BASH_VERSION)). Please upgrade your version of bash. If on macOS, see https://formulae.brew.sh/formula/bash)
+# endif

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -1,0 +1,74 @@
+# Override this in your own top-level Makefile if this is in a different path in your repo.
+GO_TOOLS_FILE ?= $(REPO_ROOT)/.go-tools
+
+# Explicitly override GOBIN so it does not inherit from the environment - this allows for a truly
+# self-contained build environment for the project.
+override GOBIN := $(LOCAL_DIR)/bin
+export GOBIN
+export PATH := $(GOBIN):$(PATH)
+
+ifneq ($(wildcard $(GO_TOOLS_FILE)),)
+define install_go_tool
+	mkdir -p $(GOBIN)
+	CGO_ENABLED=0 go install -v $$(grep $1 $(GO_TOOLS_FILE))
+endef
+
+.PHONY: install-tool.go.%
+install-tool.go.%: ## Installs specific go tool
+install-tool.go.%: install-tool.golang ; $(info $(M) installing go tool $*)
+	$(call install_go_tool,$*)
+endif
+
+ifndef TEAMCITY_VERSION
+ifeq ($(shell command -v asdf),)
+  $(error "This repo requires asdf - see https://asdf-vm.com/guide/getting-started.html#_3-install-asdf")
+endif
+endif
+
+define install_tool
+	$(if $(1), \
+		asdf plugin list | grep -E '^$(1)$$' &>/dev/null || asdf plugin add $(1), \
+		grep -Eo '^[^#]\S+' $(REPO_ROOT)/.tool-versions | xargs -I{} bash -ec 'asdf plugin list | grep -E '^{}$$' &>/dev/null || asdf plugin add {}' \
+	)
+	asdf install $1
+endef
+
+ifneq ($(wildcard $(GO_TOOLS_FILE)),)
+.PHONY: install-tools.go
+install-tools.go: ## Install all go tools
+install-tools.go: install-tool.golang ; $(info $(M) installing all go tools)
+	cat $(GO_TOOLS_FILE) | xargs -L1 go install -v
+endif
+
+.PHONY: install-tools
+install-tools: ## Install all tools
+install-tools: ; $(info $(M) installing all tools)
+	$(call install_tool,)
+
+.PHONY: install-tool.%
+install-tool.%: ## Install specific tool
+install-tool.%: ; $(info $(M) installing $*)
+	$(call install_tool,$*)
+
+.PHONY: upgrade-tools
+# ASDF plugins use different env vars for GitHub authentication when querying releases. Try to
+# handle this nicely by specifying some of the known env vars to prevent rate limiting.
+ifdef GITHUB_USER_TOKEN
+upgrade-tools: export GITHUB_API_TOKEN=$(GITHUB_USER_TOKEN)
+else
+ifdef GITHUB_TOKEN
+upgrade-tools: export GITHUB_API_TOKEN=$(GITHUB_TOKEN)
+endif
+endif
+upgrade-tools: export OAUTH_TOKEN=$(GITHUB_API_TOKEN)
+upgrade-tools: ## Upgrades all tools to latest available versions
+upgrade-tools: ; $(info $(M) upgrading all tools to latest available versions)
+	grep -Eo '^[^#]\S+' $(REPO_ROOT)/.tool-versions | xargs -I{} bash -ec 'asdf plugin list | grep -E '^{}$$' &>/dev/null || asdf plugin add {}'
+	grep -v '# FREEZE' $(REPO_ROOT)/.tool-versions | \
+		grep -Eo '^[^#]\S+' | \
+		xargs -I{} bash -ec '\
+			export VERSION="$$( \
+				asdf list all {} | \
+				grep -vE "(^Available versions:|-src|-dev|-latest|-stm|[-\\.]rc|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" | \
+				tail -1 \
+			)" && asdf install {} $${VERSION} && asdf local {} $${VERSION}'


### PR DESCRIPTION
This change bootstraps a Make configuration for running targets in CI
as well as a 'flux-update' target that updates the manifests of Flux
to the latest Flux version.

https://jira.d2iq.com/browse/D2IQ-81179