### PR TITLE
chore(loki): Bump gateway nginx image tag

### DIFF
--- a/services/grafana-loki/0.33.2/defaults/cm.yaml
+++ b/services/grafana-loki/0.33.2/defaults/cm.yaml
@@ -139,3 +139,8 @@ data:
       persistence:
         enabled: true
         size: 10Gi
+
+    gateway:
+      image:
+        # This defaults to 1.19-alpine but overridden here to patch CVEs
+        tag: 1.21.6-alpine

--- a/services/grafana-loki/0.33.2/defaults/cm.yaml
+++ b/services/grafana-loki/0.33.2/defaults/cm.yaml
@@ -142,5 +142,6 @@ data:
 
     gateway:
       image:
-        # This defaults to 1.19-alpine but overridden here to patch CVEs
+        # Check to see if this image is bumped when we upgrade from 0.33.2 to a later version
+        # This image override fixes the following critical CVEs: CVE-2021-22945, CVE-2021-36159, and CVE-2021-3711
         tag: 1.21.6-alpine


### PR DESCRIPTION
testing in https://github.com/mesosphere/kommander/pull/1612. 