### PR TITLE
chore: bump loki ingester limits as a precaution

### DIFF
--- a/services/grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.4/defaults/cm.yaml
@@ -48,6 +48,9 @@ data:
           reject_old_samples_max_age: 168h
           max_cache_freshness_per_query: 10m
           split_queries_by_interval: 15m
+          ingestion_rate_mb: 10
+          # ingestion_burst_size_mb should be set at least to the maximum logs size expected in a single push request.
+          ingestion_burst_size_mb: 10
         schema_config:
           configs:
             - from: 2020-09-07

--- a/services/grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.4/defaults/cm.yaml
@@ -51,6 +51,8 @@ data:
           ingestion_rate_mb: 10
           # ingestion_burst_size_mb should be set at least to the maximum logs size expected in a single push request.
           ingestion_burst_size_mb: 10
+          per_stream_rate_limit: 10MB
+          per_stream_rate_limit_burst: 15MB
         schema_config:
           configs:
             - from: 2020-09-07


### PR DESCRIPTION
**What problem does this PR solve?**:

Follow up of #516 

acc. to https://grafana.com/docs/loki/latest/configuration/#limits_config docs, since #516 bumped the max client payload to 10Mb we should bump ingester burst size to be at least 10Mb

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
