### PR TITLE
feat: Deploy resource quota with fluent-bit

### DIFF
--- a/services/fluent-bit/0.20.5/kustomization.yaml
+++ b/services/fluent-bit/0.20.5/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - fluent-bit.yaml
   - grafana-dashboards
   - grafana-dashboards-logging
+  - resource-quota.yaml

--- a/services/fluent-bit/0.20.5/resource-quota.yaml
+++ b/services/fluent-bit/0.20.5/resource-quota.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: fluent-bit-resource-quota
+  namespace: ${releaseNamespace}
+spec:
+  force: true
+  prune: true
+  wait: true
+  interval: 6h
+  retryInterval: 1m
+  path: ./services/fluent-bit/0.20.5/resource-quota
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 1m
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: substitution-vars

--- a/services/fluent-bit/0.20.5/resource-quota/resourcequota.yaml
+++ b/services/fluent-bit/0.20.5/resource-quota/resourcequota.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: fluent-bit-critical-pods
+  namespace: ${releaseNamespace}
+spec:
+  hard:
+    pods: "1G"
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+      - system-node-critical


### PR DESCRIPTION
**What problem does this PR solve?**:
Installing fluent-bit with priorityClass: system-critical-nodes on a GKE cluster resulted in these errors:
```
Events:
  Type     Reason        Age                  From                  Message
  ----     ------        ----                 ----                  -------
  Warning  FailedCreate  24s (x16 over 3m8s)  daemonset-controller  Error creating: insufficient quota to match these scopes: [{PriorityClass In [system-node-critical system-cluster-critical]}]
```
Fluent-bit fails to deploy on GKE clusters since GKE limits priority class consumption by default. See https://github.com/open-policy-agent/gatekeeper/issues/1120 for more info - we are running into the same issue with fluent-bit because we specify a priority class by default in our config. 

testing in https://github.com/mesosphere/kommander/pull/2220

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.d2iq.com/browse/D2IQ-91821

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
In 2.3.0 we documented the workaround to manually create the `ResourceQuota`. This fix here deploys that `ResourceQuota` with fluent-bit anytime the app is deployed. Downsides: this `resourcequota` will always be deployed on all types of clusters (not just GKE), and due to our app config limitations, this resource cannot be easily updated - only way to update it is to clone the gitrepo and push changes.

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
