### PR TITLE
fix: Add metadata name to mtls-proxy

### DIFF
--- a/services/kommander/0.2.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
+++ b/services/kommander/0.2.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
@@ -3,6 +3,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   generateName: ${generatedName}
+  name: ${name}
   namespace: ${namespace}
   labels:
     kommander.mesosphere.io/cluster-id: ${clusterID}


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-86874
If name is set, name will be used. If name is `""`, generateName will generate a name.

goes along with https://github.com/mesosphere/kommander/pull/1618