### PR TITLE
feat: enable startupProbe for gitea pod

### DIFF
--- a/services/gitea/4.1.1/defaults/cm.yaml
+++ b/services/gitea/4.1.1/defaults/cm.yaml
@@ -32,6 +32,13 @@ data:
         service:
           REQUIRE_SIGNIN_VIEW: false
           DISABLE_REGISTRATION: true
+      startupProbe:
+        enabled: true
+        initialDelaySeconds: 60
+        timeoutSeconds: 1
+        periodSeconds: 10
+        successThreshold: 1
+        failureThreshold: 10
     service:
       http:
         port: 443


### PR DESCRIPTION

> The kubelet uses startup probes to know when a container application has started. If such a probe is configured, it disables liveness and readiness checks until it succeeds, making sure those probes don't interfere with the application startup. This can be used to adopt liveness checks on slow starting containers, avoiding them getting killed by the kubelet before they are up and running.


By adding a startupProbe gitea pod readiness check will be delayed and it will not accept commits when it is just beginning to initialize. Needed for https://github.com/mesosphere/kommander/pull/1562 