### PR TITLE
fix: usage of readonly var in `update-flux.sh`

### DIFF
--- a/hack/flux/update-flux.sh
+++ b/hack/flux/update-flux.sh
@@ -51,8 +51,7 @@ function update_flux() {
     git push --set-upstream origin "${BRANCH_NAME}"
 
     git fetch origin main
-    readonly KOMMANDER_APPLICATIONS_PR
-    KOMMANDER_APPLICATIONS_PR=$(gh pr create --base main --fill --head "${BRANCH_NAME}" -t "${COMMIT_MSG}" -l ready-for-review -l ok-to-test -l slack-notify)
+    readonly KOMMANDER_APPLICATIONS_PR=$(gh pr create --base main --fill --head "${BRANCH_NAME}" -t "${COMMIT_MSG}" -l ready-for-review -l ok-to-test -l slack-notify)
     echo "${KOMMANDER_APPLICATIONS_PR} is created"
 }
 


### PR DESCRIPTION
follow up of #463 