### PR TITLE
fix: Expand Loki storage

### DIFF
--- a/services/grafana-loki/0.48.3/minio.yaml
+++ b/services/grafana-loki/0.48.3/minio.yaml
@@ -13,6 +13,37 @@ metadata:
 spec:
   image: quay.io/minio/minio:RELEASE.2022-01-08T03-11-54Z
   pools:
+    # We define multiple pools in order to add storage while supporting existing clusters. Server pools can't
+    # be expanded, so cluster storage can only be expanded by adding new pools.
+    # See <https://github.com/minio/operator/blob/7ae1610432ad3174150f4adaab1562c3ee522468/docs/expansion.md#underlying-details-in-tenant-expansion>.
+    - servers: 4
+      volumesPerServer: 1
+      volumeClaimTemplate:
+        metadata:
+          name: grafana-loki-minio
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 10Gi
+      resources:
+        limits:
+          cpu: 750m
+          memory: 1Gi
+        requests:
+          cpu: 250m
+          memory: 768Mi
+      # In DKP 2.1, the minio-operator version (v4.1.3) ran minio as root.
+      # In later operator versions that was changed to always run minio as a non-root user
+      # unfortunately that means to support upgrading from 2.1 -> 2.2 we have to explicitly set the securityContext
+      # to run minio as root so the existing data in minio remains accessible.
+      # https://github.com/minio/operator/blob/master/UPGRADE.md#v423---v424
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        runAsNonRoot: false
+        fsGroup: 0
     - servers: 4
       volumesPerServer: 1
       volumeClaimTemplate:

--- a/services/project-grafana-loki/0.48.3/minio.yaml
+++ b/services/project-grafana-loki/0.48.3/minio.yaml
@@ -11,7 +11,7 @@ metadata:
     prometheus.io/port: "9000"
     prometheus.io/scrape: "true"
 spec:
-  image: minio/minio:RELEASE.2022-04-01T03-41-39Z
+  image: quay.io/minio/minio:RELEASE.2022-01-08T03-11-54Z
   pools:
     - servers: 4
       volumesPerServer: 1
@@ -27,10 +27,20 @@ spec:
       resources:
         limits:
           cpu: 750m
-          memory: 768Mi
+          memory: 1Gi
         requests:
           cpu: 250m
-          memory: 384Mi
+          memory: 768Mi
+      # In DKP 2.1, the minio-operator version (v4.1.3) ran minio as root.
+      # In later operator versions that was changed to always run minio as a non-root user
+      # unfortunately that means to support upgrading from 2.1 -> 2.2 we have to explicitly set the securityContext
+      # to run minio as root so the existing data in minio remains accessible.
+      # https://github.com/minio/operator/blob/master/UPGRADE.md#v423---v424
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        runAsNonRoot: false
+        fsGroup: 0
 
   credsSecret:
     name: project-grafana-loki-minio

--- a/services/project-grafana-loki/0.48.3/minio.yaml
+++ b/services/project-grafana-loki/0.48.3/minio.yaml
@@ -13,6 +13,37 @@ metadata:
 spec:
   image: quay.io/minio/minio:RELEASE.2022-01-08T03-11-54Z
   pools:
+    # We define multiple pools in order to add storage while supporting existing clusters. Server pools can't
+    # be expanded, so cluster storage can only be expanded by adding new pools.
+    # See <https://github.com/minio/operator/blob/7ae1610432ad3174150f4adaab1562c3ee522468/docs/expansion.md#underlying-details-in-tenant-expansion>.
+    - servers: 4
+      volumesPerServer: 1
+      volumeClaimTemplate:
+        metadata:
+          name: project-grafana-loki-minio
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 10Gi
+      resources:
+        limits:
+          cpu: 750m
+          memory: 1Gi
+        requests:
+          cpu: 250m
+          memory: 768Mi
+      # In DKP 2.1, the minio-operator version (v4.1.3) ran minio as root.
+      # In later operator versions that was changed to always run minio as a non-root user
+      # unfortunately that means to support upgrading from 2.1 -> 2.2 we have to explicitly set the securityContext
+      # to run minio as root so the existing data in minio remains accessible.
+      # https://github.com/minio/operator/blob/master/UPGRADE.md#v423---v424
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        runAsNonRoot: false
+        fsGroup: 0
     - servers: 4
       volumesPerServer: 1
       volumeClaimTemplate:


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-88867

This PR expands Loki's storage from 40 GB to 80 GB. The daily cluster (7 nodes) consumes about 5 GB a day, which is 70 GB every two weeks. Loki's default retention period is two weeks.

This PR also updates the project Loki MinIO Tenant to match the workspace Loki, pulling in changes from #401.

This will need to be backported to release-2.2.

Tested against kommander at https://github.com/mesosphere/kommander/pull/1871.