### PR TITLE
feat: collect Loki distributor metrics

### DIFF
--- a/services/grafana-loki/0.48.4/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.4/defaults/cm.yaml
@@ -158,3 +158,8 @@ data:
         serverSnippet: |-
           client_max_body_size 10M;
       verboseLogging: false
+
+    distributor:
+      serviceLabels:
+        servicemonitor.kommander.mesosphere.io/path: "metrics"
+        servicemonitor.kommander.mesosphere.io/port: "http"


### PR DESCRIPTION
**What problem does this PR solve?**:
While doing some Loki debugging and what not I noticed we are not collecting metrics from the distributor, this PR adds the required labels to the distributor service so it is targeted by the existing Prometheus ServiceMonitor

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
