### PR TITLE
feat: Use gh-dkp tool for calculating dev release name (#474)

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 awscli 2.4.24
 flux2 0.31.4
-github-cli 2.5.2
+github-cli 2.13.0
 golang 1.18.1
 kustomize 4.5.2
 pre-commit 2.17.0

--- a/make/repo.mk
+++ b/make/repo.mk
@@ -17,10 +17,5 @@ endif
 
 .PHONY: repo.dev.tag
 repo.dev.tag: ## Returns development tag
-repo.dev.tag: install-tool.go.svu
-ifeq ($(GIT_CURRENT_BRANCH),main)
-	git fetch --tags
-	svu minor --pattern 'v[0-9].[0-9]{[0-9],}.[0-9]{[0-9],[0-9]-rc.*,-rc.*,}' --suffix dev --tag-mode=all-branches --no-metadata
-else
-	svu patch --pattern 'v[0-9].[0-9]{[0-9],}.[0-9]{[0-9],[0-9]-rc.*,-rc.*,}' --suffix dev --no-metadata
-endif
+repo.dev.tag: install-tool.gh-dkp
+	gh dkp generate dev-version --repository-owner $(GITHUB_ORG) --repository-name $(GITHUB_REPOSITORY)

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -50,6 +50,11 @@ install-tool.%: ## Install specific tool
 install-tool.%: ; $(info $(M) installing $*)
 	$(call install_tool,$*)
 
+.PHONY: install-tool.gh-dkp
+install-tool.gh-dkp: install-tool.github-cli
+install-tool.gh-dkp: ; $(info $(M) installing $*)
+	gh extensions install mesosphere/gh-dkp || gh dkp -h
+
 .PHONY: upgrade-tools
 # ASDF plugins use different env vars for GitHub authentication when querying releases. Try to
 # handle this nicely by specifying some of the known env vars to prevent rate limiting.


### PR DESCRIPTION
**What problem does this PR solve?**:
We need to use gh-dkp for daily tag calculation since the release tag is not in the release brach (but on a separate branch created specifically for the release).

**Which issue(s) does this PR fix?**:
- https://jira.d2iq.com/browse/D2IQ-91920

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
