### PR TITLE
fix: Produce correct tag for a daily release

### DIFF
--- a/.go-tools
+++ b/.go-tools
@@ -1,1 +1,1 @@
-github.com/caarlos0/svu@v1.9.0
+github.com/caarlos0/svu@5b40c3113f8d7fd477f2410d8e14eaf835f3a76e

--- a/make/repo.mk
+++ b/make/repo.mk
@@ -19,7 +19,7 @@ endif
 repo.dev.tag: ## Returns development tag
 repo.dev.tag: install-tool.go.svu
 ifeq ($(GIT_CURRENT_BRANCH),main)
-	svu minor --pattern 'v[0-9].[0-9]{[0-9],}.[0-9]{[0-9],}' --suffix dev
+	svu minor --pattern 'v[0-9].[0-9]{[0-9],}.[0-9]{[0-9],}' --suffix dev --tag-mode=all-branches
 else
 	svu patch --pattern 'v[0-9].[0-9]{[0-9],}.[0-9]{[0-9],}' --suffix dev
 endif

--- a/make/repo.mk
+++ b/make/repo.mk
@@ -19,7 +19,7 @@ endif
 repo.dev.tag: ## Returns development tag
 repo.dev.tag: install-tool.go.svu
 ifeq ($(GIT_CURRENT_BRANCH),main)
-	svu minor --pattern 'v[0-9].[0-9]{[0-9],}.[0-9]{[0-9],}' --suffix dev --tag-mode=all-branches
+	svu minor --pattern 'v[0-9].[0-9]{[0-9],}.[0-9]{[0-9],[0-9]-rc.*,-rc.*,}' --suffix dev --tag-mode=all-branches --no-metadata
 else
-	svu patch --pattern 'v[0-9].[0-9]{[0-9],}.[0-9]{[0-9],}' --suffix dev
+	svu patch --pattern 'v[0-9].[0-9]{[0-9],}.[0-9]{[0-9],[0-9]-rc.*,-rc.*,}' --suffix dev --no-metadata
 endif


### PR DESCRIPTION
- `v2.2.0` is on `release-2.2` branch so in the current state, the daily
release tag is still `v2.2.0-dev`. With this commit, the daily release will be `v2.3.0-dev`.
- When releasing a rc, a daily tag should be bumped to the next minor, e.g., after releasing v2.3.0-rc.1, a daily tag should become v2.4.0-dev

jira: https://jira.d2iq.com/browse/D2IQ-87570
