### PR TITLE
[backport][release-2.1] fix: Bump minio memory limits/requests

### DIFF
--- a/services/grafana-loki/0.33.1/minio.yaml
+++ b/services/grafana-loki/0.33.1/minio.yaml
@@ -26,10 +26,10 @@ spec:
       resources:
         limits:
           cpu: 750m
-          memory: 512Mi
+          memory: 1Gi
         requests:
           cpu: 250m
-          memory: 256Mi
+          memory: 768Mi
 
   credsSecret:
     name: grafana-loki-minio


### PR DESCRIPTION
We've bumped these limits/requests in 2.2/2.3, so we should likely do the same in 2.1 as this will help with minio upgrades in the future 