### PR TITLE
Add NFS Server Provisioner service

### DIFF
--- a/services/nfs-server-provisioner/0.6.0/defaults/cm.yaml
+++ b/services/nfs-server-provisioner/0.6.0/defaults/cm.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/services/nfs-server-provisioner/0.6.0/defaults/cm.yaml
+++ b/services/nfs-server-provisioner/0.6.0/defaults/cm.yaml
@@ -1,0 +1,21 @@
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nfs-server-provisioner-0.6.0-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |-
+    persistence:
+      enabled: true
+      size: 100Gi
+    storageClass:
+      name: nfsserverprovisioner
+    resources:
+      limits:
+         cpu: 1000m
+         memory: 1024Mi
+      requests:
+         cpu: 50m
+         memory: 256Mi

--- a/services/nfs-server-provisioner/0.6.0/defaults/cm.yaml
+++ b/services/nfs-server-provisioner/0.6.0/defaults/cm.yaml
@@ -12,10 +12,3 @@ data:
       size: 100Gi
     storageClass:
       name: nfsserverprovisioner
-    resources:
-      limits:
-         cpu: 1000m
-         memory: 1024Mi
-      requests:
-         cpu: 50m
-         memory: 256Mi

--- a/services/nfs-server-provisioner/0.6.0/defaults/kustomization.yaml
+++ b/services/nfs-server-provisioner/0.6.0/defaults/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cm.yaml

--- a/services/nfs-server-provisioner/0.6.0/kustomization.yaml
+++ b/services/nfs-server-provisioner/0.6.0/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - nfs-server-provisioner.yaml

--- a/services/nfs-server-provisioner/0.6.0/nfs-server-provisioner.yaml
+++ b/services/nfs-server-provisioner/0.6.0/nfs-server-provisioner.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: nfs-server-provisioner
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: nfs-server-provisioner
+      sourceRef:
+        kind: HelmRepository
+        name: mesosphere.github.io-charts-staging
+        namespace: kommander-flux
+      version: 0.6.0
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: nfs-server-provisioner
+  valuesFrom:
+    - kind: ConfigMap
+      name: nfs-server-provisioner-0.6.0-d2iq-defaults
+  targetNamespace: ${releaseNamespace}

--- a/services/nfs-server-provisioner/metadata.yaml
+++ b/services/nfs-server-provisioner/metadata.yaml
@@ -1,0 +1,11 @@
+displayName: NFS Server Provisioner
+description: NFS Server Provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
+type: platform
+overview: |-
+  # Overview
+  NFS Server Provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy
+  shared storage that works almost anywhere.
+
+  This chart will deploy the Kubernetes external-storage projects nfs provisioner.
+  This provisioner includes a built in NFS server, and is not intended for connecting to a pre-existing NFS server.
+  If you have a pre-existing NFS Server, please consider using the NFS Client Provisioner instead.

--- a/services/nfs-server-provisioner/metadata.yaml
+++ b/services/nfs-server-provisioner/metadata.yaml
@@ -1,6 +1,8 @@
 displayName: NFS Server Provisioner
 description: NFS Server Provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 type: platform
+scope:
+  - workspace
 overview: |-
   # Overview
   NFS Server Provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy

--- a/services/nfs-server-provisioner/metadata.yaml
+++ b/services/nfs-server-provisioner/metadata.yaml
@@ -1,6 +1,6 @@
 displayName: NFS Server Provisioner
 description: NFS Server Provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
-type: platform
+type: catalog
 scope:
   - workspace
 overview: |-


### PR DESCRIPTION
Resolves [D2IQ-81559](https://jira.d2iq.com/browse/D2IQ-81559).

This PR adds the `nfs-server-provisioner` based on https://github.com/mesosphere/charts/tree/master/staging/nfs-server-provisioner chart to Kommander applications.