### PR TITLE
build: add backport-action to repo

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,27 @@
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - closed
+
+jobs:
+  backport:
+    name: Backport PR
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.merged == true
+      && contains(github.event.pull_request.labels.*.name, 'auto-backport')
+      && (
+        (github.event.action == 'labeled' && github.event.label.name == 'auto-backport')
+        || (github.event.action == 'closed')
+      )
+    steps:
+      - name: Backport Action
+        uses: sqren/backport-github-action@v8.4.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          auto_backport_label_prefix: backport-to-
+
+      - name: Backport log
+        if: always()
+        run: cat /home/runner/.backport/backport.log


### PR DESCRIPTION
Refer https://github.com/marketplace/actions/backport-action

If we decide to merge this change as-is, we will start labelling our PRs with 

```
auto-backport, backport-to-release-2.2
```
to backport a PR to `release-2.2` branch.

