### PR TITLE
fix: hide cert-manager on managegemtn workspace

### DIFF
--- a/services/cert-manager/metadata.yaml
+++ b/services/cert-manager/metadata.yaml
@@ -1,5 +1,6 @@
 displayName: cert-manager
 description: Automates management and issuance of TLS certificates from various issuing sources.
+hideOnManagementWorkspace: true
 category:
   - security
 type: platform


### PR DESCRIPTION
This is a PR to introduce a new label to cert-manager to be able to be hidden on the management workspace:
https://jira.d2iq.com/browse/D2IQ-87174