### PR TITLE
fix: Logging operator upgrade process

### DIFF
--- a/services/logging-operator/3.17.3/logging-operator-logging.yaml
+++ b/services/logging-operator/3.17.3/logging-operator-logging.yaml
@@ -21,6 +21,7 @@ spec:
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: logging-operator-logging

--- a/services/logging-operator/3.17.3/logging-operator.yaml
+++ b/services/logging-operator/3.17.3/logging-operator.yaml
@@ -19,6 +19,7 @@ spec:
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: logging-operator


### PR DESCRIPTION
Logging operator fails to be upgraded with:

```
Helm Release logging-operator-logging NOT READY reason: UpgradeFailed message: Helm upgrade failed: [unable to recognize "": no matches for kind "EventTailer" in version "logging-extensions.banzaicloud.io/v1alpha1", unable to recognize "": no matches for kind "HostTailer" in version "logging-extensions.banzaicloud.io/v1alpha1"]
```

This PR solves the problem
