### PR TITLE
fix: Use - instead of _ in arch name

### DIFF
--- a/make/release.mk
+++ b/make/release.mk
@@ -3,7 +3,7 @@ S3_PATH ?= "dkp/$(GIT_TAG)"
 S3_ACL ?= "bucket-owner-full-control"
 
 .PHONY: release
-release: ARCHIVE_NAME = kommander-applications_$(GIT_TAG).tar.gz
+release: ARCHIVE_NAME = kommander-applications-$(GIT_TAG).tar.gz
 release: install-tool.awscli
 	git archive --format "tar.gz" -o $(ARCHIVE_NAME) \
 	                              --prefix kommander-applications/ \


### PR DESCRIPTION
Noticed a slight discrepancy between the gitrepo tarballs. Using `-` everywhere so switching the `_` here to `-`

```
Git Repo tarballs:
- dkp-catalog-applications: https://downloads.d2iq.com/dkp/v2.2.0-rc.3/dkp-catalog-applications-v2.2.0-rc.3.tar.gz
- kommander-applications: https://downloads.d2iq.com/dkp/v2.2.0-rc.3/kommander-applications_v2.2.0-rc.3.tar.gz
```