### PR TITLE
fix: Add ttl to jobs

### DIFF
--- a/services/centralized-kubecost/0.23.3/post-install-jobs/post-install-jobs.yaml
+++ b/services/centralized-kubecost/0.23.3/post-install-jobs/post-install-jobs.yaml
@@ -34,6 +34,7 @@ metadata:
   name: copy-kubecost-grafana-datasource-cm
   namespace: kubecost
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     metadata:
       name: copy-kubecost-grafana-datasource-cm

--- a/services/centralized-kubecost/0.23.3/release/release.yaml
+++ b/services/centralized-kubecost/0.23.3/release/release.yaml
@@ -66,6 +66,7 @@ metadata:
   name: create-kubecost-thanos-query-stores-configmap
   namespace: kubecost
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     metadata:
       name: create-kubecost-thanos-query-stores-configmap

--- a/services/gatekeeper/3.7.0/cleanup/cert-cleanup.yaml
+++ b/services/gatekeeper/3.7.0/cleanup/cert-cleanup.yaml
@@ -9,6 +9,7 @@ metadata:
   name: cleanup-old-certificate
   namespace: ${releaseNamespace}
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     spec:
       serviceAccountName: cleanup-old-certificate

--- a/services/grafana-loki/0.33.2/minio.yaml
+++ b/services/grafana-loki/0.33.2/minio.yaml
@@ -71,6 +71,7 @@ metadata:
   name: grafana-loki-minio-make-bucket
   namespace: ${releaseNamespace}
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     spec:
       restartPolicy: OnFailure

--- a/services/jaeger/2.29.0/pre-upgrade/delete-jaeger-deployment.yaml
+++ b/services/jaeger/2.29.0/pre-upgrade/delete-jaeger-deployment.yaml
@@ -42,6 +42,7 @@ metadata:
   name: delete-jaeger-deployment
   namespace: istio-system
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     metadata:
       name: delete-jaeger-deployment

--- a/services/minio-operator/4.4.10/minio-operator-pre-upgrade/delete-minio-operator-deployment.yaml
+++ b/services/minio-operator/4.4.10/minio-operator-pre-upgrade/delete-minio-operator-deployment.yaml
@@ -39,6 +39,7 @@ metadata:
   name: delete-minio-operator-deployment
   namespace: ${releaseNamespace}
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     metadata:
       name: delete-minio-operator-deployment

--- a/services/project-grafana-loki/0.33.2/minio.yaml
+++ b/services/project-grafana-loki/0.33.2/minio.yaml
@@ -71,6 +71,7 @@ metadata:
   name: project-grafana-loki-minio-make-bucket
   namespace: ${releaseNamespace}
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     spec:
       restartPolicy: OnFailure

--- a/services/thanos/0.4.6/thanos.yaml
+++ b/services/thanos/0.4.6/thanos.yaml
@@ -83,6 +83,7 @@ spec:
     metadata:
       name: create-kommander-thanos-query-stores-configmap
     spec:
+      ttlSecondsAfterFinished: 100
       serviceAccountName: kommander-thanos-configmap-edit
       restartPolicy: OnFailure
       containers:

--- a/services/thanos/0.4.6/thanos.yaml
+++ b/services/thanos/0.4.6/thanos.yaml
@@ -79,11 +79,11 @@ metadata:
   name: create-kommander-thanos-query-stores-configmap
   namespace: ${releaseNamespace}
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     metadata:
       name: create-kommander-thanos-query-stores-configmap
     spec:
-      ttlSecondsAfterFinished: 100
       serviceAccountName: kommander-thanos-configmap-edit
       restartPolicy: OnFailure
       containers:


### PR DESCRIPTION
~Revert the kubectl revert (so, this PR brings them back) and~ set `ttlSecondsAfterFinished` on all jobs defined in kapps to ensure they are deleted after completion to avoid upgrade "immutable field" errors due to updated images etc.

Let's wait to bump images (except for CVE migitations) till after 2.2 GA.