### PR TITLE
feat: Add kaptain helm repository

### DIFF
--- a/common/helm-repositories/kaptain.yaml
+++ b/common/helm-repositories/kaptain.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: kaptain-helm-mirror
+  namespace: kommander-flux
+spec:
+  interval: 10m
+  timeout: 1m
+  url: "http://kaptain-helm-mirror.kommander.svc"


### PR DESCRIPTION
I propose that kaptain Helm repository can be added here even though it points to helm mirror.