### PR TITLE
feat: CreateReplace strategy for crds in HRs

### DIFF
--- a/services/centralized-grafana/34.9.3/centralized-grafana.yaml
+++ b/services/centralized-grafana/34.9.3/centralized-grafana.yaml
@@ -15,10 +15,12 @@ spec:
       version: 34.9.3
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: centralized-grafana

--- a/services/centralized-kubecost/0.25.2/release/release.yaml
+++ b/services/centralized-kubecost/0.25.2/release/release.yaml
@@ -18,10 +18,12 @@ spec:
       version: "0.25.2"
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: centralized-kubecost

--- a/services/cert-manager/1.7.1/release/release.yaml
+++ b/services/cert-manager/1.7.1/release/release.yaml
@@ -42,10 +42,12 @@ spec:
       version: "v1.7.1"
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: cert-manager

--- a/services/chartmuseum/3.6.2/chartmuseum.yaml
+++ b/services/chartmuseum/3.6.2/chartmuseum.yaml
@@ -15,9 +15,11 @@ spec:
       version: "3.6.2"
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: chartmuseum

--- a/services/dex-k8s-authenticator/1.2.10/dex-k8s-authenticator.yaml
+++ b/services/dex-k8s-authenticator/1.2.10/dex-k8s-authenticator.yaml
@@ -20,9 +20,11 @@ spec:
       version: 1.2.9
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: dex-k8s-authenticator

--- a/services/dex/2.9.18/dex.yaml
+++ b/services/dex/2.9.18/dex.yaml
@@ -15,9 +15,11 @@ spec:
       version: 2.9.18
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: dex

--- a/services/dkp-insights-management/0.1.6/helmrelease/helmrelease.yaml
+++ b/services/dkp-insights-management/0.1.6/helmrelease/helmrelease.yaml
@@ -20,9 +20,11 @@ spec:
       version: v0.1.6
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   valuesFrom:

--- a/services/external-dns/6.5.5/external-dns.yaml
+++ b/services/external-dns/6.5.5/external-dns.yaml
@@ -15,9 +15,11 @@ spec:
       version: 6.5.5
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: external-dns

--- a/services/fluent-bit/0.19.20/fluent-bit.yaml
+++ b/services/fluent-bit/0.19.20/fluent-bit.yaml
@@ -17,9 +17,11 @@ spec:
       version: 0.19.20
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   timeout: 5m0s

--- a/services/gatekeeper/3.7.0/release/release.yaml
+++ b/services/gatekeeper/3.7.0/release/release.yaml
@@ -15,9 +15,11 @@ spec:
       version: 3.7.0
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   timeout: 5m0s
@@ -48,9 +50,11 @@ spec:
       version: "v0.0.1"
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   timeout: 5m0s

--- a/services/gitea/5.0.9/gitea.yaml
+++ b/services/gitea/5.0.9/gitea.yaml
@@ -15,10 +15,12 @@ spec:
       version: 5.0.9
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: gitea

--- a/services/grafana-logging/6.28.0/grafana.yaml
+++ b/services/grafana-logging/6.28.0/grafana.yaml
@@ -15,9 +15,11 @@ spec:
       version: "6.28.0"
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: grafana-logging

--- a/services/grafana-loki/0.48.4/grafana-loki.yaml
+++ b/services/grafana-loki/0.48.4/grafana-loki.yaml
@@ -15,9 +15,11 @@ spec:
       version: "0.48.4"
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: grafana-loki

--- a/services/istio/1.13.5/helmrelease/helmrelease.yaml
+++ b/services/istio/1.13.5/helmrelease/helmrelease.yaml
@@ -18,10 +18,12 @@ spec:
       version: "1.13.5"
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: istio

--- a/services/jaeger/2.29.0/helmrelease/release.yaml
+++ b/services/jaeger/2.29.0/helmrelease/release.yaml
@@ -19,9 +19,11 @@ spec:
     - name: istio
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: jaeger

--- a/services/karma-traefik/0.0.1/karma-traefik.yaml
+++ b/services/karma-traefik/0.0.1/karma-traefik.yaml
@@ -18,9 +18,11 @@ spec:
       version: 0.0.1
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: karma-traefik

--- a/services/karma/2.0.1/karma.yaml
+++ b/services/karma/2.0.1/karma.yaml
@@ -18,9 +18,11 @@ spec:
       version: 2.0.1
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: karma

--- a/services/kiali/1.49.1/kiali.yaml
+++ b/services/kiali/1.49.1/kiali.yaml
@@ -20,9 +20,11 @@ spec:
       version: "1.49.0"
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: kiali

--- a/services/knative/0.3.10/knative-serving.yaml
+++ b/services/knative/0.3.10/knative-serving.yaml
@@ -18,9 +18,11 @@ spec:
       version: "0.3.10"
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: knative

--- a/services/kommander/0.3.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
+++ b/services/kommander/0.3.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
@@ -17,9 +17,11 @@ spec:
       version: 1.0.3
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: ${releaseName}

--- a/services/kommander/0.3.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
+++ b/services/kommander/0.3.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
@@ -19,10 +19,12 @@ spec:
       version: 0.1.6
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: ${releaseName}

--- a/services/kube-oidc-proxy/0.3.2/kube-oidc-proxy.yaml
+++ b/services/kube-oidc-proxy/0.3.2/kube-oidc-proxy.yaml
@@ -24,9 +24,11 @@ spec:
       version: 0.3.1
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: kube-oidc-proxy

--- a/services/kube-prometheus-stack/34.9.3/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/34.9.3/kube-prometheus-stack.yaml
@@ -18,6 +18,7 @@ spec:
       version: 34.9.3
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:

--- a/services/kubecost-thanos-traefik/0.0.1/kubecost-thanos-traefik.yaml
+++ b/services/kubecost-thanos-traefik/0.0.1/kubecost-thanos-traefik.yaml
@@ -18,9 +18,11 @@ spec:
       version: 0.0.1
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: kubecost-thanos-traefik

--- a/services/kubecost/0.25.2/kubecost.yaml
+++ b/services/kubecost/0.25.2/kubecost.yaml
@@ -18,10 +18,12 @@ spec:
       version: "0.25.2"
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: kubecost

--- a/services/kubefed/0.9.2/release/release.yaml
+++ b/services/kubefed/0.9.2/release/release.yaml
@@ -15,10 +15,12 @@ spec:
       version: "0.9.2"
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   targetNamespace: kube-federation-system
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: kubefed

--- a/services/kubernetes-dashboard/5.1.1/kubernetes-dashboard.yaml
+++ b/services/kubernetes-dashboard/5.1.1/kubernetes-dashboard.yaml
@@ -15,9 +15,11 @@ spec:
       version: "5.1.1"
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: kubernetes-dashboard

--- a/services/logging-operator/3.17.7/logging-operator-logging.yaml
+++ b/services/logging-operator/3.17.7/logging-operator-logging.yaml
@@ -18,6 +18,7 @@ spec:
       version: 3.17.7
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:

--- a/services/logging-operator/3.17.7/logging-operator.yaml
+++ b/services/logging-operator/3.17.7/logging-operator.yaml
@@ -16,6 +16,7 @@ spec:
       version: 3.17.7
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:

--- a/services/metallb/0.12.3/metallb.yaml
+++ b/services/metallb/0.12.3/metallb.yaml
@@ -15,9 +15,11 @@ spec:
       version: 0.12.3
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: metallb

--- a/services/minio-operator/4.4.16/minio-tenant-helmrelease/release.yaml
+++ b/services/minio-operator/4.4.16/minio-tenant-helmrelease/release.yaml
@@ -18,9 +18,11 @@ spec:
       name: minio-operator
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: minio-tenant

--- a/services/nfs-server-provisioner/0.6.0/nfs-server-provisioner.yaml
+++ b/services/nfs-server-provisioner/0.6.0/nfs-server-provisioner.yaml
@@ -15,9 +15,11 @@ spec:
       version: 0.6.0
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: nfs-server-provisioner

--- a/services/nvidia/0.4.4/nvidia.yaml
+++ b/services/nvidia/0.4.4/nvidia.yaml
@@ -15,9 +15,11 @@ spec:
       version: 0.4.4
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: nvidia

--- a/services/project-grafana-logging/6.28.0/project-grafana.yaml
+++ b/services/project-grafana-logging/6.28.0/project-grafana.yaml
@@ -15,9 +15,11 @@ spec:
       version: "6.28.0"
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   valuesFrom:

--- a/services/project-grafana-loki/0.48.3/project-grafana-loki.yaml
+++ b/services/project-grafana-loki/0.48.3/project-grafana-loki.yaml
@@ -15,9 +15,11 @@ spec:
       version: "0.48.3"
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: project-grafana-loki

--- a/services/prometheus-adapter/2.17.1/prometheus-adapter.yaml
+++ b/services/prometheus-adapter/2.17.1/prometheus-adapter.yaml
@@ -18,9 +18,11 @@ spec:
       version: 2.17.1
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: prometheus-adapter

--- a/services/prometheus-thanos-traefik/0.0.1/prometheus-thanos-traefik.yaml
+++ b/services/prometheus-thanos-traefik/0.0.1/prometheus-thanos-traefik.yaml
@@ -18,9 +18,11 @@ spec:
       version: 0.0.1
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: prometheus-thanos-traefik

--- a/services/reloader/0.0.110/reloader.yaml
+++ b/services/reloader/0.0.110/reloader.yaml
@@ -14,9 +14,11 @@ spec:
       version: v0.0.110
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   valuesFrom:

--- a/services/thanos/0.4.6/thanos.yaml
+++ b/services/thanos/0.4.6/thanos.yaml
@@ -15,9 +15,11 @@ spec:
       version: 0.4.6
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: thanos

--- a/services/traefik-forward-auth-mgmt/0.3.8/traefik-forward-auth-mgmt.yaml
+++ b/services/traefik-forward-auth-mgmt/0.3.8/traefik-forward-auth-mgmt.yaml
@@ -20,9 +20,11 @@ spec:
       version: 0.3.8
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: traefik-forward-auth-mgmt

--- a/services/traefik-forward-auth/0.3.8/traefik-forward-auth.yaml
+++ b/services/traefik-forward-auth/0.3.8/traefik-forward-auth.yaml
@@ -18,9 +18,11 @@ spec:
       version: 0.3.8
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: traefik-forward-auth

--- a/services/traefik/10.9.3/traefik.yaml
+++ b/services/traefik/10.9.3/traefik.yaml
@@ -15,9 +15,11 @@ spec:
       version: "10.9.1"
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   timeout: 5m0s

--- a/services/velero/3.2.3/velero.yaml
+++ b/services/velero/3.2.3/velero.yaml
@@ -15,9 +15,11 @@ spec:
       version: 3.2.3
   interval: 15s
   install:
+    crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 30
   releaseName: velero


### PR DESCRIPTION
During install and upgrade of HR, we can use CreateReplace strategy to ensure the right set of CRDs are used post upgrade.


Fixes https://jira.d2iq.com/browse/D2IQ-87944