### PR TITLE
chore: inject airgappedEnabled to kommander-appmanagement

### DIFF
--- a/services/kommander-appmanagement/0.2.0/defaults/cm.yaml
+++ b/services/kommander-appmanagement/0.2.0/defaults/cm.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: ${releaseNamespace}
 data:
   values.yaml: |
+    airgapped:
+      enabled: ${airgappedEnabled}
     controllerManager:
       containers:
         manager:


### PR DESCRIPTION
Adds `airgapped.enabled` value to kommander-appmanagement chart

See why this change is required in description of https://github.com/mesosphere/kommander/pull/1534

Corresponding CLI change made at https://github.com/mesosphere/kommander-cli/pull/397
