### PR TITLE
feat: Bump `dex-controller` to `v0.6.21` by bumping `dex` to `2.9.19`

### DIFF
--- a/services/dex/2.9.19/dex.yaml
+++ b/services/dex/2.9.19/dex.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: 2.9.18
+      version: 2.9.19
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:

Bumps dex-controller chart from https://github.com/mesosphere/dex-controller/releases/tag/v0.6.21 

Depends on  https://github.com/mesosphere/charts/pull/1347


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://jira.d2iq.com/browse/D2IQ-91972 

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
