### PR TITLE
fix: Make karma depend on karma-traefik

### DIFF
--- a/services/karma/2.0.0/karma.yaml
+++ b/services/karma/2.0.0/karma.yaml
@@ -5,6 +5,9 @@ metadata:
   name: karma
   namespace: ${releaseNamespace}
 spec:
+  dependsOn:
+    - namespace: ${releaseNamespace}
+      name: karma-traefik
   chart:
     spec:
       chart: karma


### PR DESCRIPTION
Making sure `karma` is not installed without `karma-traefik`.

https://jira.d2iq.com/browse/D2IQ-81449
