### PR TITLE
Fix misplaced `dependsOn` property for KNative

### DIFF
--- a/services/knative/0.18.3/knative-serving.yaml
+++ b/services/knative/0.18.3/knative-serving.yaml
@@ -4,11 +4,10 @@ kind: HelmRelease
 metadata:
   name: knative
   namespace: ${releaseNamespace}
+spec:
   dependsOn:
     - name: istio
       namespace: ${releaseNamespace}
-
-spec:
   chart:
     spec:
       chart: knative


### PR DESCRIPTION
Move `dependsOn` field to the `spec` section.