### PR TITLE
fix: Do not move if target is the same

### DIFF
--- a/hack/release/pkg/appversion/appversion.go
+++ b/hack/release/pkg/appversion/appversion.go
@@ -49,6 +49,11 @@ func SetKommanderAppsVersion(ctx context.Context, dir string, version string) er
 		return ErrVersionNotFound
 	}
 
+	if oldVersion == version {
+		// nothing to do
+		return nil
+	}
+
 	for _, componentDir := range []string{constants.KommanderAppPath, constants.KommanderAppMgmtPath} {
 		if err := move(ctx,
 			dir,


### PR DESCRIPTION
**What problem does this PR solve?**:
Move shouldn't be performed if destination is the same as the source (the kommander version didn't change).

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
