### PR TITLE
build: Align charts bundle name

### DIFF
--- a/make/release.mk
+++ b/make/release.mk
@@ -3,7 +3,7 @@ S3_PATH ?= "dkp/$(GIT_TAG)"
 S3_ACL ?= "bucket-owner-full-control"
 
 .PHONY: release
-release: ARCHIVE_NAME = kommander-applications_$(GIT_TAG).tar.gz
+release: ARCHIVE_NAME = kommander-applications-charts-bundle-$(GIT_TAG).tar.gz
 release: install-tool.awscli
 	git archive --format "tar.gz" -o $(ARCHIVE_NAME) \
 	                              --prefix kommander-applications/ \


### PR DESCRIPTION
Just updating the charts bundle name to be in line with the other chart bundles

currently:
```
- kommander: https://downloads.mesosphere.com/dkp/v2.2.0-rc.2/dkp-kommander-charts-bundle-v2.2.0-rc.2.tar.gz
- kommander-applications: https://downloads.mesosphere.com/dkp/v2.2.0-rc.2/kommander-applications_v2.2.0-rc.2.tar.gz
- dkp-catalog-applications: https://downloads.mesosphere.com/dkp/v2.2.0-rc.2/dkp-catalog-applications-charts-bundle-v2.2.0-rc.2.tar.gz
```