### PR TITLE
feat: enable compaction in grafana-loki defaults cm

### DIFF
--- a/services/grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.4/defaults/cm.yaml
@@ -44,8 +44,7 @@ data:
             replay_memory_ceiling: 4GB
             dir: /var/loki/wal
         limits_config:
-          # TODO tried to enable retention_period but fails.
-          #retention_period: 336h
+          retention_period: 168h
           enforce_metric_name: false
           reject_old_samples: true
           reject_old_samples_max_age: 168h
@@ -76,10 +75,6 @@ data:
             s3forcepathstyle: true
         chunk_store_config:
           max_look_back_period: 0s
-        table_manager:
-          # TODO: switch to compactor retention once its supported (in 2.3.0+)
-          retention_deletes_enabled: true
-          retention_period: 336h
         query_range:
           align_queries_with_step: true
           max_retries: 5
@@ -98,8 +93,9 @@ data:
           tail_proxy_url: http://{{ include "loki.querierFullname" . }}:3100
         compactor:
           shared_store: s3
-          # TODO enable, fails config parsing
-          #retention_enabled: true
+          retention_enabled: true
+          compaction_interval: 10m # Default is 10m
+          retention_delete_delay: 2h # Default is 2h
         ruler:
           storage:
             type: local

--- a/services/project-grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.48.4/defaults/cm.yaml
@@ -40,8 +40,7 @@ data:
             replay_memory_ceiling: 4GB
             dir: /var/loki/wal
         limits_config:
-          # TODO tried to enable retention_period but fails.
-          #retention_period: 336h
+          retention_period: 168h
           enforce_metric_name: false
           reject_old_samples: true
           reject_old_samples_max_age: 168h
@@ -67,10 +66,6 @@ data:
             s3forcepathstyle: true
         chunk_store_config:
           max_look_back_period: 0s
-        table_manager:
-          # TODO: switch to compactor retention once its supported (in 2.3.0+)
-          retention_deletes_enabled: true
-          retention_period: 336h
         query_range:
           align_queries_with_step: true
           max_retries: 5
@@ -89,8 +84,9 @@ data:
           tail_proxy_url: http://{{ include "loki.querierFullname" . }}:3100
         compactor:
           shared_store: s3
-          # TODO enable, fails config parsing
-          #retention_enabled: true
+          retention_enabled: true
+          compaction_interval: 10m # Default is 10m
+          retention_delete_delay: 2h # Default is 2h
         ruler:
           storage:
             type: local


### PR DESCRIPTION
This is a backport of the following PR:

https://github.com/mesosphere/kommander-applications/pull/534



**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

Implements https://jira.d2iq.com/browse/D2IQ-92137
which also fixes https://jira.d2iq.com/browse/D2IQ-91518

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

See

https://grafana.com/docs/loki/v2.3.x/configuration/#limits_config
https://grafana.com/docs/loki/v2.3.x/configuration/#compactor_config
https://grafana.com/docs/loki/v2.3.x/operations/storage/retention/


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
