### PR TITLE
build: Bump mergebot release-2.3 version back to 2.3.0

### DIFF
--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -10,7 +10,7 @@
     "interactive": false,
     "fix_version_map": {
       "main": "Kommander 2.4.0",
-      "release-2.3": "Kommander 2.3.1",
+      "release-2.3": "Kommander 2.3.0",
       "release-2.2": "Kommander 2.2.3",
       "release-2.1": "Kommander 2.1.3"
     },


### PR DESCRIPTION
**What problem does this PR solve?**:
We haven't released 2.3.0 yet, so `release-2.3` needs to still be pointing to 2.3.0 until after GA, then we can update to 2.3.1

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
