### PR TITLE
fix: Enable home dash on centralized-grafana not kps

### DIFF
--- a/services/centralized-grafana/18.1.2/defaults/cm.yaml
+++ b/services/centralized-grafana/18.1.2/defaults/cm.yaml
@@ -11,7 +11,7 @@ data:
       create: false
       homeDashboard:
         cronJob:
-          enabled: false
+          enabled: true
       ingressRBAC:
         enabled: false
     grafana:

--- a/services/kube-prometheus-stack/18.1.2/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/18.1.2/defaults/cm.yaml
@@ -21,7 +21,7 @@ data:
         velero: false
       homeDashboard:
         cronJob:
-          enabled: true
+          enabled: false
     prometheus:
       ingress:
         enabled: true


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-78014
The cronjob was enabled in the wrong app 🤦🏻‍♀️ it should be enabled in centralized-grafana, but I had mistakenly enabled it in kps instead.