### PR TITLE
fix: Restore grafana metrics

### DIFF
--- a/services/kube-prometheus-stack/33.1.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/33.1.1/defaults/cm.yaml
@@ -39,6 +39,8 @@ data:
         # **NOTE** Any changes here need to be copied to kube-prometheus-stack-overrides.yaml
         # This is because arrays in values are replaced, not appended.
         - name: dkp-service-monitor-metrics
+          additionalLabels:
+            prometheus.kommander.d2iq.io/select: true
           selector:
             matchLabels:
               servicemonitor.kommander.mesosphere.io/path: "metrics"
@@ -53,6 +55,8 @@ data:
             - targetPort: 7979
               interval: 30s
         - name: dkp-service-monitor-metrics-http
+          additionalLabels:
+            prometheus.kommander.d2iq.io/select: true
           selector:
             matchLabels:
               servicemonitor.kommander.mesosphere.io/path: "metrics"
@@ -64,6 +68,8 @@ data:
             - targetPort: http
               interval: 30s
         - name: dkp-service-monitor-api-v1-metrics-prometheus
+          additionalLabels:
+            prometheus.kommander.d2iq.io/select: true
           selector:
             matchLabels:
               servicemonitor.kommander.mesosphere.io/path: "api__v1__metrics__prometheus"
@@ -74,6 +80,8 @@ data:
               port: metrics
               interval: 30s
         - name: dkp-service-monitor-api-v1-metrics-prometheus-http-10s
+          additionalLabels:
+            prometheus.kommander.d2iq.io/select: true
           selector:
             matchLabels:
               servicemonitor.kommander.mesosphere.io/path: "api__v1__metrics__prometheus"
@@ -86,6 +94,8 @@ data:
               port: http
               interval: 10s
         - name: dkp-service-monitor-prometheus-metrics
+          additionalLabels:
+            prometheus.kommander.d2iq.io/select: true
           selector:
             matchLabels:
               servicemonitor.kommander.mesosphere.io/path: "prometheus__metrics"
@@ -114,6 +124,8 @@ data:
         #         insecureSkipVerify: true
       additionalPodMonitors:
         - name: flux-system
+          additionalLabels:
+            prometheus.kommander.d2iq.io/select: true
           podMetricsEndpoints:
             - port: http-prom
           namespaceSelector:
@@ -131,6 +143,14 @@ data:
                   - image-automation-controller
                   - image-reflector-controller
       prometheusSpec:
+        serviceMonitorNamespaceSelector: {}  # all namespaces
+        serviceMonitorSelector:
+          matchLabels:
+            prometheus.kommander.d2iq.io/select: true
+        podMonitorNamespaceSelector: {}  # all namespaces
+        podMonitorSelector:
+          matchLabels:
+            prometheus.kommander.d2iq.io/select: true
         thanos:
           version: v0.17.1
         externalLabels:
@@ -335,11 +355,7 @@ data:
       defaultDashboardsEnabled: true
       serviceMonitor:
         labels:
-          # By default, kube-prometheus-stack configures prometheus-operator with a ServiceMonitor selector that
-          # matches the label "release: <helm-release-name>". This label is applied to all ServiceMonitors declared in
-          # the kube-prometheus-stack chart, however grafana's ServiceMonitor is declared in the grafana subchart.
-          # Without this label, and with the default ServiceMonitor selector, grafana's metrics won't be scraped.
-          release: kube-prometheus-stack
+          prometheus.kommander.d2iq.io/select: true
       ingress:
         enabled: true
         annotations:

--- a/services/kube-prometheus-stack/33.1.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/33.1.1/defaults/cm.yaml
@@ -333,6 +333,13 @@ data:
     grafana:
       enabled: true
       defaultDashboardsEnabled: true
+      serviceMonitor:
+        labels:
+          # By default, kube-prometheus-stack configures prometheus-operator with a ServiceMonitor selector that
+          # matches the label "release: <helm-release-name>". This label is applied to all ServiceMonitors declared in
+          # the kube-prometheus-stack chart, however grafana's ServiceMonitor is declared in the grafana subchart.
+          # Without this label, and with the default ServiceMonitor selector, grafana's metrics won't be scraped.
+          release: kube-prometheus-stack
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-84979

This restores grafana metrics. Without this change, the default ServiceMonitor selector omits the grafana ServiceMonitor, and its metrics are not scraped.