### PR TITLE
chore: Set istio's kubectl image to the latest release

### DIFF
--- a/services/istio/1.11.6/defaults/cm.yaml
+++ b/services/istio/1.11.6/defaults/cm.yaml
@@ -24,3 +24,6 @@ data:
       serviceMonitor:
         labels:
           prometheus.kommander.d2iq.io/select: "true"
+    global:
+      image: "${kubetoolsImageRepository:=bitnami/kubectl}"
+      tag: "${kubetoolsImageTag:=1.23.5}"


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-84836

Tested at https://github.com/mesosphere/kommander/pull/1639