### PR TITLE
Revert "feat: make helmrepositories use chartmuseum's CA certificate"

### DIFF
--- a/common/helm-repositories/banzaicloud.yaml
+++ b/common/helm-repositories/banzaicloud.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://kubernetes-charts.banzaicloud.com/}"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/dashboard.yaml
+++ b/common/helm-repositories/dashboard.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://kubernetes.github.io/dashboard}"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/fluent.yaml
+++ b/common/helm-repositories/fluent.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://fluent.github.io/helm-charts/}"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/gitea.yaml
+++ b/common/helm-repositories/gitea.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://dl.gitea.io/charts/}"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/grafana.yaml
+++ b/common/helm-repositories/grafana.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://grafana.github.io/helm-charts/}"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/jaegertracing.yaml
+++ b/common/helm-repositories/jaegertracing.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://jaegertracing.github.io/helm-charts/}"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/kaptain.yaml
+++ b/common/helm-repositories/kaptain.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "http://kaptain-helm-mirror.kommander.svc"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/kiali.yaml
+++ b/common/helm-repositories/kiali.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://kiali.org/helm-charts/}"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/kommander-ui.yaml
+++ b/common/helm-repositories/kommander-ui.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/kommander-ui/charts}"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/kommander.yaml
+++ b/common/helm-repositories/kommander.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/kommander/charts}"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/kubefed.yaml
+++ b/common/helm-repositories/kubefed.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts}"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/kubetunnel.yaml
+++ b/common/helm-repositories/kubetunnel.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/kubetunnel/charts}"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/mesosphere-repos.yaml
+++ b/common/helm-repositories/mesosphere-repos.yaml
@@ -8,7 +8,6 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/charts/stable}"
-  secretRef: "${chartmuseumCASecret}"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmRepository
@@ -19,7 +18,6 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/charts/staging}"
-  secretRef: "${chartmuseumCASecret}"
 ---
 # This is to support the HelmReleases created by Kommander's cluster observer controller.
 # See https://github.com/mesosphere/kommander/blob/main/federation/pkg/controllers/clusterobserver_controller.go
@@ -32,4 +30,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/kommander-auditing-pipeline/charts}"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/minio.yaml
+++ b/common/helm-repositories/minio.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://operator.min.io/}"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/prometheus-community.yaml
+++ b/common/helm-repositories/prometheus-community.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://prometheus-community.github.io/helm-charts}"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/reloader.yaml
+++ b/common/helm-repositories/reloader.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://stakater.github.io/stakater-charts}"
-  secretRef: "${chartmuseumCASecret}"

--- a/common/helm-repositories/traefik.yaml
+++ b/common/helm-repositories/traefik.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://helm.traefik.io/traefik}"
-  secretRef: "${chartmuseumCASecret}"


### PR DESCRIPTION
Reverts mesosphere/kommander-applications#149

We need a better way to handle null-ing `secretRef`field in HelmRepository object. See also the discussion in https://mesosphere.slack.com/archives/C01LNF6KML5/p1642433423286400