### PR TITLE
fix: Pass in releaseName subst directly to istio

### DIFF
--- a/services/cert-manager/1.7.1/release.yaml
+++ b/services/cert-manager/1.7.1/release.yaml
@@ -15,7 +15,7 @@ spec:
     name: management
     namespace: kommander-flux
   timeout: 60s
-  # passing releaseNamespace to 2nd level configuration files for able to configure namespace correctly in attached clusters
+  # passing releaseNamespace to 2nd level configuration files for ability to configure namespace correctly in attached clusters
   # Using `substituteFrom` with `substitution-vars` creates 2nd level resources in `kommander` namespace instead of workspace ns
   postBuild:
     substitute:

--- a/services/cert-manager/1.7.1/root-ca.yaml
+++ b/services/cert-manager/1.7.1/root-ca.yaml
@@ -15,7 +15,7 @@ spec:
     name: management
     namespace: kommander-flux
   timeout: 480s
-  # passing releaseNamespace to 2nd level configuration files for able to configure namespace correctly in attached clusters
+  # passing releaseNamespace to 2nd level configuration files for ability to configure namespace correctly in attached clusters
   # Using `substituteFrom` with `substitution-vars` creates 2nd level resources in `kommander` namespace instead of workspace ns
   postBuild:
     substitute:

--- a/services/istio/1.11.5/helmrelease.yaml
+++ b/services/istio/1.11.5/helmrelease.yaml
@@ -16,7 +16,8 @@ spec:
     name: management
     namespace: kommander-flux
   timeout: 60s
+  # passing releaseNamespace to 2nd level configuration files for ability to configure namespace correctly in attached clusters
+  # Using `substituteFrom` with `substitution-vars` creates 2nd level resources in `kommander` namespace instead of workspace ns
   postBuild:
-    substituteFrom:
-      - kind: ConfigMap
-        name: substitution-vars
+    substitute:
+      releaseNamespace: ${releaseNamespace}

--- a/services/jaeger/2.29.0/helmrelease.yaml
+++ b/services/jaeger/2.29.0/helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
     name: management
     namespace: kommander-flux
   timeout: 60s
-  # passing releaseNamespace to 2nd level configuration files for able to configure namespace correctly in attached clusters
+  # passing releaseNamespace to 2nd level configuration files for ability to configure namespace correctly in attached clusters
   # Using `substituteFrom` with `substitution-vars` creates 2nd level resources in `kommander` namespace instead of workspace ns
   postBuild:
     substitute:

--- a/services/jaeger/2.29.0/pre-upgrade.yaml
+++ b/services/jaeger/2.29.0/pre-upgrade.yaml
@@ -16,7 +16,7 @@ spec:
     name: management
     namespace: kommander-flux
   timeout: 60s
-  # passing releaseNamespace to 2nd level configuration files for able to configure namespace correctly in attached clusters
+  # passing releaseNamespace to 2nd level configuration files for ability to configure namespace correctly in attached clusters
   # Using `substituteFrom` with `substitution-vars` creates 2nd level resources in `kommander` namespace instead of workspace ns
   postBuild:
     substitute:

--- a/services/minio-operator/4.4.10/minio-operator-helmrelease.yaml
+++ b/services/minio-operator/4.4.10/minio-operator-helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
     name: management
     namespace: kommander-flux
   timeout: 60s
-  # passing releaseNamespace to 2nd level configuration files for able to configure namespace correctly in attached clusters
+  # passing releaseNamespace to 2nd level configuration files for ability to configure namespace correctly in attached clusters
   # Using `substituteFrom` with `substitution-vars` creates 2nd level resources in `kommander` namespace instead of workspace ns
   postBuild:
     substitute:

--- a/services/minio-operator/4.4.10/minio-operator-pre-upgrade.yaml
+++ b/services/minio-operator/4.4.10/minio-operator-pre-upgrade.yaml
@@ -14,7 +14,7 @@ spec:
     name: management
     namespace: kommander-flux
   timeout: 60s
-  # passing releaseNamespace to 2nd level configuration files for able to configure namespace correctly in attached clusters
+  # passing releaseNamespace to 2nd level configuration files for ability to configure namespace correctly in attached clusters
   # Using `substituteFrom` with `substitution-vars` creates 2nd level resources in `kommander` namespace instead of workspace ns
   postBuild:
     substitute:

--- a/services/minio-operator/4.4.10/minio-tenant-helmrelease.yaml
+++ b/services/minio-operator/4.4.10/minio-tenant-helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
     name: management
     namespace: kommander-flux
   timeout: 60s
-  # passing releaseNamespace to 2nd level configuration files for able to configure namespace correctly in attached clusters
+  # passing releaseNamespace to 2nd level configuration files for ability to configure namespace correctly in attached clusters
   # Using `substituteFrom` with `substitution-vars` creates 2nd level resources in `kommander` namespace instead of workspace ns
   postBuild:
     substitute:


### PR DESCRIPTION
Accidentally reverted the fix done in https://github.com/mesosphere/kommander-applications/pull/167 when istio was upgraded - fixing again now to pass in `releaseNamespace` substitution var directly instead of using `substitutiion-vars` cm which would deploy apps to the `kommander` ns on attached clusteers