### PR TITLE
chore: Use workspaceNamespace instead of traefikNamespace

### DIFF
--- a/services/traefik-forward-auth/0.3.2/traefik-forward-auth.yaml
+++ b/services/traefik-forward-auth/0.3.2/traefik-forward-auth.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: ${releaseNamespace}
 spec:
   dependsOn:
-    - namespace: ${traefikNamespace}
+    - namespace: ${workspaceNamespace}
       name: traefik
   chart:
     spec:


### PR DESCRIPTION
We originally needed a separate `traefikNamespace` substitution variable when traefik wasn't installed in the workspace namespace, but now that it is (`kommander` ns is workspace ns) we can remove the var and just use `workspaceNamespace` instead.