### PR TITLE
[release-2.2] build: Add e2e make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/.local/
 .DS_Store
+/.local/
+/.tmp/

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -28,6 +28,10 @@ RUN --mount=type=bind,target=/tmp/kommander-cli,readwrite=true \
     bash -ec ". ~/.asdf/asdf.sh && make install-tools && \
               pre-commit install -t pre-commit -t commit-msg --install-hooks"
 
+ARG DOCKER_VERSION
+RUN curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | \
+    tar xz -C /usr/local/bin --strip-components=1 docker/docker
+
 # needed to be able to pull private repos, e.g. in 'go mod download'
 RUN git config --global url."git@github.com:".insteadOf "https://github.com/"
 RUN mkdir -p ~/.ssh && echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' > ~/.ssh/known_hosts

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ include make/all.mk
 
 # Versions for tools that are not managed by asdf.
 ASDF_VERSION=0.8.1
+DOCKER_VERSION=20.10.7
 
 # Inputs required to build the CI Docker image with a determinstic tag.
-CI_DOCKER_BUILD_ARGS=ASDF_VERSION=$(ASDF_VERSION)
+CI_DOCKER_BUILD_ARGS=ASDF_VERSION=$(ASDF_VERSION)\
+		DOCKER_VERSION=$(DOCKER_VERSION)
 CI_DOCKER_EXTRA_FILES=.tool-versions

--- a/make/all.mk
+++ b/make/all.mk
@@ -12,3 +12,4 @@ include $(INCLUDE_DIR)release.mk
 include $(INCLUDE_DIR)pre-commit.mk
 include $(INCLUDE_DIR)validate.mk
 include $(INCLUDE_DIR)go.mk
+include $(INCLUDE_DIR)test.mk

--- a/make/test.mk
+++ b/make/test.mk
@@ -1,0 +1,44 @@
+KOMMANDER_E2E_DIR  = $(REPO_ROOT)/.tmp/kommander-e2e
+
+# E2E configurations
+E2E_TIMEOUT       ?= 120m
+E2E_KINDEST_IMAGE ?= "kindest/node:v1.23.5"
+UPGRADE_FROM_VERSION ?= "v2.2.2-dev"
+
+# (aweris): This should be a temporary workaround for v2.3.0 development. If you're still see clone test in v2.4.0
+# it means "a temporary workaround" actually means "permanent solution".
+.PHONY: kommander-e2e
+kommander-e2e: ## Clones the kommander-e2e repo locally or updates the clone
+kommander-e2e:
+	@if [ -d $(KOMMANDER_E2E_DIR) ] ; then \
+		cd $(KOMMANDER_E2E_DIR) && \
+			git fetch origin && \
+			git reset --hard origin/main ; \
+	else \
+		mkdir -p $(KOMMANDER_E2E_DIR) && \
+			git clone -q https://github.com/mesosphere/kommander-e2e.git $(KOMMANDER_E2E_DIR) && \
+			cd $(KOMMANDER_E2E_DIR) && \
+			git checkout main ; \
+	fi
+
+.PHONY: test.e2e.install
+test.e2e.install: kommander-e2e ; $(info $(M) running end-to-end kommander install test from kommander-e2e)
+	cd $(KOMMANDER_E2E_DIR) && \
+		E2E_TIMEOUT=$(E2E_TIMEOUT) \
+		E2E_KINDEST_IMAGE=$(E2E_KINDEST_IMAGE) \
+		E2E_TEST_PATH="feature/install/suites/kindcluster" \
+		E2E_KOMMANDER_APPLICATIONS_REPOSITORY="github.com/mesosphere/kommander-applications.git?ref=$(GIT_COMMIT)" \
+		VERBOSE=$(VERBOSE) \
+		make test.e2e
+
+.PHONY: test.e2e.upgrade.singlecluster
+test.e2e.upgrade.singlecluster: kommander-e2e ; $(info $(M) running end-to-end kommander upgrade $(UPGRADE_FROM_VERSION) to $(GIT_COMMIT) test from kommander-e2e)
+	cd $(KOMMANDER_E2E_DIR) && \
+		E2E_TEST_PATH="feature/upgrade/suites/kind/singlecluster" \
+		E2E_TIMEOUT=$(E2E_TIMEOUT) \
+		E2E_KINDEST_IMAGE=$(E2E_KINDEST_IMAGE) \
+		E2E_KOMMANDER_APPLICATIONS_REPOSITORY="github.com/mesosphere/kommander-applications.git?ref=$(UPGRADE_FROM_VERSION)" \
+		E2E_KOMMANDER_APPLICATIONS_REPOSITORY_TO_UPGRADE="github.com/mesosphere/kommander-applications.git?ref=$(GIT_COMMIT)" \
+		E2E_KINDEST_IMAGE=$(E2E_KINDEST_IMAGE) \
+		VERBOSE=$(VERBOSE) \
+		make test.e2e

--- a/make/test.mk
+++ b/make/test.mk
@@ -3,7 +3,7 @@ KOMMANDER_E2E_DIR  = $(REPO_ROOT)/.tmp/kommander-e2e
 # E2E configurations
 E2E_TIMEOUT       ?= 120m
 E2E_KINDEST_IMAGE ?= "kindest/node:v1.23.5"
-UPGRADE_FROM_VERSION ?= "v2.2.2-dev"
+UPGRADE_FROM_VERSION ?= "v2.1.3-dev"
 
 # (aweris): This should be a temporary workaround for v2.3.0 development. If you're still see clone test in v2.4.0
 # it means "a temporary workaround" actually means "permanent solution".

--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -27,6 +27,18 @@
       "required": "true",
       "priority": 2,
       "id": "ClosedSource_Kommander2_KommanderApplications_ManifestValidation"
+    },
+    "kommander-applications/upgrade-e2e-tests": {
+      "type": "teamcity",
+      "required": "true",
+      "priority": 2,
+      "id": "ClosedSource_Kommander2_KommanderApplications_UpgradeE2eTests"
+    },
+    "kommander-applications/install-e2e-tests": {
+      "type": "teamcity",
+      "required": "true",
+      "priority": 2,
+      "id": "ClosedSource_Kommander2_KommanderApplications_InstallE2eTests"
     }
   },
   "autotest-on-backports-and-trains": true,


### PR DESCRIPTION
**What problem does this PR solve?**:
Backporting https://github.com/mesosphere/kommander-applications/pull/433 e2e make targets to release-2.2 branch

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
