### PR TITLE
feat: make helmrepositories use chartmuseum's CA certificate

### DIFF
--- a/common/helm-repositories/banzaicloud.yaml
+++ b/common/helm-repositories/banzaicloud.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://kubernetes-charts.banzaicloud.com/}"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/dashboard.yaml
+++ b/common/helm-repositories/dashboard.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://kubernetes.github.io/dashboard}"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/fluent.yaml
+++ b/common/helm-repositories/fluent.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://fluent.github.io/helm-charts/}"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/gitea.yaml
+++ b/common/helm-repositories/gitea.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://dl.gitea.io/charts/}"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/grafana.yaml
+++ b/common/helm-repositories/grafana.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://grafana.github.io/helm-charts/}"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/jaegertracing.yaml
+++ b/common/helm-repositories/jaegertracing.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://jaegertracing.github.io/helm-charts/}"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/kaptain.yaml
+++ b/common/helm-repositories/kaptain.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "http://kaptain-helm-mirror.kommander.svc"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/kiali.yaml
+++ b/common/helm-repositories/kiali.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://kiali.org/helm-charts/}"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/kommander-ui.yaml
+++ b/common/helm-repositories/kommander-ui.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/kommander-ui/charts}"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/kommander.yaml
+++ b/common/helm-repositories/kommander.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/kommander/charts}"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/kubefed.yaml
+++ b/common/helm-repositories/kubefed.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts}"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/kubetunnel.yaml
+++ b/common/helm-repositories/kubetunnel.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/kubetunnel/charts}"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/mesosphere-repos.yaml
+++ b/common/helm-repositories/mesosphere-repos.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/charts/stable}"
+  secretRef: "${chartmuseumCASecret}"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmRepository
@@ -18,6 +19,7 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/charts/staging}"
+  secretRef: "${chartmuseumCASecret}"
 ---
 # This is to support the HelmReleases created by Kommander's cluster observer controller.
 # See https://github.com/mesosphere/kommander/blob/main/federation/pkg/controllers/clusterobserver_controller.go
@@ -30,3 +32,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/kommander-auditing-pipeline/charts}"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/minio.yaml
+++ b/common/helm-repositories/minio.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://operator.min.io/}"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/prometheus-community.yaml
+++ b/common/helm-repositories/prometheus-community.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://prometheus-community.github.io/helm-charts}"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/reloader.yaml
+++ b/common/helm-repositories/reloader.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://stakater.github.io/stakater-charts}"
+  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/traefik.yaml
+++ b/common/helm-repositories/traefik.yaml
@@ -8,3 +8,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://helm.traefik.io/traefik}"
+  secretRef: "${chartmuseumCASecret}"


### PR DESCRIPTION
This is a bit of a hack meant to enable k-cli to inject chartmuseum's CA certificate when airgapped deployment is in place and skip this step otherwise.

The idea is to use variable substitution - in case of airgapped install we provide variable, in non-airgapped install - we do not which results in the field's value being empty-string, which in turn results in disabling custom CA certificate option.

https://jira.d2iq.com/browse/D2IQ-83371