### PR TITLE
fix: Upgrade Grafana to pull in a fix for CVE-2021-43798

### DIFF
--- a/services/centralized-grafana/18.1.1/defaults/cm.yaml
+++ b/services/centralized-grafana/18.1.1/defaults/cm.yaml
@@ -16,6 +16,10 @@ data:
         enabled: false
     grafana:
       enabled: true
+      image:
+        # Overriding version to pull in a fix for a CVE.
+        # See <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43798>.
+        tag: 8.2.7
       defaultDashboardsEnabled: true
       sidecar:
         image:

--- a/services/grafana-logging/6.16.14/defaults/cm.yaml
+++ b/services/grafana-logging/6.16.14/defaults/cm.yaml
@@ -8,6 +8,11 @@ metadata:
 data:
   values.yaml: |
     ---
+    image:
+      # Overriding version to pull in a fix for a CVE.
+      # See <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43798>.
+      tag: 8.2.7
+
     datasources:
       datasources.yaml:
         apiVersion: 1

--- a/services/kube-prometheus-stack/18.1.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/18.1.1/defaults/cm.yaml
@@ -324,6 +324,10 @@ data:
             memory: 50Mi
     grafana:
       enabled: true
+      image:
+        # Overriding version to pull in a fix for a CVE.
+        # See <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43798>.
+        tag: 8.2.7
       defaultDashboardsEnabled: true
       ingress:
         enabled: true


### PR DESCRIPTION
See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43798.

This PR is tested against kommander at https://github.com/mesosphere/kommander/pull/1246.

Which issue(s) does this PR fix?:

https://jira.d2iq.com/browse/D2IQ-82337
