### PR TITLE
fix: Restore all pod labels to metrics emitted by kube-state-metrics

### DIFF
--- a/services/kube-prometheus-stack/18.1.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/18.1.1/defaults/cm.yaml
@@ -407,3 +407,6 @@ data:
     #     keyFile: "/etc/prometheus/secrets/etcd-certs/server.key"
     nodeExporter:
       enabled: true
+    kube-state-metrics:
+      metricLabelsAllowlist:
+        - pods=[*]


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-82012

<img width="1308" alt="Screen Shot 2021-12-03 at 6 37 01 PM" src="https://user-images.githubusercontent.com/42242/144693977-7ce2149b-6d44-4532-aa38-bfb0081a31df.png">

Caveat from KSM docs: https://github.com/kubernetes/kube-state-metrics/blob/master/docs/cli-arguments.md#available-options
> A single '\*' can be provided per resource instead to allow any labels, but that has severe performance implications (Example: '=pods=[*]').

Should we come up with a targeted list of labels instead?