### PR TITLE
fix: Prevent gatekeeper from ignoring the kommander namespace

### DIFF
--- a/services/gatekeeper/3.8.1/defaults/cm.yaml
+++ b/services/gatekeeper/3.8.1/defaults/cm.yaml
@@ -19,3 +19,6 @@ data:
       excludeNamespacesFromProxy: []
       namespaceSelectorForProxy: {}
       sideEffects: "None"
+    postInstall:
+      labelNamespace:
+        enabled: false


### PR DESCRIPTION
**What problem does this PR solve?**:
This disables the option of injecting an ignore label on the namespace where gatekeeper is installed (kommander). If enabled, gatekeeper ignores all policies set in the kommander namespace. This explicitly disables this behavior (we accidentally were doing this in kommander code; see https://github.com/mesosphere/kommander/pull/2173 and https://mesosphere.slack.com/archives/C02JG0RHADR/p1660852024096139?thread_ts=1660848620.702489&cid=C02JG0RHADR)

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.d2iq.com/browse/D2IQ-91794

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
