### PR TITLE
fix: usage of readonly var in `update-flux.sh`

### DIFF
--- a/hack/flux/update-flux.sh
+++ b/hack/flux/update-flux.sh
@@ -51,7 +51,8 @@ function update_flux() {
     git push --set-upstream origin "${BRANCH_NAME}"
 
     git fetch origin main
-    readonly KOMMANDER_APPLICATIONS_PR=$(gh pr create --base main --fill --head "${BRANCH_NAME}" -t "${COMMIT_MSG}" -l ready-for-review -l ok-to-test -l slack-notify)
+    KOMMANDER_APPLICATIONS_PR=$(gh pr create --base main --fill --head "${BRANCH_NAME}" -t "${COMMIT_MSG}" -l ready-for-review -l ok-to-test -l slack-notify)
+    readonly KOMMANDER_APPLICATIONS_PR
     echo "${KOMMANDER_APPLICATIONS_PR} is created"
 }
 


### PR DESCRIPTION
zillionth attempt to make both the pre-commit and the kommander PR happy. 

https://github.com/mesosphere/kommander/pull/2003 and https://github.com/mesosphere/kommander-applications/pull/467 are created from the latest run so i think this should be the last PR.