### PR TITLE
feat: enable kommander/kommander-appamangement subst-vars upgrade

### DIFF
--- a/services/kommander-appmanagement/0.2.0/defaults/cm.yaml
+++ b/services/kommander-appmanagement/0.2.0/defaults/cm.yaml
@@ -11,6 +11,6 @@ data:
         manager:
           replicas: "${kommanderAppManagementReplicas}"
           image:
-            tag: "${appManagementImageTag}"
+            tag: "${appManagementImageTagWithDefault:=v2.2.0-dev}"
             repository: "${appManagementImageRepository}"
             pullPolicy: IfNotPresent

--- a/services/kommander/0.2.0/defaults/cm.yaml
+++ b/services/kommander/0.2.0/defaults/cm.yaml
@@ -56,11 +56,11 @@ data:
           manager:
             rootCertSecretName: ${caSecretName}
             image:
-              tag: ${licensingControllerManagerImageTag}
+              tag: ${licensingControllerManagerImageTagWithDefault:=2.2.0-dev}
               repository: ${licensingControllerManagerImageRepository}
       webhook:
         image:
-          tag: ${licensingControllerWebhookImageTag}
+          tag: ${licensingControllerWebhookImageTagWithDefault:=2.2.0-dev}
           repository: ${licensingControllerWebhookImageRepository}
       defaultEnterpriseApps:
         centralized-kubecost: "0.22.1"

--- a/services/kommander/0.2.0/kommander.yaml
+++ b/services/kommander/0.2.0/kommander.yaml
@@ -17,7 +17,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-kommander-charts
         namespace: kommander-flux
-      version: "${chartVersion}"
+      version: "${chartVersionWithDefault:=2.2.0-dev}"
   interval: 15s
   # Kommander is quite a big chart and it may need some more time than
   # other charts to get ready so setting this to 10 minutes increases


### PR DESCRIPTION
This is a prerequisite for https://github.com/mesosphere/kommander-cli/pull/380 - it makes `kommander` and `kommander-applications` Apps use different substitute variables for defining chart version so that during upgrade we can upgrade them independently.

