### PR TITLE
chore: Add kubecost 0.20.2

### DIFF
--- a/services/centralized-kubecost/0.20.2/defaults/cm.yaml
+++ b/services/centralized-kubecost/0.20.2/defaults/cm.yaml
@@ -63,7 +63,7 @@ data:
         # These values are set so that kubecost grafana dashboards are installed.
         # Grafana itself is not installed.
         sidecar:
-          image: kiwigrid/k8s-sidecar:1.3.0
+          image: kiwigrid/k8s-sidecar:1.12.3
           dashboards:
             enabled: true
             label: grafana_dashboard_kommander

--- a/services/centralized-kubecost/0.20.2/defaults/cm.yaml
+++ b/services/centralized-kubecost/0.20.2/defaults/cm.yaml
@@ -63,7 +63,6 @@ data:
         # These values are set so that kubecost grafana dashboards are installed.
         # Grafana itself is not installed.
         sidecar:
-          image: kiwigrid/k8s-sidecar:1.12.3
           dashboards:
             enabled: true
             label: grafana_dashboard_kommander

--- a/services/centralized-kubecost/0.20.2/defaults/cm.yaml
+++ b/services/centralized-kubecost/0.20.2/defaults/cm.yaml
@@ -1,0 +1,143 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: centralized-kubecost-0.20.2-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    ---
+    cost-analyzer:
+      fullnameOverride: "kommander-kubecost-cost-analyzer"
+      global:
+        prometheus:
+          fqdn: http://kubecost-prometheus-server.kommander.svc.cluster.local
+          enabled: false
+
+        thanos:
+          enabled: true
+          queryService: http://kommander-kubecost-thanos-query-http.kubecost.svc.cluster.local:10902
+          # The wait time before Kommander begins querying cost data for all attached clusters
+          queryOffset: 5m
+          query:
+            deploymentAnnotations:
+              secret.reloader.stakater.com/reload: kommander-kubecost-thanos-client-tls
+
+        grafana:
+          enabled: false
+          # Use kommander monitoring Grafana instance
+          domainName: centralized-grafana.${releaseNamespace}.svc.cluster.local
+
+      # For Thanos Installs, Allow Higher Concurrency from Cost-Model
+      # Still may require tweaking for some installs, but the thanos-query-frontend
+      # will greatly assist in reduction memory bloat in query.
+      kubecostModel:
+        maxQueryConcurrency: 5
+        # This configuration is applied to thanos only. Expresses the resolution to
+        # use for longer query ranges. Options: raw, 5m, 1h - Default: raw
+        maxSourceResolution: 5m
+
+      ingress:
+        enabled: true
+        # We can remove this once https://github.com/kubecost/cost-analyzer-helm-chart/pull/1132 is released.
+        className: ""
+        annotations:
+          kubernetes.io/ingress.class: kommander-traefik
+          ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
+          traefik.ingress.kubernetes.io/router.tls: "true"
+          traefik.ingress.kubernetes.io/router.middlewares: "${releaseNamespace}-stripprefixes@kubernetescrd,${releaseNamespace}-forwardauth@kubernetescrd"
+        paths:
+          - "/dkp/kommander/kubecost/frontend/"
+        hosts:
+          - ""
+        tls: []
+
+      kubecostDeployment:
+        labels:
+          vendor.kubecost.io/partner: d2iq
+
+      podSecurityPolicy:
+        enabled: false
+
+      grafana:
+        # These values are set so that kubecost grafana dashboards are installed.
+        # Grafana itself is not installed.
+        sidecar:
+          image: kiwigrid/k8s-sidecar:1.3.0
+          dashboards:
+            enabled: true
+            label: grafana_dashboard_kommander
+          datasources:
+            enabled: true
+            defaultDatasourceEnabled: false
+            label: grafana_datasource_kommander
+
+      prometheus:
+        fullnameOverride: "kommander-kubecost-prometheus"
+        server:
+          fullnameOverride: "kommander-kubecost-prometheus-server"
+        alertmanager:
+          fullnameOverride: "kommander-kubecost-prometheus-alertmanager"
+        kube-state-metrics:
+          fullnameOverride: "kommander-kubecost-prometheus-kube-state-metrics"
+
+        configmapReload:
+          prometheus:
+            image:
+              tag: v0.5.0
+          alertmanager:
+            image:
+              tag: v0.5.0
+
+      thanos:
+        fullnameOverride: "kommander-kubecost-thanos"
+        nameOverride: "kubecost-thanos"
+        query:
+          enabled: true
+          timeout: 3m
+          maxConcurrent: 10
+          # Name of HTTP request header used for dynamic prefixing of UI links and redirects.
+          webPrefixHeader: "X-Forwarded-Prefix"
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 16Gi
+            requests:
+              cpu: 1000m
+              memory: 4Gi
+          http:
+            service:
+              labels:
+                servicemonitor.kommander.mesosphere.io/path: "metrics"
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: kommander-traefik
+                traefik.ingress.kubernetes.io/router.tls: "true"
+                traefik.ingress.kubernetes.io/router.middlewares: "${releaseNamespace}-stripprefixes@kubernetescrd,${releaseNamespace}-forwardauth@kubernetescrd"
+              path: "/dkp/kommander/kubecost/query"
+              hosts:
+                - ""
+              tls: []
+          # Enable DNS discovery for stores
+          storeDNSDiscovery: false
+          # Enable DNS discovery for sidecars (this is for the chart built-in sidecar service)
+          sidecarDNSDiscovery: false
+          # Names of configmaps that contain addresses of store API servers, used for file service discovery.
+          serviceDiscoveryFileConfigMaps:
+            - kubecost-thanos-query-stores
+          # Refresh interval to re-read file SD files. It is used as a resync fallback.
+          serviceDiscoveryInterval: 5m
+          extraArgs:
+            - "--log.format=json"
+            - "--grpc-client-tls-secure"
+            - "--grpc-client-tls-cert=/etc/certs/tls.crt"
+            - "--grpc-client-tls-key=/etc/certs/tls.key"
+            - "--grpc-client-tls-ca=/etc/certs/ca.crt"
+            - "--grpc-client-server-name=server.thanos.kubecost.localhost.localdomain"
+          certSecretName: kommander-kubecost-thanos-client-tls
+
+      kubecostProductConfigs:
+        grafanaURL: "/dkp/kommander/monitoring/grafana"
+        # used for display in Kubecost UI
+        clusterName: "Kommander Host"

--- a/services/centralized-kubecost/0.20.2/defaults/kustomization.yaml
+++ b/services/centralized-kubecost/0.20.2/defaults/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cm.yaml

--- a/services/centralized-kubecost/0.20.2/kustomization.yaml
+++ b/services/centralized-kubecost/0.20.2/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yaml
+  - post-install-jobs.yaml

--- a/services/centralized-kubecost/0.20.2/post-install-jobs.yaml
+++ b/services/centralized-kubecost/0.20.2/post-install-jobs.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: centralized-kubecost-post-install-jobs
+  namespace: ${releaseNamespace}
+spec:
+  force: false
+  prune: true
+  interval: 1m0s
+  path: ./services/centralized-kubecost/0.20.2/post-install-jobs
+  dependsOn:
+    - name: centralized-kubecost-release
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 60s
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: substitution-vars

--- a/services/centralized-kubecost/0.20.2/post-install-jobs/post-install-jobs.yaml
+++ b/services/centralized-kubecost/0.20.2/post-install-jobs/post-install-jobs.yaml
@@ -1,0 +1,50 @@
+# Copy grafana-datasource cm after it has been created in the release.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubecost-configmap-edit
+  namespace: kubecost
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubecost-configmap-edit
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubecost-configmap-edit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubecost-configmap-edit
+subjects:
+  - kind: ServiceAccount
+    name: kubecost-configmap-edit
+    namespace: kubecost
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: copy-kubecost-grafana-datasource-cm
+  namespace: kubecost
+spec:
+  template:
+    metadata:
+      name: copy-kubecost-grafana-datasource-cm
+    spec:
+      serviceAccountName: kubecost-configmap-edit
+      restartPolicy: OnFailure
+      containers:
+        - name: kubectl
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.21.3}"
+          command:
+            - sh
+            - -c
+            - |
+              kubectl get configmap grafana-datasource --namespace=kubecost -o yaml | sed 's/namespace: kubecost/namespace: ${releaseNamespace}/' | sed 's/name: grafana-datasource/name: centralized-kubecost-grafana-datasource/' | grep -v '^\s*uid:\s' | grep -v '^\s*resourceVersion:\s' | kubectl apply -f -

--- a/services/centralized-kubecost/0.20.2/release.yaml
+++ b/services/centralized-kubecost/0.20.2/release.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: centralized-kubecost-release
+  namespace: ${releaseNamespace}
+spec:
+  force: false
+  prune: true
+  interval: 1m0s
+  path: ./services/centralized-kubecost/0.20.2/release
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 60s
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: substitution-vars

--- a/services/centralized-kubecost/0.20.2/release/release.yaml
+++ b/services/centralized-kubecost/0.20.2/release/release.yaml
@@ -1,0 +1,157 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: centralized-kubecost
+  namespace: ${releaseNamespace}
+spec:
+  dependsOn:
+    - namespace: ${releaseNamespace}
+      name: traefik
+  chart:
+    spec:
+      chart: kubecost
+      sourceRef:
+        kind: HelmRepository
+        name: mesosphere.github.io-charts-stable
+        namespace: kommander-flux
+      version: "0.20.2"
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: centralized-kubecost
+  valuesFrom:
+    - kind: ConfigMap
+      name: centralized-kubecost-0.20.2-d2iq-defaults
+  targetNamespace: kubecost
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubecost-thanos-configmap-edit
+  namespace: kubecost
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubecost-thanos-configmap-edit
+  namespace: kubecost
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubecost-thanos-configmap-edit
+  namespace: kubecost
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubecost-thanos-configmap-edit
+subjects:
+  - kind: ServiceAccount
+    name: kubecost-thanos-configmap-edit
+    namespace: kubecost
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-kubecost-thanos-query-stores-configmap
+  namespace: kubecost
+spec:
+  template:
+    metadata:
+      name: create-kubecost-thanos-query-stores-configmap
+    spec:
+      serviceAccountName: kubecost-thanos-configmap-edit
+      restartPolicy: OnFailure
+      containers:
+        - name: kubectl
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.21.3}"
+          command:
+            - sh
+            - "-c"
+            - |
+              /bin/bash <<'EOF'
+              set -o nounset
+              set -o errexit
+              set -o pipefail
+
+              echo "checking if kubecost-thanos-query-stores configmap exists"
+
+              RES=$(set -o errexit; kubectl get configmap --ignore-not-found kubecost-thanos-query-stores)
+              if [[ $RES == "" ]]; then
+                echo "kubecost-thanos-query-stores configmap does not exist - creating"
+                printf '%s\n' "apiVersion: v1" "kind: ConfigMap" "metadata:" "  name: kubecost-thanos-query-stores" "data:" "  stores.yaml: |-" "    - targets: []" > /tmp/kubecost-thanos-query-stores.yaml
+                kubectl apply -f /tmp/kubecost-thanos-query-stores.yaml
+                exit 0
+              fi
+
+              echo "kubecost-thanos-query-stores configmap already exists - no need to create"
+              EOF
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kommander-kubecost-thanos-client-cert
+  namespace: kubecost
+spec:
+  commonName: client.thanos.kubecost.localhost.localdomain
+  dnsNames:
+    - client.thanos.kubecost.localhost.localdomain
+  duration: 87600h
+  subject:
+    organizations:
+      - D2iQ
+  secretName: kommander-kubecost-thanos-client-tls
+  issuerRef:
+    name: kommander-ca
+    kind: ClusterIssuer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dkp-centralized-kubecost-view
+rules:
+  - nonResourceURLs:
+      - /dkp/kommander/kubecost
+      - /dkp/kommander/kubecost/*
+    verbs:
+      - get
+      - head
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dkp-centralized-kubecost-edit
+rules:
+  - nonResourceURLs:
+      - /dkp/kommander/kubecost
+      - /dkp/kommander/kubecost/*
+    verbs:
+      - get
+      - head
+      - post
+      - put
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dkp-centralized-kubecost-admin
+rules:
+  - nonResourceURLs:
+      - /dkp/kommander/kubecost
+      - /dkp/kommander/kubecost/*
+    verbs:
+      - get
+      - head
+      - post
+      - put
+      - delete

--- a/services/kubecost/0.20.2/defaults/cm.yaml
+++ b/services/kubecost/0.20.2/defaults/cm.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubecost-0.20.2-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    ---
+    cost-analyzer:
+      global:
+        prometheus:
+          enabled: true
+        grafana:
+          enabled: true
+
+      ingress:
+        enabled: true
+        # We can remove this once https://github.com/kubecost/cost-analyzer-helm-chart/pull/1132 is released.
+        className: ""
+        annotations:
+          kubernetes.io/ingress.class: kommander-traefik
+          ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
+          traefik.ingress.kubernetes.io/router.tls: "true"
+          traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth@kubernetescrd"
+        paths:
+          - "/dkp/kubecost/frontend/"
+        hosts:
+          - ""
+        tls: []
+
+      podSecurityPolicy:
+        enabled: false
+
+      grafana:
+        ingress:
+          enabled: true
+          annotations:
+            kubernetes.io/ingress.class: kommander-traefik
+            ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
+            traefik.ingress.kubernetes.io/router.tls: "true"
+            traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth@kubernetescrd"
+          hosts: [""]
+          path: "/dkp/kubecost/grafana"
+        grafana.ini:
+          server:
+            protocol: http
+            enable_gzip: true
+            root_url: "%(protocol)s://%(domain)s:%(http_port)s/dkp/kubecost/grafana"
+          auth.proxy:
+            enabled: true
+            header_name: X-Forwarded-User
+            auto-sign-up: true
+          auth.basic:
+            enabled: false
+          users:
+            auto_assign_org_role: Admin
+
+      kubecostProductConfigs:
+        grafanaURL: "/dkp/kubecost/grafana"
+        # used for display in Kubecost UI
+        clusterName: "Kommander Managed Cluster"

--- a/services/kubecost/0.20.2/defaults/kustomization.yaml
+++ b/services/kubecost/0.20.2/defaults/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cm.yaml

--- a/services/kubecost/0.20.2/kubecost.yaml
+++ b/services/kubecost/0.20.2/kubecost.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kubecost
+  namespace: ${releaseNamespace}
+spec:
+  dependsOn:
+    - namespace: ${releaseNamespace}
+      name: traefik
+  chart:
+    spec:
+      chart: kubecost
+      sourceRef:
+        kind: HelmRepository
+        name: mesosphere.github.io-charts-stable
+        namespace: kommander-flux
+      version: "0.20.2"
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: kubecost
+  valuesFrom:
+    - kind: ConfigMap
+      name: kubecost-0.20.2-d2iq-defaults
+  targetNamespace: ${releaseNamespace}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubecost-app-dashboard-info
+  namespace: ${releaseNamespace}
+  labels:
+    "kommander.d2iq.io/application": "kubecost"
+data:
+  name: "Kubecost"
+  dashboardLink: "/dkp/kubecost/frontend/overview.html"
+  docsLink: "http://docs.kubecost.com/"
+  version: "1.84.1"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dkp-kubecost-view
+rules:
+  - nonResourceURLs:
+      - /dkp/kubecost/frontend
+      - /dkp/kubecost/frontend/*
+    verbs:
+      - get
+      - head
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dkp-kubecost-edit
+rules:
+  - nonResourceURLs:
+      - /dkp/kubecost/frontend
+      - /dkp/kubecost/frontend/*
+    verbs:
+      - get
+      - head
+      - post
+      - put
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dkp-kubecost-admin
+rules:
+  - nonResourceURLs:
+      - /dkp/kubecost/frontend
+      - /dkp/kubecost/frontend/*
+    verbs:
+      - get
+      - head
+      - post
+      - put
+      - delete

--- a/services/kubecost/0.20.2/kustomization.yaml
+++ b/services/kubecost/0.20.2/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kubecost.yaml


### PR DESCRIPTION
Bumps kubecost + bumps sidecar image to address CVE
https://jira.d2iq.com/browse/D2IQ-81263

New version is added here instead of overwriting the older version in case we need to retain 2.1.0 versions for upgrades.