### PR TITLE
fix: synchronize kubetunmnel versioning scheme

### DIFF
--- a/services/kubetunnel/0.0.10/kubetunnel.yaml
+++ b/services/kubetunnel/0.0.10/kubetunnel.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-kubetunnel-charts
         namespace: kommander-flux
-      version: "0.0.10"
+      version: "v0.0.10"
   interval: 15s
   install:
     remediation:


### PR DESCRIPTION
kubetunnel chart defines version v0.0.8 in Chart.yaml :
```
$ tar -O -xvf charts-bundle.tar.gz kubetunnel-v0.0.8.tgz | tar -O -xzvf - kubetunnel/Chart.yaml
kubetunnel-v0.0.8.tgz
kubetunnel/Chart.yaml
apiVersion: v1
appVersion: v0.0.8
description: Kubernetes Tunneling
home: https://github.com/mesosphere/kubetunnel
maintainers:
- name: mhrabovcin
- name: jongiddy
- name: tillt
- name: hectorj2f
name: kubetunnel
sources:
- https://github.com/mesosphere/kubetunnel
version: v0.0.8
```
whereas helmrelease uses version 0.0.8:
```
  1 ---
  2 apiVersion: helm.toolkit.fluxcd.io/v2beta1
  3 kind: HelmRelease
  4 metadata:
  5   name: kubetunnel
  6   namespace: ${releaseNamespace}
  7 spec:
  8   chart:
  9     spec:
 10       chart: kubetunnel
 11       sourceRef:
 12         kind: HelmRepository
 13         name: mesosphere.github.io-kubetunnel-charts
 14         namespace: kommander-flux
 15       version: "0.0.8"
 16   interval: 15s
 17   install:
 18     remediation:
 19       retries: 30
 20   upgrade:
 21     remediation:
 22       retries: 30
 23   releaseName: kubetunnel
 24   valuesFrom:
 25     - kind: ConfigMap
 26       name: kubetunnel-0.0.8-d2iq-defaults
```
This is a followup from https://mesosphere.slack.com/archives/C01LNF6KML5/p1641483022012200 Fixing this will help getting airgapped tests that use chartmuseum green again.

This is not the only case when we will be using `v` prefix - reloader does it too. In theory we should fix charts instead, but this is more work and I am not sure if we need it ATM.

Verified manually by installing k20 using the patched version:
```
Handling connection for 38483
chart kubetunnel-v0.0.10.tgz is already present in chartmuseum, skipping
```
kubetunnel installed OK.
```
$ k get helmreleases.helm.toolkit.fluxcd.io -n kommander kubetunnel
NAME         READY   STATUS                             AGE
kubetunnel   True    Release reconciliation succeeded   2m25s
```