### PR TITLE
fix: promote HTTPS chartmuseum to Traefik

### DIFF
--- a/services/chartmuseum/3.4.0/defaults/cm.yaml
+++ b/services/chartmuseum/3.4.0/defaults/cm.yaml
@@ -20,6 +20,8 @@ data:
       existingClaim: chartmuseum
     service:
       servicename: chartmuseum
+      annotations:
+        traefik.ingress.kubernetes.io/service.serversscheme: https
     deployment:
       extraVolumeMounts:
         - name: tls


### PR DESCRIPTION
We need to let Traefik now that chartmuseum is served over HTTPS and
not HTTP. Since the chart doesn't allow us to directly change the port
name from http to https, we add the annotation here as is documented
at
https://doc.traefik.io/traefik/routing/providers/kubernetes-ingress/#communication-between-traefik-and-pods