### PR TITLE
fix: Disable clusterroles in project-grafana-logging

### DIFF
--- a/services/project-grafana-logging/6.13.9/defaults/cm.yaml
+++ b/services/project-grafana-logging/6.13.9/defaults/cm.yaml
@@ -75,6 +75,7 @@ data:
       failureThreshold: 10
     rbac:
       enabled: true
+      namespaced: true
       pspUseAppArmor: false
       pspEnabled: false
     # to avoid needing to download any plugins at runtime, use a container and a shared volume


### PR DESCRIPTION
We shouldn't be deploying cluster scoped resources in project apps