### PR TITLE
[release-2.3] chore: relax logging stack resource limitations

### DIFF
--- a/services/fluent-bit/0.19.20/defaults/cm.yaml
+++ b/services/fluent-bit/0.19.20/defaults/cm.yaml
@@ -9,11 +9,11 @@ data:
     ---
     # overriding the default image tag to be consistent with logging-operator
     image:
-      tag: 1.8.13
+      tag: 1.9.3
 
     resources:
       limits:
-        memory: 500Mi
+        memory: 750Mi
       requests:
         cpu: 350m
         memory: 250Mi

--- a/services/grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.4/defaults/cm.yaml
@@ -145,3 +145,8 @@ data:
         # Override nginx image to address known CVEs.
         # As of 0.48.4, chart maintainers are still using 1.19-alpine.
         tag: 1.22.0-alpine
+      nginxConfig:
+        httpSnippet: |-
+          client_max_body_size 10M;
+        serverSnippet: |-
+          client_max_body_size 10M;

--- a/services/grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.4/defaults/cm.yaml
@@ -48,6 +48,11 @@ data:
           reject_old_samples_max_age: 168h
           max_cache_freshness_per_query: 10m
           split_queries_by_interval: 15m
+          ingestion_rate_mb: 10
+          # ingestion_burst_size_mb should be set at least to the maximum logs size expected in a single push request.
+          ingestion_burst_size_mb: 10
+          per_stream_rate_limit: 10MB
+          per_stream_rate_limit_burst: 15MB
         schema_config:
           configs:
             - from: 2020-09-07

--- a/services/grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.4/defaults/cm.yaml
@@ -16,6 +16,9 @@ data:
           http_listen_port: 3100
           # info is a little too quiet.
           log_level: debug
+          grpc_server_max_recv_msg_size: 10485760
+          # grpc_server_max_send_msg_size should be set at least to the maximum logs size expected in a single push request.
+          grpc_server_max_send_msg_size: 10485760
         distributor:
           ring:
             kvstore:


### PR DESCRIPTION
Backport of #516 #520 and #521 

See the stability of fix on daily at https://a05b80baca80e4e0a91eddd0c9f4b044-1570651377.us-west-2.elb.amazonaws.com/dkp/grafana/d/ZHfDq4kVz/test-mesosphere-kommander-applications-pull-520?orgId=1&from=now-6h&to=now 
or see the output of this cmd on daily:

```
k logs -nkommander daemonset/kommander-fluent-bit 
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.d2iq.com/browse/D2IQ-91518

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
