### PR TITLE
build: Bump e2e and mergebot config versions post-2.3

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -16,7 +16,7 @@ E2E_KINDEST_IMAGE ?= "mesosphere/kind-node:v1.24.3"
 # and therefore the whole install process so we need to run the upgrade tests against an older version
 # of Kubernetes. This can be removed once the `UPGRADE_FROM_VERSION` below is Kommander >=v2.4.
 E2E_KINDEST_IMAGE_FOR_UPGRADE_TEST ?= "mesosphere/kind-node:v1.23.9"
-UPGRADE_FROM_VERSION ?= "v2.2.2-dev"
+UPGRADE_FROM_VERSION ?= "v2.3.1-dev"
 
 # (aweris): This should be a temporary workaround for v2.3.0 development. If you're still see clone test in v2.4.0
 # it means "a temporary workaround" actually means "permanent solution".

--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -10,7 +10,7 @@
     "interactive": false,
     "fix_version_map": {
       "main": "Kommander 2.4.0",
-      "release-2.3": "Kommander 2.3.0",
+      "release-2.3": "Kommander 2.3.1",
       "release-2.2": "Kommander 2.2.3",
       "release-2.1": "Kommander 2.1.3"
     },


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumps e2e upgrade from version and release-2.3 version mregebot-config post-2.3.0. Might have missed automating these in k-apps post-release bumps? But we are hoping to replace these e2e tests, so maybe we can leave that one out.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
