### PR TITLE
fix: add k8s 1.22 support for various configurations

### DIFF
--- a/services/centralized-kubecost/0.22.1/defaults/cm.yaml
+++ b/services/centralized-kubecost/0.22.1/defaults/cm.yaml
@@ -38,19 +38,21 @@ data:
         maxSourceResolution: 5m
 
       ingress:
-        enabled: true
-        # We can remove this once https://github.com/kubecost/cost-analyzer-helm-chart/pull/1132 is released.
-        className: ""
-        annotations:
-          kubernetes.io/ingress.class: kommander-traefik
-          ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
-          traefik.ingress.kubernetes.io/router.tls: "true"
-          traefik.ingress.kubernetes.io/router.middlewares: "${releaseNamespace}-stripprefixes@kubernetescrd,${releaseNamespace}-forwardauth@kubernetescrd"
-        paths:
-          - "/dkp/kommander/kubecost/frontend/"
-        hosts:
-          - ""
-        tls: []
+        enabled: false
+        # TODO(mh): Enable once `kubecost` chart supports Ingress for k8s 1.22+
+        # enabled: true
+        # # We can remove this once https://github.com/kubecost/cost-analyzer-helm-chart/pull/1132 is released.
+        # className: ""
+        # annotations:
+        #   kubernetes.io/ingress.class: kommander-traefik
+        #   ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
+        #   traefik.ingress.kubernetes.io/router.tls: "true"
+        #   traefik.ingress.kubernetes.io/router.middlewares: "${releaseNamespace}-stripprefixes@kubernetescrd,${releaseNamespace}-forwardauth@kubernetescrd"
+        # paths:
+        #   - "/dkp/kommander/kubecost/frontend/"
+        # hosts:
+        #   - ""
+        # tls: []
 
       kubecostDeployment:
         labels:
@@ -109,15 +111,23 @@ data:
               labels:
                 servicemonitor.kommander.mesosphere.io/path: "metrics"
             ingress:
-              enabled: true
-              annotations:
-                kubernetes.io/ingress.class: kommander-traefik
-                traefik.ingress.kubernetes.io/router.tls: "true"
-                traefik.ingress.kubernetes.io/router.middlewares: "${releaseNamespace}-stripprefixes@kubernetescrd,${releaseNamespace}-forwardauth@kubernetescrd"
-              path: "/dkp/kommander/kubecost/query"
-              hosts:
-                - ""
-              tls: []
+              enabled: false
+              # TODO(mh): Enable this once the `kubecost` chart bundles thanos
+              # version that supports k8s 1.22+ by using stable Ingress API
+              # version.
+              #
+              # This ingress is for now created as a seprate object of the helm
+              # chart using flux installation.
+              #
+              # enabled: true
+              # annotations:
+              #   kubernetes.io/ingress.class: kommander-traefik
+              #   traefik.ingress.kubernetes.io/router.tls: "true"
+              #   traefik.ingress.kubernetes.io/router.middlewares: "${releaseNamespace}-stripprefixes@kubernetescrd,${releaseNamespace}-forwardauth@kubernetescrd"
+              # path: "/dkp/kommander/kubecost/query"
+              # hosts:
+              #   - ""
+              # tls: []
           # Enable DNS discovery for stores
           storeDNSDiscovery: false
           # Enable DNS discovery for sidecars (this is for the chart built-in sidecar service)

--- a/services/centralized-kubecost/0.22.1/release/release.yaml
+++ b/services/centralized-kubecost/0.22.1/release/release.yaml
@@ -155,3 +155,58 @@ rules:
       - post
       - put
       - delete
+---
+# TODO(mh): See `../defaults/cm.yaml` section of
+# `cost-analyzer.thanos.query.ingress`. This is a fix for thanos chart bundled
+# by kubecost installing Ingress with version that is not supported in k8s 1.22+
+# anymore.
+# This should be removed once the upstream chart is fixed.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kommander-kubecost-thanos-query-http
+  labels:
+    app.kubernetes.io/component: query
+  annotations:
+    kubernetes.io/ingress.class: kommander-traefik
+    traefik.ingress.kubernetes.io/router.middlewares: ${releaseNamespace}-stripprefixes@kubernetescrd,${releaseNamespace}-forwardauth@kubernetescrd
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  rules:
+    - host: ""
+      http:
+        paths:
+          - path: /dkp/kommander/kubecost/query
+            pathType: Prefix
+            backend:
+              service:
+                name: kommander-kubecost-thanos-query-http
+                port:
+                  number: 10902
+---
+# TODO(mh): See `../defaults/cm.yaml` section of
+# `cost-analyzer.ingress`. This is a fix for thanos chart bundled
+# by kubecost installing Ingress with version that is not supported in k8s 1.22+
+# anymore.
+# This should be removed once the upstream chart is fixed.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kommander-kubecost-cost-analyzer
+  annotations:
+    ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
+    kubernetes.io/ingress.class: kommander-traefik
+    traefik.ingress.kubernetes.io/router.middlewares: ${releaseNamespace}-stripprefixes@kubernetescrd,${releaseNamespace}-forwardauth@kubernetescrd
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  rules:
+    - host: ""
+      http:
+        paths:
+          - path: /dkp/kommander/kubecost/frontend/
+            pathType: Prefix
+            backend:
+              service:
+                name: centralized-kubecost-cost-analyzer
+                port:
+                  name: tcp-frontend

--- a/services/centralized-kubecost/0.22.1/release/release.yaml
+++ b/services/centralized-kubecost/0.22.1/release/release.yaml
@@ -186,8 +186,8 @@ spec:
                   number: 10902
 ---
 # TODO(mh): See `../defaults/cm.yaml` section of
-# `cost-analyzer.ingress`. This is a fix for thanos chart bundled
-# by kubecost installing Ingress with version that is not supported in k8s 1.22+
+# `cost-analyzer.ingress`. This is a fix for the cost-analyzer chart
+# installing Ingress with version that is not supported in k8s 1.22+
 # anymore.
 # This should be removed once the upstream chart is fixed.
 apiVersion: networking.k8s.io/v1

--- a/services/centralized-kubecost/0.22.1/release/release.yaml
+++ b/services/centralized-kubecost/0.22.1/release/release.yaml
@@ -165,6 +165,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: kommander-kubecost-thanos-query-http
+  namespace: kommander-flux
   labels:
     app.kubernetes.io/component: query
   annotations:
@@ -193,6 +194,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: kommander-kubecost-cost-analyzer
+  namespace: kommander-flux
   annotations:
     ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
     kubernetes.io/ingress.class: kommander-traefik

--- a/services/dex/2.9.12/defaults/cm.yaml
+++ b/services/dex/2.9.12/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
   values.yaml: |-
     ---
     image: mesosphere/dex
-    imageTag: v2.27.0-4-g8c72a-d2iq
+    imageTag: v2.31.0-d2iq
     resources:
       requests:
         cpu: 100m

--- a/services/kubecost/0.22.1/defaults/cm.yaml
+++ b/services/kubecost/0.22.1/defaults/cm.yaml
@@ -15,33 +15,37 @@ data:
           enabled: true
 
       ingress:
-        enabled: true
-        # We can remove this once https://github.com/kubecost/cost-analyzer-helm-chart/pull/1132 is released.
-        className: ""
-        annotations:
-          kubernetes.io/ingress.class: kommander-traefik
-          ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
-          traefik.ingress.kubernetes.io/router.tls: "true"
-          traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth@kubernetescrd"
-        paths:
-          - "/dkp/kubecost/frontend/"
-        hosts:
-          - ""
-        tls: []
+        enabled: false
+        # TODO(mh): Enable once `kubecost` chart supports Ingress for k8s 1.22+
+        # enabled: true
+        # # We can remove this once https://github.com/kubecost/cost-analyzer-helm-chart/pull/1132 is released.
+        # className: ""
+        # annotations:
+        #   kubernetes.io/ingress.class: kommander-traefik
+        #   ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
+        #   traefik.ingress.kubernetes.io/router.tls: "true"
+        #   traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth@kubernetescrd"
+        # paths:
+        #   - "/dkp/kubecost/frontend/"
+        # hosts:
+        #   - ""
+        # tls: []
 
       podSecurityPolicy:
         enabled: false
 
       grafana:
         ingress:
-          enabled: true
-          annotations:
-            kubernetes.io/ingress.class: kommander-traefik
-            ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
-            traefik.ingress.kubernetes.io/router.tls: "true"
-            traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth@kubernetescrd"
-          hosts: [""]
-          path: "/dkp/kubecost/grafana"
+          enabled: false
+          # TODO(mh): Enable once `kubecost` chart supports Ingress for k8s 1.22+
+          # enabled: true
+          # annotations:
+          #   kubernetes.io/ingress.class: kommander-traefik
+          #   ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
+          #   traefik.ingress.kubernetes.io/router.tls: "true"
+          #   traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth@kubernetescrd"
+          # hosts: [""]
+          # path: "/dkp/kubecost/grafana"
         grafana.ini:
           server:
             protocol: http

--- a/services/kubecost/0.22.1/kubecost.yaml
+++ b/services/kubecost/0.22.1/kubecost.yaml
@@ -84,3 +84,60 @@ rules:
       - post
       - put
       - delete
+---
+# TODO(mh): See `../defaults/cm.yaml` section of
+# `cost-analyzer.grafana.ingress`. This is a fix for grafana chart bundled
+# by kubecost installing Ingress with version that is not supported in k8s 1.22+
+# anymore.
+# This should be removed once the upstream chart is fixed and enabled in default
+# CM configuration.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kubecost-grafana
+  namespace: kommander-flux
+  annotations:
+    ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
+    kubernetes.io/ingress.class: kommander-traefik
+    traefik.ingress.kubernetes.io/router.middlewares: ${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth@kubernetescrd
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  rules:
+    - host: ""
+      http:
+        paths:
+          - path: /dkp/kubecost/grafana
+            pathType: Prefix
+            backend:
+              service:
+                name: kubecost-grafana
+                port:
+                  number: 80
+---
+# TODO(mh): See `../defaults/cm.yaml` section of
+# `cost-analyzer.ingress`. This is a fix for thanos chart bundled
+# by kubecost installing Ingress with version that is not supported in k8s 1.22+
+# anymore.
+# This should be removed once the upstream chart is fixed.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kubecost-cost-analyzer
+  namespace: kommander-flux
+  annotations:
+    ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
+    kubernetes.io/ingress.class: kommander-traefik
+    traefik.ingress.kubernetes.io/router.middlewares: ${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth@kubernetescrd
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  rules:
+    - host: ""
+      http:
+        paths:
+          - path: /dkp/kubecost/frontend/
+            pathType: Prefix
+            backend:
+              service:
+                name: kubecost-cost-analyzer
+                port:
+                  name: tcp-frontend

--- a/services/kubecost/0.22.1/kubecost.yaml
+++ b/services/kubecost/0.22.1/kubecost.yaml
@@ -115,8 +115,8 @@ spec:
                   number: 80
 ---
 # TODO(mh): See `../defaults/cm.yaml` section of
-# `cost-analyzer.ingress`. This is a fix for thanos chart bundled
-# by kubecost installing Ingress with version that is not supported in k8s 1.22+
+# `cost-analyzer.ingress`. This is a fix for the cost-analyzer chart
+# installing Ingress with version that is not supported in k8s 1.22+
 # anymore.
 # This should be removed once the upstream chart is fixed.
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
JIRA: https://jira.d2iq.com/browse/D2IQ-81723

* Fixes use of outdated networking APIs in `kubecost` chart
* Updates dex to the latest version to be compatible with 1.22

Tests: https://github.com/mesosphere/kommander/pull/1480