### PR TITLE
feat: Add versions of default enterprise apps (kommander-licensing)

### DIFF
--- a/hack/validate-default-apps-versions.sh
+++ b/hack/validate-default-apps-versions.sh
@@ -3,13 +3,18 @@ set -euo pipefail
 
 latestKommanderVersion=$(find "services/kommander" -maxdepth 1 -type d -regextype sed -regex '.*/[0-9]\+.[0-9]\+.[0-9]\+' -printf "%f\n" | sort --version-sort | tail -1)
 
-readarray apps < <(yq -e '.data["values.yaml"]' "services/kommander/$latestKommanderVersion/defaults/cm.yaml" | yq -e '.attached.prerequisites.defaultApps')
+validate_apps_in_yaml_path() {
+  readarray apps < <(yq -e '.data["values.yaml"]' "services/kommander/$latestKommanderVersion/defaults/cm.yaml" | yq -e "$1")
 
-for app in "${apps[@]}"; do
-  name=$(echo "$app" | yq -e 'keys | .[0]')
-  version=$(echo "$app" | yq -e '.[]')
-  if [ ! -d "services/$name/$version" ]; then
-    echo "kommander is set to use $name in version $version which doesn't exist"
-    exit 1
-  fi
-done
+  for app in "${apps[@]}"; do
+    name=$(echo "$app" | yq -e 'keys | .[0]')
+    version=$(echo "$app" | yq -e '.[]')
+    if [ ! -d "services/$name/$version" ]; then
+      echo "app $name in version $version specified in $1 doesn't exist"
+      exit 1
+    fi
+  done
+}
+
+validate_apps_in_yaml_path ".attached.prerequisites.defaultApps"
+validate_apps_in_yaml_path ".kommander-licensing.defaultEnterpriseApps"

--- a/services/kommander/0.2.0/defaults/cm.yaml
+++ b/services/kommander/0.2.0/defaults/cm.yaml
@@ -62,6 +62,13 @@ data:
         image:
           tag: ${licensingControllerWebhookImageTag}
           repository: ${licensingControllerWebhookImageRepository}
+      defaultEnterpriseApps:
+        centralized-kubecost: "0.22.1"
+        centralized-grafana: "32.0.2"
+        karma: "2.0.0"
+        karma-traefik: "0.0.1"
+        prometheus-thanos-traefik: "0.0.1"
+        thanos: "0.4.6"
     kubetools:
       image:
         repository: ${kubetoolsImageRepository}


### PR DESCRIPTION
jira: https://jira.d2iq.com/browse/D2IQ-85356

An example of failing `pre-commit` check: https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_Kommander2_KommanderApplications_PreCommitChecks/3357848?buildTab=log&focusLine=1865&linesState=450