### PR TITLE
fix: use release Kustomization for Gatekeeper

### DIFF
--- a/services/gatekeeper/0.6.8/constrainttemplates.yaml
+++ b/services/gatekeeper/0.6.8/constrainttemplates.yaml
@@ -13,7 +13,7 @@ spec:
     name: management
     namespace: kommander-flux
   dependsOn:
-    - name: gatekeeper
+    - name: gatekeeper-release
   timeout: 60s
   healthChecks:
     - apiVersion: templates.gatekeeper.sh/v1beta1

--- a/services/gatekeeper/0.6.8/kustomization.yaml
+++ b/services/gatekeeper/0.6.8/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./release
+  - release.yaml
   - constraints.yaml
   - constrainttemplates.yaml

--- a/services/gatekeeper/0.6.8/release.yaml
+++ b/services/gatekeeper/0.6.8/release.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: gatekeeper-release
+  namespace: ${releaseNamespace}
+spec:
+  force: false
+  prune: true
+  interval: 1m0s
+  path: ./services/gatekeeper/0.6.8/release
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 60s
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: substitution-vars
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+      kind: HelmRelease
+      name: gatekeeper
+      namespace: ${releaseNamespace}


### PR DESCRIPTION
A dedicated Kustomization gatekeeper-release is created that the other
two Kustomizations can depend on other than depending on a
Kustomization that isn't maintained as part of this repository. This
makes the whole gatekeeper service self-contained and less prone to
bugs.

This follows the same pattern we use for kubefed so we don't use
different approaches within this repo.