### PR TITLE
refactor: rename kommander version variables

### DIFF
--- a/services/kommander-appmanagement/0.2.0/defaults/cm.yaml
+++ b/services/kommander-appmanagement/0.2.0/defaults/cm.yaml
@@ -11,6 +11,6 @@ data:
         manager:
           replicas: "${kommanderAppManagementReplicas}"
           image:
-            tag: "${appManagementImageTag}"
-            repository: "${appManagementImageRepository}"
+            tag: "${kommanderAppManagementImageTag}"
+            repository: "${kommanderAppManagementImageRepository}"
             pullPolicy: IfNotPresent

--- a/services/kommander/0.2.0/defaults/cm.yaml
+++ b/services/kommander/0.2.0/defaults/cm.yaml
@@ -56,11 +56,11 @@ data:
           manager:
             rootCertSecretName: ${caSecretName}
             image:
-              tag: ${kommanderLicensingControllerManagerImageTag:=v2.2.0-dev}
+              tag: ${kommanderLicensingControllerManagerImageTag}
               repository: ${kommanderLicensingControllerManagerImageRepository}
       webhook:
         image:
-          tag: ${kommanderLicensingControllerWebhookImageTag:=v2.2.0-dev}
+          tag: ${kommanderLicensingControllerWebhookImageTag}
           repository: ${kommanderLicensingControllerWebhookImageRepository}
       defaultEnterpriseApps:
         centralized-kubecost: "0.22.1"

--- a/services/kommander/0.2.0/defaults/cm.yaml
+++ b/services/kommander/0.2.0/defaults/cm.yaml
@@ -10,8 +10,8 @@ data:
       enabled: ${airgappedEnabled}
     authorizedlister:
       image:
-        tag: ${authorizedlisterImageTag}
-        repository: ${authorizedlisterImageRepository}
+        tag: ${kommanderAuthorizedlisterImageTag}
+        repository: ${kommanderAuthorizedlisterImageRepository}
     certificates:
       ca:
         issuer:
@@ -26,18 +26,18 @@ data:
           rootCertSecretName: ${caSecretName}
           rootCertSecretNamespace: ${caSecretNamespace}
           image:
-            tag: ${controllerManagerImageTag}
-            repository: ${controllerManagerImageRepository}
+            tag: ${kommanderControllerManagerImageTag}
+            repository: ${kommanderControllerManagerImageRepository}
     webhook:
       image:
-        tag: ${controllerWebhookImageTag}
-        repository: ${controllerWebhookImageRepository}
+        tag: ${kommanderControllerWebhookImageTag}
+        repository: ${kommanderControllerWebhookImageRepository}
     fluxOperator:
       containers:
         manager:
           image:
-            tag: ${fluxOperatorManagerImageTag}
-            repository: ${fluxOperatorManagerImageRepository}
+            tag: ${kommanderFluxOperatorManagerImageTag}
+            repository: ${kommanderFluxOperatorManagerImageRepository}
       gitRepo:
         gitCredentialsSecret:
           namespace: kommander-flux
@@ -56,12 +56,12 @@ data:
           manager:
             rootCertSecretName: ${caSecretName}
             image:
-              tag: ${licensingControllerManagerImageTag}
-              repository: ${licensingControllerManagerImageRepository}
+              tag: ${kommanderLicensingControllerManagerImageTag:=v2.2.0-dev}
+              repository: ${kommanderLicensingControllerManagerImageRepository}
       webhook:
         image:
-          tag: ${licensingControllerWebhookImageTag}
-          repository: ${licensingControllerWebhookImageRepository}
+          tag: ${kommanderLicensingControllerWebhookImageTag:=v2.2.0-dev}
+          repository: ${kommanderLicensingControllerWebhookImageRepository}
       defaultEnterpriseApps:
         centralized-kubecost: "0.22.1"
         centralized-grafana: "33.1.1"
@@ -71,8 +71,8 @@ data:
         thanos: "0.4.6"
     kubetools:
       image:
-        repository: ${kubetoolsImageRepository}
-        tag: ${kubetoolsImageTag}
+        repository: ${kommanderKubetoolsImageRepository}
+        tag: ${kommanderKubetoolsImageTag}
     kommander-ui:
       ingress:
         enabled: true


### PR DESCRIPTION
This is a followup for following PRs:
* https://github.com/mesosphere/kommander-cli/pull/381
* https://github.com/mesosphere/kommander-applications/pull/228
* https://github.com/mesosphere/kommander-applications/pull/221

There were two problems that this PR solves:
* we need to define a default version for kommander-licensing subchart as it does not define sane defaults by itself. Cleaning it up is beyond the scope of the UniversalUpdater work.
* the substitute variable names in kommander v2.2.0 need to be different than the ones in kommander v2.1.0

The second bulletpoint requires some clarification - in v2.2.0 we are changing the way we supply the default version of kommander and kommander-appmanagement charts. 

Instead of storing it in k-cli, we moved it to k-apps repo. The substitute variables we were using so far may contain version information that is incompatible with v2.2.0 and we can't change them before upgrading the appdeployment as this will cause Flux to start rolling out changes in kommander v2.1.0 appdeployment as the version of the chart in this version is taken from these substitute variables. Changing the names of these vars and relying on their defaults solves this.