### PR TITLE
[release-2.1] feat: Add mesosphere-spark and pravega helmrepos

### DIFF
--- a/common/helm-repositories/mesosphere-spark.yaml
+++ b/common/helm-repositories/mesosphere-spark.yaml
@@ -1,0 +1,10 @@
+# TODO: Remove once airgapped support for catalog is implemented
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: mesosphere.github.io-spark-charts
+  namespace: kommander-flux
+spec:
+  interval: 10m
+  url: "${helmMirrorURL:=http://mesosphere.github.io/spark-on-k8s-operator}"

--- a/common/helm-repositories/pravega.yaml
+++ b/common/helm-repositories/pravega.yaml
@@ -1,0 +1,10 @@
+# TODO: Remove once airgapped support for catalog is implemented
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: charts.pravega.io
+  namespace: kommander-flux
+spec:
+  interval: 10m
+  url: "${helmMirrorURL:=https://charts.pravega.io}"


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-82477

Add the helmrepos required for dkp-catalog-applications to kommander-applications to bundle them with kommander installation. This is meant to be a temporary change (hack) for 2.1.1 until we come up with a plan for airgapped support for external catalog repos. Not putting this in `main` since we will implement the actual airgapped solution for 2.2.