### PR TITLE
fix: Enable home dashboard in centralized grafana

### DIFF
--- a/services/kube-prometheus-stack/18.1.2/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/18.1.2/defaults/cm.yaml
@@ -21,7 +21,7 @@ data:
         velero: false
       homeDashboard:
         cronJob:
-          enabled: false
+          enabled: true
     prometheus:
       ingress:
         enabled: true


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-78014

Centralized Grafana's home dashboard isn't getting set - we should be enabling the cronjob to set it. The required `dkp-credentials` will always exist in the workspace namespace that this grafana instance is deployed to on the mgmt cluster (centralized-grafana only deployed to mgmt-cluster, so we can enable it at the top-level here vs in overrides like we do for kube-prometheus-stack).