### PR TITLE
Revert "fix: Add ttl to jobs (#301)"

### DIFF
--- a/services/centralized-kubecost/0.23.3/post-install-jobs/post-install-jobs.yaml
+++ b/services/centralized-kubecost/0.23.3/post-install-jobs/post-install-jobs.yaml
@@ -34,7 +34,6 @@ metadata:
   name: copy-kubecost-grafana-datasource-cm
   namespace: kubecost
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       name: copy-kubecost-grafana-datasource-cm

--- a/services/centralized-kubecost/0.23.3/release/release.yaml
+++ b/services/centralized-kubecost/0.23.3/release/release.yaml
@@ -66,7 +66,6 @@ metadata:
   name: create-kubecost-thanos-query-stores-configmap
   namespace: kubecost
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       name: create-kubecost-thanos-query-stores-configmap

--- a/services/gatekeeper/3.7.0/cleanup/cert-cleanup.yaml
+++ b/services/gatekeeper/3.7.0/cleanup/cert-cleanup.yaml
@@ -9,7 +9,6 @@ metadata:
   name: cleanup-old-certificate
   namespace: ${releaseNamespace}
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     spec:
       serviceAccountName: cleanup-old-certificate

--- a/services/grafana-loki/0.33.2/minio.yaml
+++ b/services/grafana-loki/0.33.2/minio.yaml
@@ -71,7 +71,6 @@ metadata:
   name: grafana-loki-minio-make-bucket
   namespace: ${releaseNamespace}
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     spec:
       restartPolicy: OnFailure

--- a/services/jaeger/2.29.0/pre-upgrade/delete-jaeger-deployment.yaml
+++ b/services/jaeger/2.29.0/pre-upgrade/delete-jaeger-deployment.yaml
@@ -42,7 +42,6 @@ metadata:
   name: delete-jaeger-deployment
   namespace: istio-system
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       name: delete-jaeger-deployment

--- a/services/minio-operator/4.4.10/minio-operator-pre-upgrade/delete-minio-operator-deployment.yaml
+++ b/services/minio-operator/4.4.10/minio-operator-pre-upgrade/delete-minio-operator-deployment.yaml
@@ -39,7 +39,6 @@ metadata:
   name: delete-minio-operator-deployment
   namespace: ${releaseNamespace}
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       name: delete-minio-operator-deployment

--- a/services/project-grafana-loki/0.33.2/minio.yaml
+++ b/services/project-grafana-loki/0.33.2/minio.yaml
@@ -71,7 +71,6 @@ metadata:
   name: project-grafana-loki-minio-make-bucket
   namespace: ${releaseNamespace}
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     spec:
       restartPolicy: OnFailure

--- a/services/thanos/0.4.6/thanos.yaml
+++ b/services/thanos/0.4.6/thanos.yaml
@@ -79,7 +79,6 @@ metadata:
   name: create-kommander-thanos-query-stores-configmap
   namespace: ${releaseNamespace}
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       name: create-kommander-thanos-query-stores-configmap


### PR DESCRIPTION
This reverts commit 20a81bb8670e72fdd36f28d7045853972221ffbb.

Reverting adding ttl to our jobs defined in kapps since they should not get re-run (specifically, the gatekeeper cleanup job getting re-run would end up deleting secrets that may not get recreated in the helm chart is already deployed)

```
	// Force instructs the controller to recreate resources
	// when patching fails due to an immutable field change.
	// +kubebuilder:default:=false
	// +optional
	Force bool `json:"force,omitempty"`
```
Post release, we will revisit setting these kustomizations `Force` to `true` to avoid the `immutable field` errors if we want to update the images in the jobs (instead of setting ttl).