### PR TITLE
fix: use Recreate strategy for chartmuseum upgrades

### DIFF
--- a/services/chartmuseum/3.9.0/defaults/cm.yaml
+++ b/services/chartmuseum/3.9.0/defaults/cm.yaml
@@ -33,6 +33,8 @@ data:
             secretName: chartmuseum-tls
       annotations:
         secret.reloader.stakater.com/reload: chartmuseum-tls
+    strategy:
+      type: Recreate
     extraArgs:
       - --tls-cert=/tls/tls.crt
       - --tls-key=/tls/tls.key


### PR DESCRIPTION
**What problem does this PR solve?**:
Slack thread -> https://mesosphere.slack.com/archives/C01LNF6KML5/p1657829502294979

Chartmuseum is using a ReadManyOnce PVC, which can only be mounted on one node at a time. It's possible that a Chartmuseum pod is scheduled on another node because the deployment strategy is rolling update.

To fix this, we can set the deployment strategy to Recreate so only one pod exists at a given time (since we only expect to have one replica)

I still have no idea how we haven't ran into this before 🤯 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.d2iq.com/browse/D2IQ-91547

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
