### PR TITLE
feat: Update project-grafana-loki values

### DIFF
--- a/services/grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.4/defaults/cm.yaml
@@ -136,6 +136,7 @@ data:
         size: 10Gi
 
     ruler:
+      enabled: true
       replicas: 1
       serviceLabels:
         servicemonitor.kommander.mesosphere.io/path: "metrics"

--- a/services/grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.4/defaults/cm.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -106,7 +105,7 @@ data:
               store: memberlist
           rule_path: /tmp/loki/scratch
           alertmanager_url: http://kube-prometheus-stack-alertmanager.${releaseNamespace}.svc.cluster.local:9093
-          external_url: ""
+          external_url: http://kube-prometheus-stack-alertmanager.${releaseNamespace}.svc.cluster.local:9093
 
     ingester:
       replicas: 1
@@ -136,7 +135,7 @@ data:
         size: 10Gi
 
     ruler:
-      enabled: true
+      enabled: false
       replicas: 1
       serviceLabels:
         servicemonitor.kommander.mesosphere.io/path: "metrics"
@@ -144,6 +143,9 @@ data:
       persistence:
         enabled: true
         size: 10Gi
+      # -- Directories containing rules files
+      directories:
+        grafana-loki-minio: {}
 
     gateway:
       image:

--- a/services/project-grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.48.4/defaults/cm.yaml
@@ -14,6 +14,9 @@ data:
         server:
           http_listen_port: 3100
           log_level: warn
+          grpc_server_max_recv_msg_size: 10485760
+          # grpc_server_max_send_msg_size should be set at least to the maximum logs size expected in a single push request.
+          grpc_server_max_send_msg_size: 10485760
         distributor:
           ring:
             kvstore:
@@ -46,6 +49,11 @@ data:
           reject_old_samples_max_age: 168h
           max_cache_freshness_per_query: 10m
           split_queries_by_interval: 15m
+          ingestion_rate_mb: 10
+          # ingestion_burst_size_mb should be set at least to the maximum logs size expected in a single push request.
+          ingestion_burst_size_mb: 10
+          per_stream_rate_limit: 10MB
+          per_stream_rate_limit_burst: 15MB
         schema_config:
           configs:
             - from: 2020-09-07
@@ -132,6 +140,11 @@ data:
     gateway:
       image:
         # Override nginx image to address known CVEs.
-        # As of 0.48.4, chart maintainers are still using 1.19-alpine
+        # As of 0.48.4, chart maintainers are still using 1.19-alpine.
         tag: 1.22.0-alpine
       verboseLogging: false
+      nginxConfig:
+        httpSnippet: |-
+          client_max_body_size 10M;
+        serverSnippet: |-
+          client_max_body_size 10M;


### PR DESCRIPTION
**What problem does this PR solve?**:
- ~It looks like `ruler` was meant to be enabled, but it defaults to false so we need to explicitly set it to true. This was overlooked probably because a few other components are always enabled and do not have the enabled field to set.~  Wrangled with this a bit, and kept it disabled because it probably just makes sense for a user to enable it if they actually want to add some rules to evaluate. I at least updated the fields with some working values so that if it is enabled, the user just needs to add some rules and it shouldn't error otherwise.
- Updated project-grafana-loki values to be the same as grafana-loki (except for `ruler` which was explicitely set to `enabled: false` so I left that). We probably made changes to grafana-loki and forgot to port the same changes to the project app so they got out of sync

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
