### PR TITLE
chore: Make v2.2.0-rc.1 a default kommander chart

### DIFF
--- a/services/kommander-appmanagement/0.2.0/kommander-appmanagement.yaml
+++ b/services/kommander-appmanagement/0.2.0/kommander-appmanagement.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-kommander-charts
         namespace: kommander-flux
-      version: "${kommanderChartVersion:=v2.2.0-dev}"
+      version: "${kommanderChartVersion:=v2.2.0-rc.1}"
   interval: 15s
   install:
     remediation:

--- a/services/kommander/0.2.0/kommander.yaml
+++ b/services/kommander/0.2.0/kommander.yaml
@@ -17,7 +17,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-kommander-charts
         namespace: kommander-flux
-      version: "${kommanderChartVersion:=v2.2.0-dev}"
+      version: "${kommanderChartVersion:=v2.2.0-rc.1}"
   interval: 15s
   # Kommander is quite a big chart and it may need some more time than
   # other charts to get ready so setting this to 10 minutes increases


### PR DESCRIPTION
Switch to a new release
