### PR TITLE
bug: move Knative to "general" category

### DIFF
--- a/services/knative/metadata.yaml
+++ b/services/knative/metadata.yaml
@@ -1,7 +1,7 @@
 displayName: Knative
 description: Kubernetes-based platform to build, deploy, and manage modern serverless workloads
 category:
-  - foundation
+  - general
 type: catalog
 scope:
   - workspace


### PR DESCRIPTION
Having Knative in the foundational category leads to the UI issuing a
warning about not all foundational components being installed and thus
the UI blocks any deployment of additional applications.

As long as we haven't settled on the right category for Knative, I'm
just moving it to "general" for now to enable users to deploy apps
again.