### PR TITLE
chore: bump cluster observer

### DIFF
--- a/services/kommander/0.2.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
+++ b/services/kommander/0.2.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-kommander-auditing-pipeline-charts
         namespace: kommander-flux
-      version: 1.0.0
+      version: 1.0.2
   interval: 15s
   install:
     remediation:


### PR DESCRIPTION
Bump cluster observer as a follow up on https://github.com/mesosphere/kommander/pull/1409.

I'll likely have to create another PR for the release-2.1 branch in the kommander repo since the cluster observer version/helm release was managed in the cluster observer controller in 2.1.1.

Here's the kommander PR to make sure tests pass https://github.com/mesosphere/kommander/pull/1432