### PR TITLE
fix: Put minio creds secret back at old name

### DIFF
--- a/services/grafana-loki/0.48.3/minio.yaml
+++ b/services/grafana-loki/0.48.3/minio.yaml
@@ -33,7 +33,7 @@ spec:
           memory: 384Mi
 
   credsSecret:
-    name: grafana-loki-minio-root
+    name: grafana-loki-minio
 
   users:
     - name: grafana-loki-minio-user
@@ -62,7 +62,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: grafana-loki-minio-root
+  name: grafana-loki-minio
   namespace: ${releaseNamespace}
 type: Opaque
 data:

--- a/services/project-grafana-loki/0.48.3/minio.yaml
+++ b/services/project-grafana-loki/0.48.3/minio.yaml
@@ -33,7 +33,7 @@ spec:
           memory: 384Mi
 
   credsSecret:
-    name: project-grafana-loki-minio-root
+    name: project-grafana-loki-minio
 
   users:
     - name: project-grafana-loki-minio-user
@@ -62,7 +62,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: project-grafana-loki-minio-root
+  name: project-grafana-loki-minio
   namespace: ${releaseNamespace}
 type: Opaque
 data:


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-88873

This renames the secret that contains root credentials for the MinIO tenant back to what it was in Kommander 2.2. This can help to prevent a situation where a MinIO tenant upgrade may become stuck if it was attempted while the tenant's MinIO API was unavailable. See https://jira.d2iq.com/browse/D2IQ-88873 for additional context.

Tested against kommander at https://github.com/mesosphere/kommander/pull/1744.