### PR TITLE
fix: increase flux helm-controller memory/CPU limit

### DIFF
--- a/services/kommander-flux/0.31.5/templates/apps_v1_deployment_helm-controller.yaml
+++ b/services/kommander-flux/0.31.5/templates/apps_v1_deployment_helm-controller.yaml
@@ -54,10 +54,10 @@ spec:
         resources:
           limits:
             cpu: 1000m
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 100m
-            memory: 64Mi
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/services/kommander-flux/0.31.5/templates/apps_v1_deployment_helm-controller.yaml
+++ b/services/kommander-flux/0.31.5/templates/apps_v1_deployment_helm-controller.yaml
@@ -53,7 +53,7 @@ spec:
             port: healthz
         resources:
           limits:
-            cpu: 1000m
+            cpu: 2000m
             memory: 2Gi
           requests:
             cpu: 100m


### PR DESCRIPTION
**What problem does this PR solve?**:
https://mesosphere.slack.com/archives/C01LNF6KML5/p1659625343482829

Based on some upgrade testing, it looks like the helm-controller was OOMKilled during the platform upgrade. Looking at the metrics from that cluster, we need to bump the memory and CPU limits which spike heavily during the upgrade.

https://aca569ee7816f4e62a18a4e21fe8eb8e-877128020.us-west-2.elb.amazonaws.com/dkp/grafana/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-datasource=default&var-cluster=&var-namespace=kommander-flux&var-pod=helm-controller-59758cb7d8-fgdqc&orgId=1&refresh=10s&from=now-6h&to=now

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
