### PR TITLE
fix: Change project logging app metadata to type platform

### DIFF
--- a/services/project-grafana-logging/metadata.yaml
+++ b/services/project-grafana-logging/metadata.yaml
@@ -2,7 +2,7 @@ displayName: Grafana Logging
 description: Logging dashboard used to view logs aggregated to Grafana Loki. Requires Grafana Loki.
 category:
   - logging
-type: catalog
+type: platform
 scope:
   - project
 certifications:

--- a/services/project-grafana-loki/metadata.yaml
+++ b/services/project-grafana-loki/metadata.yaml
@@ -2,7 +2,7 @@ displayName: Grafana Loki
 description: Horizontally-scalable, highly-available, multi-tenant log aggregation system inspired by Prometheus. Requires Logging Operator.
 category:
   - logging
-type: catalog
+type: platform
 scope:
   - project
 certifications:

--- a/services/project-logging/metadata.yaml
+++ b/services/project-logging/metadata.yaml
@@ -2,7 +2,7 @@ displayName: Project Logging
 description: Application by D2iQ that defines resources for the Logging Operator, which are used for directing project logs to its Loki application.
 category:
   - logging
-type: catalog
+type: platform
 scope:
   - project
 certifications:


### PR DESCRIPTION
**What problem does this PR solve?**:
Project logging apps should be platform apps, not catalog apps.

Dependent on UI piece of work https://jira.d2iq.com/browse/D2IQ-91829

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.d2iq.com/browse/D2IQ-91739
https://jira.d2iq.com/browse/D2IQ-91831

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
