### PR TITLE
feat: add dummy helm releases

### DIFF
--- a/services/kommander/0.1.0/dynamic-helmreleases/README.txt
+++ b/services/kommander/0.1.0/dynamic-helmreleases/README.txt
@@ -1,6 +1,11 @@
-The purpose of these directories is to have ALL HelmRelease objects in the k-apps
-repo, including the ones that are generated dynamically.
+The purpose of these directories is to have ALL HelmRelease objects in the
+k-apps repo, including the ones that are generated dynamically.
 
-This way fetching charts and creating charts bundle can be done without any extra
-information - simply by scanning k-apps repository. The controllers that create
-these helmreleases create kustomizations instead that change these charts accordingly.
+By dynamically created, we mean HelmReleases which are created/maintained by
+controllers as opposed to simply creating Appdeployments and updating git
+repository.
+
+Thanks to this approach, fetching charts and creating charts bundle can be done
+without any extra information - simply by scanning k-apps repository. The
+controllers that create these helmreleases create kustomizations instead that
+change these charts accordingly.

--- a/services/kommander/0.1.0/dynamic-helmreleases/README.txt
+++ b/services/kommander/0.1.0/dynamic-helmreleases/README.txt
@@ -1,0 +1,6 @@
+The purpose of these directories is to have ALL HelmRelease objects in the k-apps
+repo, including the ones that are generated dynamically.
+
+This way fetching charts and creating charts bundle can be done without any extra
+information - simply by scanning k-apps repository. The controllers that create
+these helmreleases create kustomizations instead that change these charts accordingly.

--- a/services/kommander/0.1.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
+++ b/services/kommander/0.1.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: needsToBeOverriden
+  namespace: needsToBeOverriden
+  labels:
+    kommander.mesosphere.io/cluster-id: needsToBeOverriden
+spec:
+  chart:
+    spec:
+      chart: cluster-observer
+      sourceRef:
+        kind: HelmRepository
+        name: mesosphere.github.io-kommander-auditing-pipeline-charts
+        namespace: kommander-flux
+      version: 1.0.0
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: needsToBeOverriden
+  valuesFrom:
+    - kind: ConfigMap
+      name: needsToBeOverriden
+  targetNamespace: needsToBeOverriden

--- a/services/kommander/0.1.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
+++ b/services/kommander/0.1.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
@@ -2,10 +2,10 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
-  name: needsToBeOverriden
-  namespace: needsToBeOverriden
+  name: needsToBeOverridden
+  namespace: needsToBeOverridden
   labels:
-    kommander.mesosphere.io/cluster-id: needsToBeOverriden
+    kommander.mesosphere.io/cluster-id: needsToBeOverridden
 spec:
   chart:
     spec:
@@ -22,8 +22,8 @@ spec:
   upgrade:
     remediation:
       retries: 30
-  releaseName: needsToBeOverriden
+  releaseName: needsToBeOverridden
   valuesFrom:
     - kind: ConfigMap
-      name: needsToBeOverriden
-  targetNamespace: needsToBeOverriden
+      name: needsToBeOverridden
+  targetNamespace: needsToBeOverridden

--- a/services/kommander/0.1.0/dynamic-helmreleases/cluster-observer/kustomization.yaml
+++ b/services/kommander/0.1.0/dynamic-helmreleases/cluster-observer/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-observer.yaml

--- a/services/kommander/0.1.0/dynamic-helmreleases/mtls-proxy/kustomization.yaml
+++ b/services/kommander/0.1.0/dynamic-helmreleases/mtls-proxy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - mtls-proxy.yaml

--- a/services/kommander/0.1.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
+++ b/services/kommander/0.1.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
@@ -2,11 +2,11 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
-  name: needsToBeOverriden
-  namespace: needsToBeOverriden
+  name: needsToBeOverridden
+  namespace: needsToBeOverridden
   labels:
-    kommander.mesosphere.io/cluster-id: needsToBeOverriden
-    kommander.d2iq.com/prometheus-service: needsToBeOverriden
+    kommander.mesosphere.io/cluster-id: needsToBeOverridden
+    kommander.d2iq.com/prometheus-service: needsToBeOverridden
 spec:
   chart:
     spec:
@@ -24,8 +24,8 @@ spec:
   upgrade:
     remediation:
       retries: 30
-  releaseName: needsToBeOverriden
+  releaseName: needsToBeOverridden
   valuesFrom:
     - kind: ConfigMap
-      name: needsToBeOverriden
-  targetNamespace: needsToBeOverriden
+      name: needsToBeOverridden
+  targetNamespace: needsToBeOverridden

--- a/services/kommander/0.1.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
+++ b/services/kommander/0.1.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: needsToBeOverriden
+  namespace: needsToBeOverriden
+  labels:
+    kommander.mesosphere.io/cluster-id: needsToBeOverriden
+    kommander.d2iq.com/prometheus-service: needsToBeOverriden
+spec:
+  chart:
+    spec:
+      chart: mtls-proxy
+      sourceRef:
+        kind: HelmRepository
+        name: mesosphere.github.io-charts-stable
+        namespace: kommander-flux
+      version: 0.1.5
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: needsToBeOverriden
+  valuesFrom:
+    - kind: ConfigMap
+      name: needsToBeOverriden
+  targetNamespace: needsToBeOverriden


### PR DESCRIPTION
This PR is meant to unblock https://jira.d2iq.com/browse/D2IQ-82657 on one hand and on the other - enable pararelising the upgrades work as once it gets merged it can be worked on independently.

The idea behind this PR is to add dummy helm releases that will replace dynamic helm releases generated by:
* federation/pkg/controllers/kommandercluster_prometheus_proxy.go
* federation/pkg/controllers/kommandercluster_observer_controller.go

This way the charts parsing logic that populates helm-mirror/chartmuseum in https://github.com/mesosphere/kommander-cli/pull/298 will be able to determine versions of charts to download while still letting controllers create helm releases dynamically. The only difference is going to be that the controllers will be creating Flux kustomizations that point to these templates instead.