### PR TITLE
fix(loki): set flush_op_timeout to 10m

### DIFF
--- a/services/grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.4/defaults/cm.yaml
@@ -37,6 +37,7 @@ data:
           chunk_encoding: snappy
           chunk_retain_period: 1m
           max_transfer_retries: 0
+          flush_op_timeout: 10m
           wal:
             enabled: true
             flush_on_shutdown: false

--- a/services/project-grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.48.4/defaults/cm.yaml
@@ -33,6 +33,7 @@ data:
           chunk_encoding: snappy
           chunk_retain_period: 1m
           max_transfer_retries: 0
+          flush_op_timeout: 10m
           wal:
             enabled: true
             flush_on_shutdown: false


### PR DESCRIPTION
**What problem does this PR solve?**:
As a part of https://jira.d2iq.com/browse/D2IQ-91707, it was found that the `flush_op_timeout` is defaulted to 10s in Loki <2.5.0 and that was causing issues with Loki failing to startup as the object storage was down for a long time and the WAL built up so the initial flushing of the WAL was taking longer than 10s.

We should set the default here to avoid issues in the future with respect to changing Loki versions.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
