### PR TITLE
feat: Bump dex-controller chart to v0.6.21

### DIFF
--- a/services/dex/2.9.18/dex.yaml
+++ b/services/dex/2.9.18/dex.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: 2.9.18
+      version: 2.9.19
   interval: 15s
   install:
     remediation:


### PR DESCRIPTION
This is a backport of the following PR:

https://github.com/mesosphere/kommander-applications/pull/518



# Backport

This will backport the following commits from `main` to `release-2.3`:
 - [feat: Bump dex-controller chart to v0.6.21 (#517)](https://github.com/mesosphere/kommander-applications/pull/517)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)