### PR TITLE
chore: sops encryption config params in kommander-vars cm

### DIFF
--- a/services/kommander/0.3.0/defaults/cm.yaml
+++ b/services/kommander/0.3.0/defaults/cm.yaml
@@ -28,6 +28,11 @@ data:
           image:
             tag: ${kommanderControllerManagerImageTag}
             repository: ${kommanderControllerManagerImageRepository}
+          extraArgs:
+            git-credentials-secret-namespace: ${kommanderFluxNamespace}
+            git-credentials-secret-name: ${kommanderGitCredentialsSecretName}
+            age-encryption-secret-name: ${ageEncryptionSecretName}
+            age-encryption-secret-key: ${ageEncryptionSecretKey}
     webhook:
       image:
         tag: ${kommanderControllerWebhookImageTag}


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-87209 

See https://github.com/mesosphere/kommander/pull/1698 and https://github.com/mesosphere/kommander-cli/pull/501 for more context

CLI generates git credentials and sops age secret to encrypt those
credentials and commit to the management git repository itself
during install time. After these are created, kommander
controllers should be responsible (implemented in [mesosphere/kommander#1698 (files)](https://github.com/mesosphere/kommander/pull/1698/files#diff-ecb9f4538d65070683a35f68a1214c4b76b0aa48121a150fb9feba4764de8320)) to ensure the secrets are kept
up-to-date (such as when the Certificate information changes) and
this change ensures that the necessary variables are set in
kommander-vars configmap (see https://github.com/mesosphere/kommander-cli/pull/501) so that the kommander controllers are aware of
which secret to encrypt and reconcile correctly.