### PR TITLE
fix: Add required env var to config reloader container

### DIFF
--- a/services/kube-prometheus-stack/18.1.3/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/18.1.3/defaults/cm.yaml
@@ -138,6 +138,11 @@ data:
           version: v0.17.1
         externalLabels:
           cluster: $(CLUSTER_ID)
+        containers:
+          - name: config-reloader
+            envFrom:
+            - configMapRef:
+                name: cluster-info-configmap
         initContainers:
           - name: init-config-reloader
             envFrom:


### PR DESCRIPTION
Fixes https://jira.d2iq.com/browse/D2IQ-81451.

The config-reloader container was failing due to not being able to expand the `CLUSTER_ID` environment variable in the config file (line 140). The service wouldn't actually fail/exit, it will just hang out and not watch for config changes which is curious.

Here's the error:
```
expand environment variables: found reference to unset environment variable \"CLUSTER_ID\""
```

We pass in this env var in the config reload init container but not the container i.e.
```
        initContainers:
          - name: init-config-reloader
            envFrom:
            - configMapRef:
                name: cluster-info-configmap
```

I tested this by first installing Kommander then adding a test `remote_write` config to the kps ConfigMap override, and re-running the install command. It took about 

```
  prometheusSpec:
    remoteWrite:
      - url: http://localhost
```