### PR TITLE
feat: set namespace creation to false in project grafana

### DIFF
--- a/services/cert-manager/0.2.7/release/release.yaml
+++ b/services/cert-manager/0.2.7/release/release.yaml
@@ -17,7 +17,6 @@ spec:
   install:
     remediation:
       retries: 30
-    createNamespace: true
   upgrade:
     remediation:
       retries: 30

--- a/services/dex-k8s-authenticator/1.2.8/dex-k8s-authenticator.yaml
+++ b/services/dex-k8s-authenticator/1.2.8/dex-k8s-authenticator.yaml
@@ -22,7 +22,6 @@ spec:
   install:
     remediation:
       retries: 30
-    createNamespace: true
   upgrade:
     remediation:
       retries: 30

--- a/services/dex/2.9.10/dex.yaml
+++ b/services/dex/2.9.10/dex.yaml
@@ -17,7 +17,6 @@ spec:
   install:
     remediation:
       retries: 30
-    createNamespace: true
   upgrade:
     remediation:
       retries: 30

--- a/services/external-dns/2.20.5/external-dns.yaml
+++ b/services/external-dns/2.20.5/external-dns.yaml
@@ -17,7 +17,6 @@ spec:
   install:
     remediation:
       retries: 30
-    createNamespace: true
   upgrade:
     remediation:
       retries: 30

--- a/services/grafana-logging/6.13.9/grafana.yaml
+++ b/services/grafana-logging/6.13.9/grafana.yaml
@@ -17,7 +17,6 @@ spec:
   install:
     remediation:
       retries: 30
-    createNamespace: true
   upgrade:
     remediation:
       retries: 30

--- a/services/kube-oidc-proxy/0.2.5/kube-oidc-proxy.yaml
+++ b/services/kube-oidc-proxy/0.2.5/kube-oidc-proxy.yaml
@@ -26,7 +26,6 @@ spec:
   install:
     remediation:
       retries: 30
-    createNamespace: true
   upgrade:
     remediation:
       retries: 30

--- a/services/kube-prometheus-stack/17.2.1/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/17.2.1/kube-prometheus-stack.yaml
@@ -20,7 +20,6 @@ spec:
   install:
     remediation:
       retries: 30
-    createNamespace: true
   upgrade:
     remediation:
       retries: 30

--- a/services/nvidia/0.4.3/nvidia.yaml
+++ b/services/nvidia/0.4.3/nvidia.yaml
@@ -17,7 +17,6 @@ spec:
   install:
     remediation:
       retries: 30
-    createNamespace: true
   upgrade:
     remediation:
       retries: 30

--- a/services/project-grafana-logging/6.13.9/project-grafana.yaml
+++ b/services/project-grafana-logging/6.13.9/project-grafana.yaml
@@ -17,7 +17,6 @@ spec:
   install:
     remediation:
       retries: 30
-    createNamespace: true
   upgrade:
     remediation:
       retries: 30

--- a/services/prometheus-adapter/2.11.1/prometheus-adapter.yaml
+++ b/services/prometheus-adapter/2.11.1/prometheus-adapter.yaml
@@ -20,7 +20,6 @@ spec:
   install:
     remediation:
       retries: 30
-    createNamespace: true
   upgrade:
     remediation:
       retries: 30

--- a/services/reloader/0.0.99/reloader.yaml
+++ b/services/reloader/0.0.99/reloader.yaml
@@ -16,7 +16,6 @@ spec:
   install:
     remediation:
       retries: 30
-    createNamespace: true
   upgrade:
     remediation:
       retries: 30

--- a/services/traefik-forward-auth-mgmt/0.3.2/traefik-forward-auth-mgmt.yaml
+++ b/services/traefik-forward-auth-mgmt/0.3.2/traefik-forward-auth-mgmt.yaml
@@ -22,7 +22,6 @@ spec:
   install:
     remediation:
       retries: 30
-    createNamespace: true
   upgrade:
     remediation:
       retries: 30


### PR DESCRIPTION
I changed the following 
![image](https://user-images.githubusercontent.com/2296947/142063815-0cbde5b1-bf46-40cb-beac-8a636df82eff.png)

to 
![image](https://user-images.githubusercontent.com/2296947/142063784-fb33dea4-30e0-4eb8-8239-793e2f2883d2.png)

To prevent errors in CI like: 
```
          +      Helm install failed: namespaces is forbidden: User "system:serviceaccount:kuttl-prj-2:kuttl-prj-2" cannot create resource "namespaces" in API group "" at the cluster scope
```
when using SA on HelmRelease - https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_Kommander2_KuttlTestsMultiCluster/3290430?buildTab=tests&expandedTest=build%3A%28id%3A3290430%29%2Cid%3A3950&showLog=3290430_3950_467.3941.3950&logFilter=debug
