### PR TITLE
feat: add crds policy to minio-operator HelmRelease

### DIFF
--- a/services/minio-operator/4.4.16/minio-operator-helmrelease/release.yaml
+++ b/services/minio-operator/4.4.16/minio-operator-helmrelease/release.yaml
@@ -15,9 +15,11 @@ spec:
       version: 4.4.16
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: minio-operator


### PR DESCRIPTION
While testing the grafana-loki upgrade from 2.1 -> 2.2, I found that this [change](https://github.com/mesosphere/kommander-applications/pull/390) allowed the tests to pass. However, in addition to the change, I needed to set this CRD policy on the `HelmRelease` so the Tenant CRD is updated with the new functionality introduced in  https://github.com/mesosphere/kommander-applications/pull/390.