### PR TITLE
fix: Add timeouts in install/upgrade

### DIFF
--- a/services/kube-prometheus-stack/34.9.3/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/34.9.3/kube-prometheus-stack.yaml
@@ -18,10 +18,12 @@ spec:
       version: 34.9.3
   interval: 15s
   install:
+    timeout: 5m0s
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    timeout: 5m0s
     crds: CreateReplace
     remediation:
       retries: 30


### PR DESCRIPTION
**What problem does this PR solve?**:
The KPS upgrade failed in this [test](https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_Kommander2_KommanderCli_UpgradeE2eTestsMultiCluster/3542098?buildTab=log&focusLine=3005&expandAll=true) with a timeout of 1m. I am still not sure how that value is being set so lets set 5m for the install and upgrade sections.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
