### PR TITLE
chore: bump grpc client size

### DIFF
--- a/services/grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.4/defaults/cm.yaml
@@ -17,6 +17,7 @@ data:
           # info is a little too quiet.
           log_level: debug
           grpc_server_max_recv_msg_size: 10485760
+          # grpc_server_max_send_msg_size should be set at least to the maximum logs size expected in a single push request.
           grpc_server_max_send_msg_size: 10485760
         distributor:
           ring:

--- a/services/grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.4/defaults/cm.yaml
@@ -16,6 +16,8 @@ data:
           http_listen_port: 3100
           # info is a little too quiet.
           log_level: debug
+          grpc_server_max_recv_msg_size: 10485760
+          grpc_server_max_send_msg_size: 10485760
         distributor:
           ring:
             kvstore:


### PR DESCRIPTION
**What problem does this PR solve?**:

follow up for #520 

i saw these errors on daily:

```
[2022/07/29 14:52:49] [error] [output:loki:kubernetes_audit] grafana-loki-loki-distributed-gateway.kommander.svc:80, HTTP status=500
rpc error: code = ResourceExhausted desc = grpc: received message larger than max (5458785 vs. 4194304)

[2022/07/29 14:52:49] [ warn] [engine] failed to flush chunk '1-1659070758.859689762.flb', retry in 794 seconds: task_id=849, input=kubernetes_audit > output=kubernetes_audit (out_id=0)
```


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
