### PR TITLE
fix: Update Loki tenant to support minio-operator upgrade

### DIFF
--- a/services/grafana-loki/0.48.3/minio.yaml
+++ b/services/grafana-loki/0.48.3/minio.yaml
@@ -11,7 +11,7 @@ metadata:
     prometheus.io/port: "9000"
     prometheus.io/scrape: "true"
 spec:
-  image: minio/minio:RELEASE.2022-04-01T03-41-39Z
+  image: quay.io/minio/minio:RELEASE.2022-01-08T03-11-54Z
   pools:
     - servers: 4
       volumesPerServer: 1
@@ -27,11 +27,20 @@ spec:
       resources:
         limits:
           cpu: 750m
-          memory: 768Mi
+          memory: 1Gi
         requests:
           cpu: 250m
-          memory: 384Mi
-
+          memory: 768Mi
+      # In DKP 2.1, the minio-operator version (v4.1.3) ran minio as root.
+      # In later operator versions that was changed to always run minio as a non-root user
+      # unfortunately that means to support upgrading from 2.1 -> 2.2 we have to explicitly set the securityContext
+      # to run minio as root so the existing data in minio remains accessible.
+      # https://github.com/minio/operator/blob/master/UPGRADE.md#v423---v424
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        runAsNonRoot: false
+        fsGroup: 0
   credsSecret:
     name: grafana-loki-minio
 


### PR DESCRIPTION
When upgrading loki, there are a number of issues
when the tenant is upgraded. There was a permission
change in the minio-operator (see comment) and minio was OOMKilled
during the upgrade causing it to fail.

See https://jira.d2iq.com/browse/D2IQ-88873?focusedCommentId=382031&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-382031 for more info.