### PR TITLE
feat: Bump traefik to 10.24.0

### DIFF
--- a/services/traefik/10.9.3/traefik.yaml
+++ b/services/traefik/10.9.3/traefik.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: helm.traefik.io-traefik
         namespace: kommander-flux
-      version: "10.9.1"
+      version: "10.24.0"
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
PR created by [gh-dkp](https://github.com/mesosphere/gh-dkp/) to upgrade this application to the latest chart version.