### PR TITLE
fix: add directories for kustomizing the helm-mirror ca cert

### DIFF
--- a/common/airgapped/kustomization.yaml
+++ b/common/airgapped/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../helm-repositories/
+patches:
+  - path: patch-add-secret-ref.yaml
+    target:
+      kind: HelmRepository

--- a/common/airgapped/patch-add-secret-ref.yaml
+++ b/common/airgapped/patch-add-secret-ref.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: not-used-in-a-patch
+spec:
+  secretRef:
+    name: "tls-root-ca"

--- a/common/base/kustomization.yaml
+++ b/common/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../helm-repositories/


### PR DESCRIPTION
This PR, together with https://github.com/mesosphere/kommander-cli/pull/327 unifies the way the helm-mirror certificate is handled for management and attached clusters.

So far, attached clusters were variing the kustomization path and setting it between `common/airgapped` and `common/base` in order to define whether an extra `.spec.secretRef` should be added to all HelmRepository objects in case of airgapped install. This field was then pointing to the secret that contained CA certificate that should be used to connect to helm mirror.

Management clusters were not using TLS at all, but this had to change together with introduction of dynamic/mutable helm-repository as the login credentials for manipulating its contents had to be passed over TLS. So the CLI will be doing the same thing for the management cluster by choosing different path to the kustomization in order to define if the field should be added. This requires that the kustomizations in question need to be present in the k-apps repo though. This PR adds them.