### PR TITLE
feat: disable remote bases in kustomize overlays

### DIFF
--- a/hack/flux/flux-update-kustomization.yaml
+++ b/hack/flux/flux-update-kustomization.yaml
@@ -2,3 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - flux.yaml
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: kustomize-controller
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --no-remote-bases=true

--- a/services/kommander-flux/0.30.2/templates/apps_v1_deployment_kustomize-controller.yaml
+++ b/services/kommander-flux/0.30.2/templates/apps_v1_deployment_kustomize-controller.yaml
@@ -28,6 +28,7 @@ spec:
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election
+        - --no-remote-bases=true
         env:
         - name: RUNTIME_NAMESPACE
           valueFrom:


### PR DESCRIPTION
kustomize-controller 0.25.0+ introduced a flag to support remote
kustomization overlays by default. We don't use remote bases for
kustomizations (yet!) so we can safely disable it (as per recommendation
upstream).

See https://github.com/fluxcd/kustomize-controller/pull/638