### PR TITLE
feat: provide defaults for new kommander chart values

### DIFF
--- a/services/kommander/0.1.0/defaults/cm.yaml
+++ b/services/kommander/0.1.0/defaults/cm.yaml
@@ -42,6 +42,9 @@ data:
         gitCredentialsSecret:
           namespace: kommander-flux
           name: kommander-git-credentials
+        ingressCertificateSecret:
+          namespace: kommander
+          name: kommander-traefik-certificate
         branch: main
         service:
           namespace: ${releaseNamespace}


### PR DESCRIPTION
This commit provides defaults for the new values in the kommander
chart that were introduced in
https://github.com/mesosphere/kommander/pull/1438.

This is a forward-port of #190 