### PR TITLE
drop the dependson of root-ca resources and change the issuer type&name

### DIFF
--- a/services/cert-manager/0.2.7/root-ca.yaml
+++ b/services/cert-manager/0.2.7/root-ca.yaml
@@ -13,7 +13,7 @@ spec:
     kind: GitRepository
     name: management
     namespace: kommander-flux
-  timeout: 60s
+  timeout: 480s
   # passing releaseNamespace to 2nd level configuration files for able to configure namespace correctly in attached clusters
   # Using `substituteFrom` with `substitution-vars` creates 2nd level resources in `kommander` namespace instead of workspace ns
   postBuild:

--- a/services/cert-manager/0.2.7/root-ca.yaml
+++ b/services/cert-manager/0.2.7/root-ca.yaml
@@ -9,9 +9,6 @@ spec:
   prune: true
   interval: 1m0s
   path: ./services/cert-manager/0.2.7/root-ca
-  dependsOn:
-    - name: cert-manager-release
-      namespace: ${releaseNamespace}
   sourceRef:
     kind: GitRepository
     name: management

--- a/services/cert-manager/0.2.7/root-ca/root-ca.yaml
+++ b/services/cert-manager/0.2.7/root-ca/root-ca.yaml
@@ -4,6 +4,44 @@
 ## follow-up ticket for mirroring: https://jira.d2iq.com/browse/D2IQ-78135
 ---
 apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kommander-bootstrap-ca-issuer
+  namespace: ${releaseNamespace}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kommander-bootstrap-root-certificate
+  namespace: ${releaseNamespace}
+spec:
+  commonName: ca.kommander-bootstrap
+  dnsNames:
+    - ca.kommander-bootstrap
+  duration: 8760h
+  isCA: true
+  issuerRef:
+    name: kommander-bootstrap-ca-issuer
+  secretName: kommander-bootstrap-root-ca
+  subject:
+    organizations:
+      - cert-manager
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kommander-bootstrap-issuer
+  namespace: ${releaseNamespace}
+spec:
+  ca:
+    secretName: kommander-bootstrap-root-ca
+---
+# a quick solution to fix kommander-traefik and kube-oidc-proxy certificate in attached clusters (with and without cert-manager pre-installed)
+# https://jira.d2iq.com/browse/D2IQ-84510
+---
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: selfsigned-issuer

--- a/services/cert-manager/0.2.7/root-ca/root-ca.yaml
+++ b/services/cert-manager/0.2.7/root-ca/root-ca.yaml
@@ -4,36 +4,33 @@
 ## follow-up ticket for mirroring: https://jira.d2iq.com/browse/D2IQ-78135
 ---
 apiVersion: cert-manager.io/v1
-kind: Issuer
+kind: ClusterIssuer
 metadata:
-  name: kommander-bootstrap-ca-issuer
-  namespace: ${releaseNamespace}
+  name: selfsigned-issuer
 spec:
   selfSigned: {}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: kommander-bootstrap-root-certificate
-  namespace: ${releaseNamespace}
+  name: kommander-ca
+  namespace: cert-manager
 spec:
-  commonName: ca.kommander-bootstrap
-  dnsNames:
-    - ca.kommander-bootstrap
-  duration: 8760h
   isCA: true
+  commonName: kommander-ca
+  secretName: kommander-ca
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   issuerRef:
-    name: kommander-bootstrap-ca-issuer
-  secretName: kommander-bootstrap-root-ca
-  subject:
-    organizations:
-      - cert-manager
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
 ---
 apiVersion: cert-manager.io/v1
-kind: Issuer
+kind: ClusterIssuer
 metadata:
-  name: kommander-bootstrap-issuer
-  namespace: ${releaseNamespace}
+  name: kommander-ca
 spec:
   ca:
-    secretName: kommander-bootstrap-root-ca
+    secretName: kommander-ca


### PR DESCRIPTION
This is a quick fix of the issue where attached clusters are missing the kommander root-ca bootstrap cert resources. 

https://jira.d2iq.com/browse/D2IQ-84510

kuttl test PR: https://github.com/mesosphere/kommander/pull/1422