### PR TITLE
fix: Restore missing metrics scrape targets

### DIFF
--- a/services/centralized-grafana/33.1.4/defaults/cm.yaml
+++ b/services/centralized-grafana/33.1.4/defaults/cm.yaml
@@ -15,6 +15,9 @@ data:
     grafana:
       enabled: true
       defaultDashboardsEnabled: true
+      serviceMonitor:
+        labels:
+          prometheus.kommander.d2iq.io/select: "true"
       sidecar:
         dashboards:
           enabled: true

--- a/services/kube-prometheus-stack/33.1.4/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/33.1.4/defaults/cm.yaml
@@ -445,3 +445,8 @@ data:
         monitor:
           additionalLabels:
             prometheus.kommander.d2iq.io/select: "true"
+    prometheus-node-exporter:
+      prometheus:
+        monitor:
+          additionalLabels:
+            prometheus.kommander.d2iq.io/select: "true"

--- a/services/kube-prometheus-stack/33.1.4/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/33.1.4/defaults/cm.yaml
@@ -441,3 +441,7 @@ data:
       metricLabelsAllowlist:
         - pods=[*]
         - namespaces=[*]
+      prometheus:
+        monitor:
+          additionalLabels:
+            prometheus.kommander.d2iq.io/select: "true"


### PR DESCRIPTION
This restores some missing scrape targets by applying a label to their servicemonitors that the servicemonitor selector matches against.