### PR TITLE
[release-2.2][BACKPORT] fix: Set user creds on minio tenant

### DIFF
--- a/services/grafana-loki/0.33.2/minio.yaml
+++ b/services/grafana-loki/0.33.2/minio.yaml
@@ -33,7 +33,10 @@ spec:
           memory: 384Mi
 
   credsSecret:
-    name: grafana-loki-minio
+    name: grafana-loki-minio-root
+
+  users:
+    - name: grafana-loki-minio-user
 
   # Disable TLS.
   requestAutoCert: false
@@ -56,11 +59,23 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: grafana-loki-minio
+  name: grafana-loki-minio-root
   namespace: ${releaseNamespace}
 type: Opaque
 data:
-  ## Access Key for MinIO Tenant, base64 encoded (echo -n 'minio' | base64)
+  # Root access key for MinIO Tenant, base64 encoded (echo -n 'minio' | base64)
   accesskey: bWluaW8=
-  ## Secret Key for MinIO Tenant, base64 encoded (echo -n 'minio123' | base64)
+  # Root secret key for MinIO Tenant, base64 encoded (echo -n 'minio123' | base64)
   secretkey: bWluaW8xMjM=
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-loki-minio-user
+  namespace: ${releaseNamespace}
+type: Opaque
+data:
+  # User access key for MinIO Tenant, base64 encoded (echo -n 'minio-user' | base64)
+  CONSOLE_ACCESS_KEY: bWluaW8tdXNlcg==
+  # User secret key for MinIO Tenant, base64 encoded (echo -n 'minio123' | base64)
+  CONSOLE_SECRET_KEY: bWluaW8xMjM=

--- a/services/grafana-loki/0.33.2/minio.yaml
+++ b/services/grafana-loki/0.33.2/minio.yaml
@@ -33,7 +33,7 @@ spec:
           memory: 384Mi
 
   credsSecret:
-    name: grafana-loki-minio-root
+    name: grafana-loki-minio
 
   users:
     - name: grafana-loki-minio-user
@@ -59,7 +59,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: grafana-loki-minio-root
+  name: grafana-loki-minio
   namespace: ${releaseNamespace}
 type: Opaque
 data:

--- a/services/project-grafana-loki/0.33.2/minio.yaml
+++ b/services/project-grafana-loki/0.33.2/minio.yaml
@@ -33,7 +33,10 @@ spec:
           memory: 384Mi
 
   credsSecret:
-    name: project-grafana-loki-minio
+    name: project-grafana-loki-minio-root
+
+  users:
+    - name: project-grafana-loki-minio-user
 
   # Disable TLS.
   requestAutoCert: false
@@ -56,11 +59,23 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: project-grafana-loki-minio
+  name: project-grafana-loki-minio-root
   namespace: ${releaseNamespace}
 type: Opaque
 data:
-  ## Access Key for MinIO Tenant, base64 encoded (echo -n 'minio' | base64)
+  # Root access key for MinIO Tenant, base64 encoded (echo -n 'minio' | base64)
   accesskey: bWluaW8=
-  ## Secret Key for MinIO Tenant, base64 encoded (echo -n 'minio123' | base64)
+  # Root secret key for MinIO Tenant, base64 encoded (echo -n 'minio123' | base64)
   secretkey: bWluaW8xMjM=
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: project-grafana-loki-minio-user
+  namespace: ${releaseNamespace}
+type: Opaque
+data:
+  # User access key for MinIO Tenant, base64 encoded (echo -n 'minio-user' | base64)
+  CONSOLE_ACCESS_KEY: bWluaW8tdXNlcg==
+  # User secret key for MinIO Tenant, base64 encoded (echo -n 'minio123' | base64)
+  CONSOLE_SECRET_KEY: bWluaW8xMjM=

--- a/services/project-grafana-loki/0.33.2/minio.yaml
+++ b/services/project-grafana-loki/0.33.2/minio.yaml
@@ -33,7 +33,7 @@ spec:
           memory: 384Mi
 
   credsSecret:
-    name: project-grafana-loki-minio-root
+    name: project-grafana-loki-minio
 
   users:
     - name: project-grafana-loki-minio-user
@@ -59,7 +59,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: project-grafana-loki-minio-root
+  name: project-grafana-loki-minio
   namespace: ${releaseNamespace}
 type: Opaque
 data:


### PR DESCRIPTION
This is a backport of the following PR:

https://github.com/mesosphere/kommander-applications/pull/368



This defines a set of user credentials for the MinIO Tenant used by Loki. This is necessary in order for minio-operator to create buckets when reconciling the Tenant.

Tested against kommander at https://github.com/mesosphere/kommander/pull/1718.

Tested manually on kind:
```
branden@crateria ~ % kubectl curl -n kommander "http://$(kubectl -n kommander get pod -l app.kubernetes.io/name=loki-distributed -l app.kubernetes.io/instance=grafana-loki -l app.kubernetes.io/component=gateway --no-headers -o custom-columns=:metadata.name)/loki/api/v1/labels"
{"status":"success","data":["__name__","alertmanager","app","app_kubernetes_io_component","app_kubernetes_io_instance","app_kubernetes_io_managed_by","app_kubernetes_io_name","app_kubernetes_io_part_of","app_kubernetes_io_version","chart","component","container","container_id","control_plane","controller_revision_hash","controller_uid","env","gatekeeper_sh_operation","gatekeeper_sh_system","group","helm_sh_chart","heritage","host","jobLabel","job_name","k8s_app","kommander_mesosphere_io_flux_source_controller_ingress_access","kommander_mesosphere_io_name","kubefed_admission_webhook","kubefed_control_plane","log_source","name","namespace","operator","operator_prometheus_io_name","operator_prometheus_io_shard","pod","pod_id","pod_template_generation","pod_template_hash","prometheus","prometheus_kommander_d2iq_io_select","provider","release","statefulset_kubernetes_io_pod_name","tier","version"]}
branden@crateria ~ %
```