### PR TITLE
fix: Bump project-grafana-logging/kubecost graf img to pull in a fix for CVE-2021-43798

### DIFF
--- a/services/kubecost/0.20.2/defaults/cm.yaml
+++ b/services/kubecost/0.20.2/defaults/cm.yaml
@@ -33,6 +33,12 @@ data:
         enabled: false
 
       grafana:
+        image:
+          # Overriding version to pull in a fix for a CVE.
+          # See <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43798>.
+          # Can remove once image bump done in below PR is released.
+          # https://github.com/kubecost/cost-analyzer-helm-chart/pull/1171
+          tag: 8.3.2
         ingress:
           enabled: true
           annotations:

--- a/services/project-grafana-logging/6.16.14/defaults/cm.yaml
+++ b/services/project-grafana-logging/6.16.14/defaults/cm.yaml
@@ -8,6 +8,11 @@ metadata:
 data:
   values.yaml: |
     ---
+    image:
+      # Overriding version to pull in a fix for a CVE.
+      # See <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43798>.
+      tag: 8.2.7
+
     datasources:
       datasources.yaml:
         apiVersion: 1


### PR DESCRIPTION
Missed updating grafana img in project-grafana-logging and kubecost grafana. Looks like kubecost already caught the CVE (https://github.com/kubecost/cost-analyzer-helm-chart/pull/1171) but it hasn't been released yet. Let's backport the image bump here to `release-2.1`, but we can remove this image bump with the next kubecost bump for `main`.