### PR TITLE
chore: update docker image tag for dex-k8s-auth

### DIFF
--- a/services/dex-k8s-authenticator/1.2.8/defaults/cm.yaml
+++ b/services/dex-k8s-authenticator/1.2.8/defaults/cm.yaml
@@ -13,7 +13,7 @@ data:
       caSecretName: kommander-traefik-certificate
     image:
       repository: mesosphere/dex-k8s-authenticator
-      tag: v1.2.2-d2iq
+      tag: v1.2.3-d2iq
     ingress:
       enabled: true
       annotations:


### PR DESCRIPTION
This PR updates the image tag to use the CVE fixed image.

Resolves: [D2IQ-81264](https://jira.d2iq.com/browse/D2IQ-81264)