### PR TITLE
build: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+**What problem does this PR solve?**:
+
+
+**Which issue(s) does this PR fix?**:
+<!-- Add a link to the JIRA issue below-->
+
+
+**Special notes for your reviewer**:
+<!--
+Use this to provide any additional information to the reviewers.
+This may include:
+- Manual testing steps.
+- Best way to review the PR.
+- Where the author wants the most review attention on.
+- etc.
+-->
+
+
+**Does this PR introduce a user-facing change?**:
+<!--
+If yes, add a message in the 'release-note' block below.
+If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
+-->
+```release-note
+
+```
+
+**If the PR adds a version bump, does it add a breaking change in License**:
+<!--
+For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
+that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple 
+parties (Like Product, Legal for example) need to be notified when such a change happens.
+-->
+
+- [ ] No License Change (or NA).


### PR DESCRIPTION
- adds a pull request template.
- This came up in sprint retro and the concern was that when bumping a chart, we _might_ forget to look at any intricacies in Licensing changes and as a first measure, lets add a template to remind that licensing is something that needs to be kept in mind when bumping upstream charts.