### PR TITLE
feat: Kustomize dynamic helmreleases

### DIFF
--- a/services/kommander/0.2.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
+++ b/services/kommander/0.2.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
@@ -2,10 +2,10 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
-  name: needsToBeOverridden
-  namespace: needsToBeOverridden
+  name: ${name}
+  namespace: ${namespace}
   labels:
-    kommander.mesosphere.io/cluster-id: needsToBeOverridden
+    kommander.mesosphere.io/cluster-id: ${clusterID}
 spec:
   chart:
     spec:
@@ -22,8 +22,8 @@ spec:
   upgrade:
     remediation:
       retries: 30
-  releaseName: needsToBeOverridden
+  releaseName: ${releaseName}
   valuesFrom:
     - kind: ConfigMap
-      name: needsToBeOverridden
-  targetNamespace: needsToBeOverridden
+      name: ${valuesFrom}
+  targetNamespace: ${targetNamespace}

--- a/services/kommander/0.2.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
+++ b/services/kommander/0.2.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
@@ -2,11 +2,11 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
-  name: needsToBeOverridden
-  namespace: needsToBeOverridden
+  generateName: ${generatedName}
+  namespace: ${namespace}
   labels:
-    kommander.mesosphere.io/cluster-id: needsToBeOverridden
-    kommander.d2iq.com/prometheus-service: needsToBeOverridden
+    kommander.mesosphere.io/cluster-id: ${clusterID}
+    kommander.d2iq.com/prometheus-service: ${prometheusService}
 spec:
   chart:
     spec:
@@ -24,8 +24,8 @@ spec:
   upgrade:
     remediation:
       retries: 30
-  releaseName: needsToBeOverridden
+  releaseName: ${releaseName}
   valuesFrom:
     - kind: ConfigMap
-      name: needsToBeOverridden
-  targetNamespace: needsToBeOverridden
+      name: ${valuesFrom}
+  targetNamespace: ${targetNamespace}


### PR DESCRIPTION
Introduces substitutions in dynamic HelmReleases so the definitions can be reused.

Jira: https://jira.d2iq.com/browse/D2IQ-83144
Changes are used in: https://github.com/mesosphere/kommander/pull/1355
