### PR TITLE
[release-2.3][BACKPORT] chore: relax logging stack resource limitations

### DIFF
--- a/services/fluent-bit/0.19.20/defaults/cm.yaml
+++ b/services/fluent-bit/0.19.20/defaults/cm.yaml
@@ -13,7 +13,7 @@ data:
 
     resources:
       limits:
-        memory: 500Mi
+        memory: 750Mi
       requests:
         cpu: 350m
         memory: 250Mi

--- a/services/fluent-bit/0.19.20/defaults/cm.yaml
+++ b/services/fluent-bit/0.19.20/defaults/cm.yaml
@@ -9,7 +9,7 @@ data:
     ---
     # overriding the default image tag to be consistent with logging-operator
     image:
-      tag: 1.8.13
+      tag: 1.9.3
 
     resources:
       limits:

--- a/services/grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.4/defaults/cm.yaml
@@ -145,3 +145,8 @@ data:
         # Override nginx image to address known CVEs.
         # As of 0.48.4, chart maintainers are still using 1.19-alpine.
         tag: 1.22.0-alpine
+      nginxConfig:
+        httpSnippet: |-
+          client_max_body_size 10M;
+        serverSnippet: |-
+          client_max_body_size 10M;


### PR DESCRIPTION
This is a backport of the following PR:

https://github.com/mesosphere/kommander-applications/pull/516



- This keeps it consistent with the limit used for the fluentbit deployed by logging-operator-logging here https://github.com/mesosphere/kommander-applications/blob/f36ee1ebe81bc0cb8dff171317f3afc39bfd5c28/services/logging-operator/3.17.7/defaults/cm.yaml#L104
- Bumps the fluentbit image to be consistent with fluentbit deployed by loki
- Bumps the grafana-loki nginx server client payload size to prevent these errors by fluentbit : 
```
[2022/07/28 20:14:29] [error] [output:loki:kubernetes_host] grafana-loki-loki-distributed-gateway.kommander.svc:80, HTTP status=413
<html>
<head><title>413 Request Entity Too Large</title></head>
<body>
<center><h1>413 Request Entity Too Large</h1></center>
<hr><center>nginx/1.22.0</center>
</body>
</html>
```

We can relax the constraints a bit more based on the performance issues we see - initial values in this PR are taken from https://github.com/grafana/grafana/issues/3176#issuecomment-368224403

**What problem does this PR solve?**:

The fluentbit deployed by logging-operator-logging has 750M as the limit but the fluentbit used to collect node level data is capped at 500M. 

Looking at the daily cluster today https://a32e264dc0c3d464c8d0d3612a827be6-1370112657.us-west-2.elb.amazonaws.com/dkp/grafana/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?orgId=1&refresh=10s&var-datasource=default&var-cluster=&var-namespace=kommander&var-pod=kommander-fluent-bit-9lpfk that has : 
![image](https://user-images.githubusercontent.com/2296947/181605846-bd93d08e-8dcb-4485-9afe-ff69a72bfd7c.png)

And after the fix has been applied in the daily - https://a32e264dc0c3d464c8d0d3612a827be6-1370112657.us-west-2.elb.amazonaws.com/dkp/grafana/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-datasource=default&var-cluster=&var-namespace=kommander&var-pod=kommander-fluent-bit-5bpkd 

![image](https://user-images.githubusercontent.com/2296947/181638791-ce43d9e0-13b8-4119-9341-187f911733c8.png)


This PR might not resolve [D2IQ-91518](https://jira.d2iq.com/browse/D2IQ-91518) completely but at least relaxes it to some extent (at the least, this should fix daily cluster).

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://jira.d2iq.com/browse/D2IQ-91518

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [x] No License Change (or NA).
