### PR TITLE
fix: Define servicemonitor labels at the top level

### DIFF
--- a/services/kube-prometheus-stack/33.1.4/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/33.1.4/defaults/cm.yaml
@@ -39,6 +39,7 @@ data:
             targetPort: grpc
       additionalServiceMonitors:
         # **NOTE** Any changes here need to be copied to kube-prometheus-stack-overrides.yaml
+        # https://github.com/mesosphere/kommander-cli/blob/main/pkg/installer/config/manifests/kube-prometheus-stack/overrides.yaml
         # This is because arrays in values are replaced, not appended.
         - name: dkp-service-monitor-metrics
           selector:

--- a/services/kube-prometheus-stack/33.1.4/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/33.1.4/defaults/cm.yaml
@@ -7,6 +7,8 @@ metadata:
 data:
   values.yaml: |
     ---
+    commonLabels:
+      prometheus.kommander.d2iq.io/select: "true"
     prometheusOperator:
       admissionWebhooks:
         patch:
@@ -39,8 +41,6 @@ data:
         # **NOTE** Any changes here need to be copied to kube-prometheus-stack-overrides.yaml
         # This is because arrays in values are replaced, not appended.
         - name: dkp-service-monitor-metrics
-          additionalLabels:
-            prometheus.kommander.d2iq.io/select: "true"
           selector:
             matchLabels:
               servicemonitor.kommander.mesosphere.io/path: "metrics"
@@ -55,8 +55,6 @@ data:
             - targetPort: 7979
               interval: 30s
         - name: dkp-service-monitor-metrics-http
-          additionalLabels:
-            prometheus.kommander.d2iq.io/select: "true"
           selector:
             matchLabels:
               servicemonitor.kommander.mesosphere.io/path: "metrics"
@@ -68,8 +66,6 @@ data:
             - targetPort: http
               interval: 30s
         - name: dkp-service-monitor-api-v1-metrics-prometheus
-          additionalLabels:
-            prometheus.kommander.d2iq.io/select: "true"
           selector:
             matchLabels:
               servicemonitor.kommander.mesosphere.io/path: "api__v1__metrics__prometheus"
@@ -80,8 +76,6 @@ data:
               port: metrics
               interval: 30s
         - name: dkp-service-monitor-api-v1-metrics-prometheus-http-10s
-          additionalLabels:
-            prometheus.kommander.d2iq.io/select: "true"
           selector:
             matchLabels:
               servicemonitor.kommander.mesosphere.io/path: "api__v1__metrics__prometheus"
@@ -94,8 +88,6 @@ data:
               port: http
               interval: 10s
         - name: dkp-service-monitor-prometheus-metrics
-          additionalLabels:
-            prometheus.kommander.d2iq.io/select: "true"
           selector:
             matchLabels:
               servicemonitor.kommander.mesosphere.io/path: "prometheus__metrics"
@@ -124,8 +116,6 @@ data:
         #         insecureSkipVerify: true
       additionalPodMonitors:
         - name: flux-system
-          additionalLabels:
-            prometheus.kommander.d2iq.io/select: "true"
           podMetricsEndpoints:
             - port: http-prom
           namespaceSelector:


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-86480

Fix to target all servicemonitors. Previously the ones defined in the chart weren't getting the necessary label; the only way to set the label on those servicemonitors is to add the label to the top-level `commonLabels` which get set on every resource. This means that we can't define them separately on other servicemonitors created via config in the chart, so removing those here.