### PR TITLE
fix: Fetch all tags before checking the most recent

### DIFF
--- a/make/repo.mk
+++ b/make/repo.mk
@@ -19,6 +19,7 @@ endif
 repo.dev.tag: ## Returns development tag
 repo.dev.tag: install-tool.go.svu
 ifeq ($(GIT_CURRENT_BRANCH),main)
+	git fetch --tags
 	svu minor --pattern 'v[0-9].[0-9]{[0-9],}.[0-9]{[0-9],[0-9]-rc.*,-rc.*,}' --suffix dev --tag-mode=all-branches --no-metadata
 else
 	svu patch --pattern 'v[0-9].[0-9]{[0-9],}.[0-9]{[0-9],[0-9]-rc.*,-rc.*,}' --suffix dev --no-metadata


### PR DESCRIPTION
TeamCity doesn't fetch all tags when cloning the repo.
