### PR TITLE
chore: bump kommander and kommander-application to 0.2.0

### DIFF
--- a/services/kommander-appmanagement/0.2.0/defaults/cm.yaml
+++ b/services/kommander-appmanagement/0.2.0/defaults/cm.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kommander-appmanagement-0.2.0-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    controllerManager:
+      containers:
+        manager:
+          replicas: "${kommanderAppManagementReplicas}"
+          image:
+            tag: "${appManagementImageTag}"
+            repository: "${appManagementImageRepository}"
+            pullPolicy: IfNotPresent

--- a/services/kommander-appmanagement/0.2.0/defaults/kustomization.yaml
+++ b/services/kommander-appmanagement/0.2.0/defaults/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cm.yaml

--- a/services/kommander-appmanagement/0.2.0/kommander-appmanagement.yaml
+++ b/services/kommander-appmanagement/0.2.0/kommander-appmanagement.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kommander-appmanagement
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: kommander-appmanagement
+      sourceRef:
+        kind: HelmRepository
+        name: mesosphere.github.io-kommander-charts
+        namespace: kommander-flux
+      version: "${chartVersion}"
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: kommander-appmanagement
+  valuesFrom:
+    - kind: ConfigMap
+      name: kommander-appmanagement-0.2.0-d2iq-defaults

--- a/services/kommander-appmanagement/0.2.0/kustomization.yaml
+++ b/services/kommander-appmanagement/0.2.0/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kommander-appmanagement.yaml

--- a/services/kommander/0.2.0/defaults/cm.yaml
+++ b/services/kommander/0.2.0/defaults/cm.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kommander-0.2.0-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    airgapped:
+      enabled: ${airgappedEnabled}
+    authorizedlister:
+      image:
+        tag: ${authorizedlisterImageTag}
+        repository: ${authorizedlisterImageRepository}
+    certificates:
+      ca:
+        issuer:
+          name: ${certificatesCAIssuerName}
+      issuer:
+        name: ${certificatesIssuerName}
+        kind: ${certificateIssuerKind:-Issuer}
+      selfSigned: false
+    controller:
+      containers:
+        manager:
+          rootCertSecretName: ${caSecretName}
+          rootCertSecretNamespace: ${caSecretNamespace}
+          image:
+            tag: ${controllerManagerImageTag}
+            repository: ${controllerManagerImageRepository}
+    webhook:
+      image:
+        tag: ${controllerWebhookImageTag}
+        repository: ${controllerWebhookImageRepository}
+    fluxOperator:
+      containers:
+        manager:
+          image:
+            tag: ${fluxOperatorManagerImageTag}
+            repository: ${fluxOperatorManagerImageRepository}
+      gitRepo:
+        gitCredentialsSecret:
+          namespace: kommander-flux
+          name: kommander-git-credentials
+        branch: main
+        service:
+          namespace: ${releaseNamespace}
+          name: gitea
+        caCertSecret:
+          namespace: ${releaseNamespace}
+          name: ${kommanderFullName}-root-ca
+      helmMirror:
+        service:
+          namespace: ${releaseNamespace}
+          name: ${kommanderFullName}-helm-mirror
+    kommander-licensing:
+      certificates:
+        issuer:
+          name: ${certificatesIssuerName}
+          kind: ${certificateIssuerKind:-Issuer}
+      controller:
+        containers:
+          manager:
+            rootCertSecretName: ${caSecretName}
+            image:
+              tag: ${licensingControllerManagerImageTag}
+              repository: ${licensingControllerManagerImageRepository}
+      webhook:
+        image:
+          tag: ${licensingControllerWebhookImageTag}
+          repository: ${licensingControllerWebhookImageRepository}
+    kubetools:
+      image:
+        repository: ${kubetoolsImageRepository}
+        tag: ${kubetoolsImageTag}
+    kommander-ui:
+      ingress:
+        enabled: true
+        extraAnnotations:
+          kubernetes.io/ingress.class: kommander-traefik
+          traefik.ingress.kubernetes.io/router.tls: "true"
+          traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth@kubernetescrd"
+        path: /dkp/kommander/dashboard
+        graphqlPath: /dkp/kommander/dashboard/graphql
+    attached:
+      prerequisites:
+        gatekeeper:
+          enabled: true

--- a/services/kommander/0.2.0/defaults/kustomization.yaml
+++ b/services/kommander/0.2.0/defaults/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cm.yaml

--- a/services/kommander/0.2.0/dynamic-helmreleases/README.txt
+++ b/services/kommander/0.2.0/dynamic-helmreleases/README.txt
@@ -1,0 +1,11 @@
+The purpose of these directories is to have ALL HelmRelease objects in the
+k-apps repo, including the ones that are generated dynamically.
+
+By dynamically created, we mean HelmReleases which are created/maintained by
+controllers as opposed to simply creating Appdeployments and updating git
+repository.
+
+Thanks to this approach, fetching charts and creating charts bundle can be done
+without any extra information - simply by scanning k-apps repository. The
+controllers that create these helmreleases create kustomizations instead that
+change these charts accordingly.

--- a/services/kommander/0.2.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
+++ b/services/kommander/0.2.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: needsToBeOverridden
+  namespace: needsToBeOverridden
+  labels:
+    kommander.mesosphere.io/cluster-id: needsToBeOverridden
+spec:
+  chart:
+    spec:
+      chart: cluster-observer
+      sourceRef:
+        kind: HelmRepository
+        name: mesosphere.github.io-kommander-auditing-pipeline-charts
+        namespace: kommander-flux
+      version: 1.0.0
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: needsToBeOverridden
+  valuesFrom:
+    - kind: ConfigMap
+      name: needsToBeOverridden
+  targetNamespace: needsToBeOverridden

--- a/services/kommander/0.2.0/dynamic-helmreleases/cluster-observer/kustomization.yaml
+++ b/services/kommander/0.2.0/dynamic-helmreleases/cluster-observer/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-observer.yaml

--- a/services/kommander/0.2.0/dynamic-helmreleases/mtls-proxy/kustomization.yaml
+++ b/services/kommander/0.2.0/dynamic-helmreleases/mtls-proxy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - mtls-proxy.yaml

--- a/services/kommander/0.2.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
+++ b/services/kommander/0.2.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: needsToBeOverridden
+  namespace: needsToBeOverridden
+  labels:
+    kommander.mesosphere.io/cluster-id: needsToBeOverridden
+    kommander.d2iq.com/prometheus-service: needsToBeOverridden
+spec:
+  chart:
+    spec:
+      chart: mtls-proxy
+      sourceRef:
+        kind: HelmRepository
+        name: mesosphere.github.io-charts-stable
+        namespace: kommander-flux
+      version: 0.1.5
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: needsToBeOverridden
+  valuesFrom:
+    - kind: ConfigMap
+      name: needsToBeOverridden
+  targetNamespace: needsToBeOverridden

--- a/services/kommander/0.2.0/kommander.yaml
+++ b/services/kommander/0.2.0/kommander.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kommander
+  namespace: ${releaseNamespace}
+spec:
+  dependsOn:
+    - namespace: ${releaseNamespace}
+      # NOTE: The `kubefed` app is not installing the HelmRelease directly.
+      # That's how its HelmRelease name is simply `kubefed`
+      name: kubefed
+  chart:
+    spec:
+      chart: kommander
+      sourceRef:
+        kind: HelmRepository
+        name: mesosphere.github.io-kommander-charts
+        namespace: kommander-flux
+      version: "${chartVersion}"
+  interval: 15s
+  # Kommander is quite a big chart and it may need some more time than
+  # other charts to get ready so setting this to 10 minutes increases
+  # the chance of the installation not timing out.
+  timeout: 10m
+  install:
+    remediation:
+      # The Kommander chart cannot be uninstalled in its current form. That's
+      # a known issue and trying to remediate an installation failure by
+      # deleting and retrying won't work so we can just as well not retry to
+      # begin with.
+      retries: 0
+  upgrade:
+    remediation:
+      # Rolling back an upgrade will very like not work and is untested so
+      # let's disable any remediation.
+      retries: 0
+  releaseName: kommander
+  valuesFrom:
+    - kind: ConfigMap
+      name: kommander-0.2.0-d2iq-defaults
+    - kind: ConfigMap
+      name: kommander-0.2.0-overrides
+      optional: true

--- a/services/kommander/0.2.0/kustomization.yaml
+++ b/services/kommander/0.2.0/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kommander.yaml


### PR DESCRIPTION
Resolves [D2IQ-82656](https://jira.d2iq.com/browse/D2IQ-82656)

This PR does the following:
- Bump the `kommander` from `0.1.0` to `0.2.0`
- Bump the `kommander-appmanagement` from `0.1.0` to `0.2.0`

Corresponding Kommander PR: [mesosphere/kommander#1330](https://github.com/mesosphere/kommander/pull/1330)