### PR TITLE
fix: Use label selector for jaeger pre-upgrade

### DIFF
--- a/services/jaeger/2.29.0/defaults/cm.yaml
+++ b/services/jaeger/2.29.0/defaults/cm.yaml
@@ -22,7 +22,6 @@ data:
             kubernetes.io/ingress.class: kommander-traefik
             traefik.ingress.kubernetes.io/router.tls: "true"
             traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth-full@kubernetescrd"
-          basePath: /dkp/jaeger
 
     rbac:
       create: true

--- a/services/jaeger/2.29.0/helmrelease.yaml
+++ b/services/jaeger/2.29.0/helmrelease.yaml
@@ -16,7 +16,8 @@ spec:
     name: management
     namespace: kommander-flux
   timeout: 60s
+  # passing releaseNamespace to 2nd level configuration files for able to configure namespace correctly in attached clusters
+  # Using `substituteFrom` with `substitution-vars` creates 2nd level resources in `kommander` namespace instead of workspace ns
   postBuild:
-    substituteFrom:
-      - kind: ConfigMap
-        name: substitution-vars
+    substitute:
+      releaseNamespace: ${releaseNamespace}

--- a/services/jaeger/2.29.0/pre-upgrade.yaml
+++ b/services/jaeger/2.29.0/pre-upgrade.yaml
@@ -16,7 +16,8 @@ spec:
     name: management
     namespace: kommander-flux
   timeout: 60s
+  # passing releaseNamespace to 2nd level configuration files for able to configure namespace correctly in attached clusters
+  # Using `substituteFrom` with `substitution-vars` creates 2nd level resources in `kommander` namespace instead of workspace ns
   postBuild:
-    substituteFrom:
-      - kind: ConfigMap
-        name: substitution-vars
+    substitute:
+      releaseNamespace: ${releaseNamespace}

--- a/services/jaeger/2.29.0/pre-upgrade/delete-jaeger-deployment.yaml
+++ b/services/jaeger/2.29.0/pre-upgrade/delete-jaeger-deployment.yaml
@@ -1,6 +1,10 @@
 # For upgrades from <2.21.4
-# The job will also be run pre-install but the kubectl --ignore-not-found flag should
-# protect against failing on nonexistent deployments (if jaeger is not installed yet)
+# https://github.com/jaegertracing/helm-charts/pull/257/files#diff-d9ac456c418c74b7ba25a05ec2cc077cd8dd45ddb7a3008c2dee25e4d347a23eR48
+# New "app.kubernetes.io/instance" label selector was added to the jaeger
+# deployment; here we select for deployments with the "app.kubernetes.io/name"
+# label but without the newly added "app.kubernetes.io/instance" label, to
+# delete. This ensures a newly-created jaeger deployment does not get deleted.
+# The job will also be run pre-install but will be a noop.
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -51,4 +55,4 @@ spec:
             - sh
             - -c
             - |
-              kubectl delete deployments.apps -l app.kubernetes.io/name=jaeger-operator,app.kubernetes.io/instance!=jaeger-operator --cascade=orphan -n istio-system --ignore-not-found
+              kubectl delete deployments.apps -l app.kubernetes.io/name=jaeger-operator,'!app.kubernetes.io/instance' --cascade=orphan -n istio-system

--- a/services/jaeger/2.29.0/pre-upgrade/delete-jaeger-deployment.yaml
+++ b/services/jaeger/2.29.0/pre-upgrade/delete-jaeger-deployment.yaml
@@ -51,4 +51,4 @@ spec:
             - sh
             - -c
             - |
-              kubectl delete deployment jaeger-jaeger-operator -n istio-system --ignore-not-found
+              kubectl delete deployments.apps -l app.kubernetes.io/name=jaeger-operator,app.kubernetes.io/instance!=jaeger-operator --cascade=orphan -n istio-system --ignore-not-found


### PR DESCRIPTION
Better to use label selectors to select for the deployment to delete in pre-upgrade, to avoid deleting the newer deployment in any races. Newer jaeger versions added a label to the deployment that wasn't in the previous version, so using that to select against newer deployments.