### PR TITLE
fix: Set CreateReplace upgrade policy on kps

### DIFF
--- a/services/centralized-grafana/34.9.0/centralized-grafana.yaml
+++ b/services/centralized-grafana/34.9.0/centralized-grafana.yaml
@@ -42,4 +42,4 @@ data:
   # https://github.com/mesosphere/charts/tree/master/staging/kube-prometheus-stack/charts
   # Then, find the Grafana app version:
   # https://artifacthub.io/packages/helm/grafana/grafana/6.22.0
-  version: "8.3.6"
+  version: "8.4.5"

--- a/services/kube-prometheus-stack/34.9.0/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/34.9.0/kube-prometheus-stack.yaml
@@ -21,6 +21,7 @@ spec:
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: kube-prometheus-stack

--- a/services/kube-prometheus-stack/34.9.0/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/34.9.0/kube-prometheus-stack.yaml
@@ -43,7 +43,7 @@ data:
   docsLink: "https://prometheus.io/docs/"
   # Prometheus app version can be found at prometheus.prometheusSpec.image.tag:
   # https://github.com/mesosphere/charts/blob/master/staging/kube-prometheus-stack/values.yaml#L2147
-  version: "2.33.4"
+  version: "2.34.0"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -58,7 +58,7 @@ data:
   docsLink: "https://prometheus.io/docs/alerting/alertmanager/"
   # Alertmanager app version can be found at alertmanager.alertmanagerSpec.image,tag:
   # https://github.com/mesosphere/charts/blob/master/staging/kube-prometheus-stack/values.yaml#L417
-  version: "0.23.0"
+  version: "0.24.0"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -74,4 +74,4 @@ data:
   # Since Grafana is a subchart of kube-prometheus-stack, get the version of the Grafana chart dependency at:
   # https://github.com/mesosphere/charts/tree/master/staging/kube-prometheus-stack/charts
   # Then, check https://artifacthub.io/packages/helm/grafana/grafana/ for app version
-  version: "8.3.6"
+  version: "8.4.5"

--- a/services/kube-prometheus-stack/metadata.yaml
+++ b/services/kube-prometheus-stack/metadata.yaml
@@ -16,18 +16,18 @@ overview: |-
   ## Dashboards
   By deploying the Prometheus Monitoring Stack, the following platform applications and their respective dashboards will be deployed. After deployment to clusters in a workspace, the dashboards will be available to access from a respective cluster's detail page.
 
-  ### Prometheus (v2.33.4)
+  ### Prometheus (v2.34.0)
 
   A software application for event monitoring and alerting. It records real-time metrics in a time series database built using a HTTP pull model, with flexible and real-time alerting.
 
   - [Prometheus Documentation - Overview](https://prometheus.io/docs/introduction/overview/)
 
-  ### Prometheus Alertmanager (v0.23.0)
+  ### Prometheus Alertmanager (v0.24.0)
   A Prometheus component that enables you to configure and manage alerts sent by the Prometheus server and to route them to notification, paging, and automation systems.
 
   - [Prometheus Alertmanager Documentation - Overview](https://prometheus.io/docs/alerting/latest/alertmanager/)
 
-  ### Grafana (v8.3.6)
+  ### Grafana (v8.4.5)
   A monitoring dashboard from Grafana that can be used to visualize metrics collected by Prometheus.
 
   - [Grafana Documentation](https://grafana.com/docs/)

--- a/services/kubetunnel/0.0.12/kubetunnel.yaml
+++ b/services/kubetunnel/0.0.12/kubetunnel.yaml
@@ -19,6 +19,7 @@ spec:
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: kubetunnel


### PR DESCRIPTION
kube-prometheus-stack has been updating CRDs across upgrades, but we didn't ste the upgrade policy to `CreateReplace` so we're not actually updating the CRDs during upgrade. We'll need to backport this to get it into the next 2.2 patch.

Also saw that kubetunnel CRDs policy was only set on `install` not `upgrade`, I think we probably need both?

testing in https://github.com/mesosphere/kommander/pull/1687