### PR TITLE
chore: update docker image tag for dex

### DIFF
--- a/services/dex/2.9.10/defaults/cm.yaml
+++ b/services/dex/2.9.10/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
   values.yaml: |-
     ---
     image: mesosphere/dex
-    imageTag: v2.27.0-7-g258c09-d2iq
+    imageTag: v2.27.0-4-g8c72a-d2iq
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
This PR updates the image tag to use the CVE fixed image.

Resolves: [D2IQ-81265](https://jira.d2iq.com/browse/D2IQ-81265)