### PR TITLE
chore: wire appmgmt webhook images from installer config

### DIFF
--- a/services/kommander-appmanagement/0.3.0/defaults/cm.yaml
+++ b/services/kommander-appmanagement/0.3.0/defaults/cm.yaml
@@ -16,8 +16,15 @@ data:
             tag: "${kommanderAppManagementImageTag}"
             repository: "${kommanderAppManagementImageRepository}"
             pullPolicy: IfNotPresent
+    kubetools:
+      image:
+        repository: "${kommanderAppManagementKubetoolsImageRepository}"
+        tag: "${kommanderAppManagementImageTag}"
     webhook:
       certificate:
         issuer:
           name: ${certificatesIssuerName}
           kind: ${certificatesIssuerKind:-Issuer}
+      image:
+        repository: "${kommanderAppManagementWebhookImageRepository}"
+        tag: "${kommanderAppManagementImageTag}"


### PR DESCRIPTION
**What problem does this PR solve?**:

when running in CI with konvoy on aws clusters, we need to override the images for the recently added appmanagement webhook and this change propagates the images from installer config into `kommander-vars` config map.

relates to https://github.com/mesosphere/kommander-cli/pull/628

- [x] No License Change (or NA).
