### PR TITLE
fix: Remove kube-prometheus-stack dep from knative

### DIFF
--- a/services/knative/0.18.3/knative-serving.yaml
+++ b/services/knative/0.18.3/knative-serving.yaml
@@ -5,9 +5,6 @@ metadata:
   name: knative
   namespace: ${releaseNamespace}
 spec:
-  dependsOn:
-    - name: kube-prometheus-stack
-      namespace: ${releaseNamespace}
   chart:
     spec:
       chart: knative


### PR DESCRIPTION
Forward-porting this fix that we made on the release branch https://github.com/mesosphere/kommander-applications/pull/102/commits/8cd83e2c789b3bfa1d3bc6a0a313789e0e3bbe2c