### PR TITLE
fix: disable eventTailer and hostTailer by default

### DIFF
--- a/services/logging-operator/3.17.3/defaults/cm.yaml
+++ b/services/logging-operator/3.17.3/defaults/cm.yaml
@@ -53,6 +53,9 @@ data:
               retry_max_times: 5
             extra_labels:
               log_source: kubernetes_container
+    # This can be removed after this commit is released https://github.com/banzaicloud/logging-operator/commit/d0e86821c2debddf632f5572241918733a2f56b4
+    eventTailer:
+    hostTailer:
     tls:
       enabled: true
     fluentd:


### PR DESCRIPTION
slack thread -> https://mesosphere.slack.com/archives/C01LNF6KML5/p1648824373631649?thread_ts=1648635583.442749&cid=C01LNF6KML5

TL;DR we bumped the logging operator and this commit came after the latest release https://github.com/banzaicloud/logging-operator/commit/d0e86821c2debddf632f5572241918733a2f56b4