### PR TITLE
feat: override thanos image tag with v0.26.0

### DIFF
--- a/services/thanos/0.4.6/defaults/cm.yaml
+++ b/services/thanos/0.4.6/defaults/cm.yaml
@@ -8,6 +8,8 @@ metadata:
 data:
   values.yaml: |
     ---
+    image:
+      tag: v0.26.0
     store:
       enabled: false
     compact:


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-89799

Override thanos image tag with v0.26.0. The upstream chart has not been updated in a while, so this assumes no breaking change has been introduced and that image overrides are supported by maintainers.