### PR TITLE
fix: kube-oidc-proxy default cm name

### DIFF
--- a/services/kube-oidc-proxy/0.3.0/defaults/cm.yaml
+++ b/services/kube-oidc-proxy/0.3.0/defaults/cm.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kube-oidc-proxy-0.2.5-d2iq-defaults
+  name: kube-oidc-proxy-0.3.0-d2iq-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/kube-oidc-proxy/0.3.0/kube-oidc-proxy.yaml
+++ b/services/kube-oidc-proxy/0.3.0/kube-oidc-proxy.yaml
@@ -32,5 +32,5 @@ spec:
   releaseName: kube-oidc-proxy
   valuesFrom:
     - kind: ConfigMap
-      name: kube-oidc-proxy-0.2.5-d2iq-defaults
+      name: kube-oidc-proxy-0.3.0-d2iq-defaults
   targetNamespace: ${releaseNamespace}


### PR DESCRIPTION
This was missed during the `kube-oidc-proxy` bump.