### PR TITLE
build: Remove prefix from git archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.local/
+.DS_Store

--- a/make/release.mk
+++ b/make/release.mk
@@ -6,7 +6,6 @@ S3_ACL ?= "bucket-owner-full-control"
 release: ARCHIVE_NAME = kommander-applications-$(GIT_TAG).tar.gz
 release: install-tool.awscli
 	git archive --format "tar.gz" -o $(ARCHIVE_NAME) \
-	                              --prefix kommander-applications/ \
 	                              $(GIT_TAG) -- \
 	                              common services
 	aws s3 cp --acl $(S3_ACL) $(ARCHIVE_NAME) s3://$(S3_BUCKET)/$(S3_PATH)/


### PR DESCRIPTION
need to test this with kommander-cli

Right now, this prefix causes the UX for installing in an airgapped env a bit weird because users would have to do something like this:

```
dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications-v2.2.0.tar.gz//kommander-applications
```

I tested this locally and it looked good!

```
➜  ~/Documents/projects/d2iq/kommander-cli git:(release-2.2) ✗ ./dist/kommander_darwin_amd64/kommander upgrade kommander --kommander-applications-repository ~/Documents/projects/d2iq/kommander-applications/kommander-applications-v2.2.0-dev.tar.gz 
 ✓ Ensuring upgrading conditions are met
 ✓ Ensuring application definitions are updated           <----- it would have failed here
 ✓ Ensuring helm-mirror implementation is migrated to chartmuseum
...
```

After this change, we'll need to update the CLI release-2.2 branch constants (pkg/constants/constants.go):

```
	KommanderApplicationsRepository      = "https://downloads.d2iq.com/dkp/v2.2.0-rc.10/kommander-applications-v2.2.0-rc.10.tar.gz"
```