### PR TITLE
chore: Use sidecar v1.12.3 for kubecost

### DIFF
--- a/services/centralized-kubecost/0.20.0/defaults/cm.yaml
+++ b/services/centralized-kubecost/0.20.0/defaults/cm.yaml
@@ -63,7 +63,7 @@ data:
         # These values are set so that kubecost grafana dashboards are installed.
         # Grafana itself is not installed.
         sidecar:
-          image: kiwigrid/k8s-sidecar:1.3.0
+          image: kiwigrid/k8s-sidecar:1.12.3
           dashboards:
             enabled: true
             label: grafana_dashboard_kommander


### PR DESCRIPTION
Resolves https://jira.d2iq.com/browse/D2IQ-81263 by using the updated sidecar image `v1.12.3` in kubecost.