### PR TITLE
refactor: Make chart version updater functionality public

### DIFF
--- a/hack/release/cmd/prerelease/prerelease.go
+++ b/hack/release/cmd/prerelease/prerelease.go
@@ -4,22 +4,16 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
-	"strings"
 
-	"github.com/drone/envsubst"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/chartversion"
 	"github.com/spf13/cobra"
 )
 
 var Cmd *cobra.Command //nolint:gochecknoglobals // Cobra commands are global.
 
 const (
-	versionFlagName               = "version"
-	repoFlagName                  = "repo"
-	kommanderChartVersionTemplate = "${kommanderChartVersion:=%s}"
-
-	kommanderHelmReleasePathPattern        = "./services/kommander/*/kommander.yaml"
-	kommanderAppMgmtHelmReleasePathPattern = "./services/kommander-appmanagement/*/kommander-appmanagement.yaml"
+	versionFlagName = "version"
+	repoFlagName    = "repo"
 )
 
 func init() { //nolint:gochecknoinits // Initializing cobra application.
@@ -33,8 +27,8 @@ func init() { //nolint:gochecknoinits // Initializing cobra application.
 			if _, err := os.Stat(kommanderApplicationsRepo); os.IsNotExist(err) {
 				return err
 			}
-			fullChartVersion := fmt.Sprintf(kommanderChartVersionTemplate, chartVersion)
-			err := updateChartVersions(kommanderApplicationsRepo, fullChartVersion)
+
+			err := chartversion.UpdateChartVersions(kommanderApplicationsRepo, chartVersion)
 			if err != nil {
 				return err
 			}
@@ -54,48 +48,4 @@ func init() { //nolint:gochecknoinits // Initializing cobra application.
 	if err != nil {
 		log.Fatal(err)
 	}
-}
-
-func updateChartVersions(kommanderApplicationsRepo, chartVersion string) error {
-	kommanderHelmReleasePaths := []string{kommanderHelmReleasePathPattern, kommanderAppMgmtHelmReleasePathPattern}
-	for _, helmReleasePath := range kommanderHelmReleasePaths {
-		// Find the HelmRelease
-		matches, err := filepath.Glob(filepath.Join(kommanderApplicationsRepo, helmReleasePath))
-		if err != nil {
-			return err
-		}
-		if len(matches) == 0 {
-			return fmt.Errorf("no matches found for HelmRelease path %s (verify the kommander-applications repo path is correct)", helmReleasePath)
-		}
-		if len(matches) > 1 {
-			return fmt.Errorf("found > 1 match for HelmRelease path %s (there should only be one match)", helmReleasePath)
-		}
-		helmReleaseFilePath := matches[0]
-
-		// Update the kommanderChartVersion value
-		parsedFile, err := envsubst.ParseFile(helmReleaseFilePath)
-		if err != nil {
-			return err
-		}
-		subVars := map[string]string{
-			"kommanderChartVersion": chartVersion,
-			"releaseNamespace":      "${releaseNamespace}",
-		}
-		updatedFile, err := parsedFile.Execute(func(s string) string {
-			return subVars[s]
-		})
-		if err != nil {
-			return err
-		}
-
-		if !strings.Contains(updatedFile, chartVersion) {
-			return fmt.Errorf("failed to update Kommander HelmRelease chart version")
-		}
-
-		err = os.WriteFile(helmReleaseFilePath, []byte(updatedFile), 0644)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/hack/release/pkg/chartversion/chartversion.go
+++ b/hack/release/pkg/chartversion/chartversion.go
@@ -1,0 +1,62 @@
+package chartversion
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/drone/envsubst"
+)
+
+const (
+	kommanderChartVersionTemplate          = "${kommanderChartVersion:=%s}"
+	kommanderHelmReleasePathPattern        = "./services/kommander/*/kommander.yaml"
+	kommanderAppMgmtHelmReleasePathPattern = "./services/kommander-appmanagement/*/kommander-appmanagement.yaml"
+)
+
+func UpdateChartVersions(kommanderApplicationsRepo, chartVersion string) error {
+	chartVersion = fmt.Sprintf(kommanderChartVersionTemplate, chartVersion)
+
+	kommanderHelmReleasePaths := []string{kommanderHelmReleasePathPattern, kommanderAppMgmtHelmReleasePathPattern}
+	for _, helmReleasePath := range kommanderHelmReleasePaths {
+		// Find the HelmRelease
+		matches, err := filepath.Glob(filepath.Join(kommanderApplicationsRepo, helmReleasePath))
+		if err != nil {
+			return err
+		}
+		if len(matches) == 0 {
+			return fmt.Errorf("no matches found for HelmRelease path %s (verify the kommander-applications repo path is correct)", helmReleasePath)
+		}
+		if len(matches) > 1 {
+			return fmt.Errorf("found > 1 match for HelmRelease path %s (there should only be one match)", helmReleasePath)
+		}
+		helmReleaseFilePath := matches[0]
+
+		// Update the kommanderChartVersion value
+		parsedFile, err := envsubst.ParseFile(helmReleaseFilePath)
+		if err != nil {
+			return err
+		}
+		subVars := map[string]string{
+			"kommanderChartVersion": chartVersion,
+			"releaseNamespace":      "${releaseNamespace}",
+		}
+		updatedFile, err := parsedFile.Execute(func(s string) string {
+			return subVars[s]
+		})
+		if err != nil {
+			return err
+		}
+
+		if !strings.Contains(updatedFile, chartVersion) {
+			return fmt.Errorf("failed to update Kommander HelmRelease chart version")
+		}
+
+		err = os.WriteFile(helmReleaseFilePath, []byte(updatedFile), 0644)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/hack/release/pkg/chartversion/chartversion_test.go
+++ b/hack/release/pkg/chartversion/chartversion_test.go
@@ -1,4 +1,4 @@
-package prerelease
+package chartversion
 
 import (
 	"fmt"
@@ -25,8 +25,8 @@ func TestUpdateChartVersionsSuccessfully(t *testing.T) {
 	err = cp.Copy(rootDir, tmpDir)
 	assert.Nil(t, err)
 
-	updateToVersion := fmt.Sprintf(kommanderChartVersionTemplate, "v1.0.0")
-	err = updateChartVersions(tmpDir, updateToVersion)
+	updateToVersion := "v1.0.0"
+	err = UpdateChartVersions(tmpDir, updateToVersion)
 	assert.Nil(t, err)
 
 	kommanderHelmReleasePaths := []string{kommanderHelmReleasePathPattern, kommanderAppMgmtHelmReleasePathPattern}
@@ -63,7 +63,10 @@ func TestUpdateChartVersionsSuccessfully(t *testing.T) {
 			// Validate that .spec.chart.spec.version is the only field that changes
 			assert.Equal(t, []string{"Spec", "Chart", "Spec", "Version"}, change.Path, "expected .spec.chart.spec.version to be the only field that changed in the Kommander HelmRelease")
 			// Validate that the updated version is what we expect
-			assert.Equal(t, updateToVersion, change.To, "expected the chart version to be updated to %s, but got %s", updateToVersion, change.To)
+			assert.Equal(t,
+				fmt.Sprintf(kommanderChartVersionTemplate, updateToVersion),
+				change.To,
+				"expected the chart version to be updated to %s, but got %s", updateToVersion, change.To)
 		}
 	}
 }
@@ -86,7 +89,7 @@ func TestUpdateChartVersionsPathChanged(t *testing.T) {
 	err = os.Rename(matches[0], filepath.Join(filepath.Dir(matches[0]), "test.yaml"))
 	assert.Nil(t, err)
 
-	err = updateChartVersions(tmpDir, updateToVersion)
+	err = UpdateChartVersions(tmpDir, updateToVersion)
 	assert.Error(t, err, "expected chart version update to fail as the filename changed")
 }
 
@@ -119,6 +122,6 @@ func TestUpdateChartVersionsVersionFormatChanged(t *testing.T) {
 	err = os.WriteFile(matches[0], []byte(updatedFile), 0644)
 	assert.Nil(t, err)
 
-	err = updateChartVersions(tmpDir, updateToVersion)
+	err = UpdateChartVersions(tmpDir, updateToVersion)
 	assert.Error(t, err, "expected chart version update to fail as the chart version was changed to something unexpected")
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
Making a function public so it can be reused by post-release script.

**Which issue(s) does this PR fix?**:
- https://jira.d2iq.com/browse/D2IQ-91716


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [x] No License Change (or NA).
