### PR TITLE
feat: align configmap-reload image tag with other containers

### DIFF
--- a/services/logging-operator/3.13.0/defaults/cm.yaml
+++ b/services/logging-operator/3.13.0/defaults/cm.yaml
@@ -56,6 +56,8 @@ data:
     tls:
       enabled: true
     fluentd:
+      configReloaderImage:
+        tag: v0.5.0
       image:
         # Explicitly use the default image. This should be updated when logging-operator is upgraded.
         repository: ghcr.io/banzaicloud/fluentd


### PR DESCRIPTION
Other containers deployed as part of Kommander use v0.5.0 while the
default of the logging-operator is v0.4.0. To bring down the number of
different images used on a Kommander cluster we're aligning the
different tags of the same image.