### PR TITLE
fix: Lint against release-2.1 branch, update tools

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,7 @@
-flux2 0.23.0
-kustomize 4.4.1
-github-cli 2.2.0
-awscli 2.4.0
+awscli 2.4.24
+flux2 0.29.5
+github-cli 2.5.2
+golang 1.17.7
+kustomize 4.5.2
+pre-commit 2.17.0
+yq 4.22.1

--- a/make/pre-commit.mk
+++ b/make/pre-commit.mk
@@ -11,4 +11,4 @@ ifeq ($(wildcard $(PRE_COMMIT_CONFIG_FILE)),)
 	$(error Cannot find pre-commit config file $(PRE_COMMIT_CONFIG_FILE). Specify the config file via PRE_COMMIT_CONFIG_FILE variable)
 endif
 	env SKIP=$(SKIP) pre-commit run -a --show-diff-on-failure --config $(PRE_COMMIT_CONFIG_FILE)
-	git fetch origin main && gitlint --ignore-stdin --commits origin/main..HEAD
+	git fetch origin release-2.1 && gitlint --ignore-stdin --commits origin/release-2.1..HEAD


### PR DESCRIPTION
As it was changed in release-2.2 a while ago, let's also fix git linting here.
