### PR TITLE
feat: Bump default kommander to a new daily release

### DIFF
--- a/services/kommander-appmanagement/0.2.0/kommander-appmanagement.yaml
+++ b/services/kommander-appmanagement/0.2.0/kommander-appmanagement.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-kommander-charts
         namespace: kommander-flux
-      version: "${kommanderChartVersion:=v2.2.0-dev}"
+      version: "${kommanderChartVersion:=v2.3.0-dev}"
   interval: 15s
   install:
     crds: CreateReplace

--- a/services/kommander/0.2.0/kommander.yaml
+++ b/services/kommander/0.2.0/kommander.yaml
@@ -17,7 +17,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-kommander-charts
         namespace: kommander-flux
-      version: "${kommanderChartVersion:=v2.2.0-dev}"
+      version: "${kommanderChartVersion:=v2.3.0-dev}"
   interval: 15s
   # Kommander is quite a big chart and it may need some more time than
   # other charts to get ready so setting this to 10 minutes increases


### PR DESCRIPTION
Since v2.2.0 is released, let's use v2.3.0-dev as a default kommander version.

Depends on https://github.com/mesosphere/kommander/pull/1668
Depends on https://github.com/mesosphere/kommander-applications/pull/336
