### PR TITLE
fix: Disable grafana datasource reload url

### DIFF
--- a/services/centralized-grafana/32.0.2/defaults/cm.yaml
+++ b/services/centralized-grafana/32.0.2/defaults/cm.yaml
@@ -34,6 +34,7 @@ data:
           # label that the configmaps with datasources are marked with
           label: grafana_datasource_kommander
           searchNamespace: ALL
+          skipReload: true
       annotations:
         configmap.reloader.stakater.com/reload: "centralized-kubecost-grafana-datasource"
       ingress:

--- a/services/centralized-grafana/32.0.2/defaults/cm.yaml
+++ b/services/centralized-grafana/32.0.2/defaults/cm.yaml
@@ -110,6 +110,27 @@ data:
           volumeMounts:
           - name: plugins
             mountPath: /var/lib/grafana/shared-plugins/
+        # Manual workaround since initcontainer was replaced by container with reloads.
+        # Admin API only works with basic auth which we disable.
+        # See: https://jira.d2iq.com/browse/D2IQ-84982
+        - name: init-grafana-sc-datasources
+          image: "quay.io/kiwigrid/k8s-sidecar:1.15.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: METHOD
+              value: "LIST"
+            - name: LABEL
+              value: "grafana_datasource_kommander"
+            - name: FOLDER
+              value: "/etc/grafana/provisioning/datasources"
+            - name: RESOURCE
+              value: "both"
+            - name: NAMESPACE
+              value: "ALL"
+          resources: {}
+          volumeMounts:
+            - name: sc-datasources-volume
+              mountPath: "/etc/grafana/provisioning/datasources"
 
     # Disable everything else
     defaultRules:

--- a/services/kube-prometheus-stack/32.0.2/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/32.0.2/defaults/cm.yaml
@@ -354,6 +354,7 @@ data:
         datasources:
           enabled: true
           skipReload: true
+          searchNamespace: ALL
       grafana.ini:
         server:
           protocol: http
@@ -410,6 +411,27 @@ data:
           volumeMounts:
           - name: plugins
             mountPath: /var/lib/grafana/shared-plugins/
+        # Manual workaround since initcontainer was replaced by container with reloads.
+        # Admin API only works with basic auth which we disable.
+        # See: https://jira.d2iq.com/browse/D2IQ-84982
+        - name: init-grafana-sc-datasources
+          image: "quay.io/kiwigrid/k8s-sidecar:1.15.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: METHOD
+              value: "LIST"
+            - name: LABEL
+              value: "grafana_datasource"
+            - name: FOLDER
+              value: "/etc/grafana/provisioning/datasources"
+            - name: RESOURCE
+              value: "both"
+            - name: NAMESPACE
+              value: "ALL"
+          resources: {}
+          volumeMounts:
+            - name: sc-datasources-volume
+              mountPath: "/etc/grafana/provisioning/datasources"
     kubeEtcd:
       # Updated to false due to EKS not allowing the retrieval of data from etcd.
       enabled: false

--- a/services/kube-prometheus-stack/32.0.2/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/32.0.2/defaults/cm.yaml
@@ -353,6 +353,7 @@ data:
           searchNamespace: ALL
         datasources:
           enabled: true
+          skipReload: true
       grafana.ini:
         server:
           protocol: http


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-84982

Newer versions of grafana added automatic reloading of datasources by hitting the Admin API. However, the API only works with basic authentication, which we disable.
https://grafana.com/docs/grafana/latest/http_api/admin

Upstream PR fix: https://github.com/grafana/helm-charts/pull/1046 we can bump to this once it is merged