### PR TITLE
feat: Disable minio inplace upgrades

### DIFF
--- a/services/grafana-loki/0.48.3/minio.yaml
+++ b/services/grafana-loki/0.48.3/minio.yaml
@@ -50,6 +50,8 @@ spec:
     # Allow unathenticated requests to metrics endpoint.
     - name: MINIO_PROMETHEUS_AUTH_TYPE
       value: public
+    - name: MINIO_UPDATE
+      value: "off"
 
   s3:
     bucketDNS: false

--- a/services/project-grafana-loki/0.48.3/minio.yaml
+++ b/services/project-grafana-loki/0.48.3/minio.yaml
@@ -50,6 +50,8 @@ spec:
     # Allow unathenticated requests to metrics endpoint.
     - name: MINIO_PROMETHEUS_AUTH_TYPE
       value: public
+    - name: MINIO_UPDATE
+      value: "off"
 
   s3:
     bucketDNS: false


### PR DESCRIPTION
testing in https://github.com/mesosphere/kommander/pull/1779

`MINIO_UPDATE` is `on` by default, which allows for inplace upgrades of minio (aka download the latest binary and trigger a restart of minio). We don't want inplace upgrades happening within the container, so this commit disables that functionality. 