### PR TITLE
fix: Remove grafana img overrides

### DIFF
--- a/services/centralized-grafana/32.0.2/defaults/cm.yaml
+++ b/services/centralized-grafana/32.0.2/defaults/cm.yaml
@@ -18,14 +18,8 @@ data:
         enabled: false
     grafana:
       enabled: true
-      image:
-        # Overriding version to pull in a fix for a CVE.
-        # See <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43798>.
-        tag: 8.2.7
       defaultDashboardsEnabled: true
       sidecar:
-        image:
-          tag: 1.12.3
         dashboards:
           enabled: true
           # label that the configmaps with dashboards are marked with

--- a/services/grafana-logging/6.20.6/defaults/cm.yaml
+++ b/services/grafana-logging/6.20.6/defaults/cm.yaml
@@ -8,11 +8,6 @@ metadata:
 data:
   values.yaml: |
     ---
-    image:
-      # Overriding version to pull in a fix for a CVE.
-      # See <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43798>.
-      tag: 8.2.7
-
     datasources:
       datasources.yaml:
         apiVersion: 1

--- a/services/kube-prometheus-stack/32.0.2/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/32.0.2/defaults/cm.yaml
@@ -335,10 +335,6 @@ data:
             memory: 50Mi
     grafana:
       enabled: true
-      image:
-        # Overriding version to pull in a fix for a CVE.
-        # See <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43798>.
-        tag: 8.2.7
       defaultDashboardsEnabled: true
       ingress:
         enabled: true
@@ -352,8 +348,11 @@ data:
         pathType: ImplementationSpecific
       sidecar:
         dashboards:
+          enabled: true
           label: grafana_dashboard
           searchNamespace: ALL
+        datasources:
+          enabled: true
       grafana.ini:
         server:
           protocol: http

--- a/services/project-grafana-logging/6.20.6/defaults/cm.yaml
+++ b/services/project-grafana-logging/6.20.6/defaults/cm.yaml
@@ -8,11 +8,6 @@ metadata:
 data:
   values.yaml: |
     ---
-    image:
-      # Overriding version to pull in a fix for a CVE.
-      # See <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43798>.
-      tag: 8.2.7
-
     datasources:
       datasources.yaml:
         apiVersion: 1


### PR DESCRIPTION
We bumped kube-prometheus-stack and grafana charts recently which bumped the grafana image to 8.3.4, so we need to remove the override when we were setting it to 8.2.7 to fix a CVE. 8.3.4 also includes the CVE fix.

Same deal with a sidecar img we were overriding, and also explicitly enabled a few things in kps just in case upstream ever decided to disable things by default