### PR TITLE
chore: kommander: remove unused parameter `ingressCertificateSecret`

### DIFF
--- a/services/kommander/0.3.0/defaults/cm.yaml
+++ b/services/kommander/0.3.0/defaults/cm.yaml
@@ -47,9 +47,6 @@ data:
         gitCredentialsSecret:
           namespace: kommander-flux
           name: kommander-git-credentials
-        ingressCertificateSecret:
-          namespace: kommander
-          name: kommander-traefik-certificate
         branch: main
     kommander-licensing:
       certificates:


### PR DESCRIPTION
This static parameter was replaced with the dynamic value from KommanderCluster status in https://github.com/mesosphere/kommander/pull/1892.