### PR TITLE
fix: `warn` log level for multiple logging stack components

### DIFF
--- a/services/fluent-bit/0.19.20/defaults/cm.yaml
+++ b/services/fluent-bit/0.19.20/defaults/cm.yaml
@@ -83,7 +83,7 @@ data:
         [SERVICE]
             Flush 1
             Daemon Off
-            Log_Level info
+            Log_Level warn
             Parsers_File parsers.conf
             Parsers_File custom_parsers.conf
             HTTP_Server On
@@ -138,7 +138,7 @@ data:
             Match audit.*
             Alias kubernetes_audit
             Labels log_source=kubernetes_audit
-            label_keys $verb,$user['username'],$objectRef['namespace'],$objectRef['resource']
+            label_keys $verb,$user['username']
             Host grafana-loki-loki-distributed-gateway.${releaseNamespace}.svc
             Port 80
             Retry_Limit 10

--- a/services/grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.4/defaults/cm.yaml
@@ -14,8 +14,7 @@ data:
         auth_enabled: false
         server:
           http_listen_port: 3100
-          # info is a little too quiet.
-          log_level: debug
+          log_level: warn
           grpc_server_max_recv_msg_size: 10485760
           # grpc_server_max_send_msg_size should be set at least to the maximum logs size expected in a single push request.
           grpc_server_max_send_msg_size: 10485760

--- a/services/project-grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.48.4/defaults/cm.yaml
@@ -13,8 +13,7 @@ data:
         auth_enabled: false
         server:
           http_listen_port: 3100
-          # info is a little too quiet.
-          log_level: debug
+          log_level: warn
         distributor:
           ring:
             kvstore:


### PR DESCRIPTION
**What problem does this PR solve?**:

We found this on soak cluster

![image](https://user-images.githubusercontent.com/2296947/184044684-ffd3b7d6-84f2-4e94-b731-5842aba9f2a4.png)

which means logging stack is generating the most amount of logs. This PR adds three changes:

1. Upgrades fluentbit log level from info to warn
2. Upgrades log level from info to warn in loki `config.server` block which applies to `querier`, `ingester` and other components.
3. Removes the `$objectRef[namespace]` reference in audit log output of fluentbit configuration.

For 3 above, this is a sample audit log:
```
tail  /var/log/kubernetes/audit/kube-apiserver-audit-2022-08-10T19-07-59.340.log -n1
.........(pretty formatted)....
{
	"kind": "Event",
	"apiVersion": "audit.k8s.io/v1",
	"level": "Metadata",
	"auditID": "dd8a547a-2c25-49f7-bd78-5337cd3b0bb2",
	"stage": "ResponseComplete",
	"requestURI": "/apis/infrastructure.cluster.x-k8s.io/v1alpha3",
	"verb": "get",
	"user": {
		"username": "system:serviceaccount:kube-system:generic-garbage-collector",
		"uid": "0202ea90-4998-42bc-9c28-83b56c858d42",
		"groups": ["system:serviceaccounts", "system:serviceaccounts:kube-system", "system:authenticated"]
	},
	"sourceIPs": ["10.0.101.86"],
	"userAgent": "kube-controller-manager/v1.23.7 (linux/amd64) kubernetes/42c05a5/system:serviceaccount:kube-system:generic-garbage-collector",
	"responseStatus": {
		"metadata": {},
		"code": 200
	},
	"requestReceivedTimestamp": "2022-08-10T19:07:59.326633Z",
	"stageTimestamp": "2022-08-10T19:07:59.339541Z",
	"annotations": {
		"authorization.k8s.io/decision": "allow",
		"authorization.k8s.io/reason": "RBAC: allowed by ClusterRoleBinding \"system:discovery\" of ClusterRole \"system:discovery\" to Group \"system:authenticated\""
	}
}
```
which we parse as
```
[OUTPUT]
            Name loki
            Match audit.*
            Alias kubernetes_audit
            Labels log_source=kubernetes_audit
            label_keys $verb,$user['username'],$objectRef['namespace'],$objectRef['resource']
            Host grafana-loki-loki-distributed-gateway.${releaseNamespace}.svc
            Port 80
            Retry_Limit 10
```
and there are no resource and namespace keys at all.... i think this varies by setting a audit policy https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/ but this is not something that we set out of the box.

because of the current setting, fluentbit keeps printing the following line:
```
[2022/08/10 22:16:15] [ warn] [output:loki:kubernetes_audit] empty record accessor key translation for pattern: $objectRef['namespace']
```
almost 10times/second and is generating a lot of noise. In this PR, we removed the reference to `objectRef` as its not present in audit logs with default configuration.

If someone creates audit policy they can also update fluentbit config to label audit logs correctly. even if they dont, the logs are still parsed and its just that they wont have labels. I think this is fine.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
