### PR TITLE
feat: Add kubecost as a default enterprise app

### DIFF
--- a/services/kommander/0.2.0/defaults/cm.yaml
+++ b/services/kommander/0.2.0/defaults/cm.yaml
@@ -64,6 +64,8 @@ data:
           repository: ${kommanderLicensingControllerWebhookImageRepository}
       defaultEnterpriseApps:
         centralized-kubecost: "0.22.1"
+        kubecost: "0.22.1"
+        kubecost-thanos-traefik: "0.0.1"
         centralized-grafana: "33.1.1"
         karma: "2.0.1"
         karma-traefik: "0.0.1"


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-85872

Kubecost will now be considered an enterprise app (and will be removed from the default set of apps)