### PR TITLE
build: add backport-action user/email to GH action config

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -16,6 +16,10 @@ jobs:
         || (github.event.action == 'closed')
       )
     steps:
+      - name: Set a username
+        run: git config --global user.name d2iq-mergebot
+      - name: Set an email
+        run: git config --global user.email ci-mergebot@d2iq.com
       - name: Backport Action
         uses: sqren/backport-github-action@v8.4.2
         with:


### PR DESCRIPTION
action is currently failing with 

```
      "status": "unhandled-error",
      "error": {
        "name": "SpawnError",
        "context": {
          "cmdArgs": [
            "commit",
            "--no-edit",
            "--no-verify"
          ],
          "code": 128,
          "stderr": "Author identity unknown\n\n*** Please tell me who you are.\n\nRun\n\n  git config --global user.email \"you@example.com\"\n  git config --global user.name \"Your Name\"\n\nto set your account's default identity.\nOmit --global to set the identity only in this repository.\n\nfatal: empty ident name (for <runner@fv-az119-428.ca0t41jjrjaujd4nublazzptxb.cx.internal.cloudapp.net>) not allowed\n",
          "stdout": ""
        }
      }
    }
```
https://github.com/mesosphere/kommander-applications/runs/6561494321?check_suite_focus=true 
this is an attempt to fix it.