### PR TITLE
 build: New workflow to revert k-apps ref

### DIFF
--- a/.github/workflows/kommander-revert-kapps-ref.yaml
+++ b/.github/workflows/kommander-revert-kapps-ref.yaml
@@ -1,8 +1,8 @@
-name: "Create Kommander Branch"
+name: "Revert k-apps ref"
 
 on:
  pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [closed]
 
 permissions:
   pull-requests: write
@@ -11,11 +11,10 @@ permissions:
 jobs:
   get-kapps-branch-name:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'open-kommander-pr')
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'open-kommander-pr')
     outputs:
       branch_name: ${{ steps.branch-name.outputs.branch_name }}
       escaped_branch_name: ${{ steps.escaped-branch-name.outputs.escaped_branch_name }}
-      base_branch_name: ${{ steps.base-branch-name.outputs.base_branch_name }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -24,19 +23,15 @@ jobs:
         run: echo "::set-output name=branch_name::${{ github.head_ref }}"
       - id: escaped-branch-name
         run: echo "::set-output name=escaped_branch_name::$(echo ${{ github.head_ref }} | sed -e 's/\//\\\//g')"
-      - id: base-branch-name
-        run: echo "::set-output name=base_branch_name::${{ github.base_ref }}"
       - name: Check output branch-name
         run: echo ${{ steps.branch-name.outputs.branch_name }}
       - name: Check output escaped-branch-name
         run: echo ${{ steps.escaped-branch-name.outputs.escaped_branch_name }}
-      - name: Check output base-branch-name
-        run: echo ${{ steps.base-branch-name.outputs.base_branch_name }}
 
-  create-kommander-branch:
+  update-kommander-branch:
     runs-on: ubuntu-latest
     needs: get-kapps-branch-name
-    if: contains(github.event.pull_request.labels.*.name, 'open-kommander-pr')
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'open-kommander-pr')
     steps:
       - uses: actions/checkout@v3
         with:
@@ -44,21 +39,19 @@ jobs:
           ssh-key: ${{ secrets.KOMM_PRIVATE_SSH_KEY }}
           path: 'kommander'
           fetch-depth: '0'
-      - name: Update kommander-applications ref on new branch
+      - name: Revert kommander-applications ref back to main on kommander branch
         run: |
           cd kommander
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          # Use same base as k-apps (main or release branch)
-          git checkout ${{ needs.get-kapps-branch-name.outputs.base_branch_name }}
-          # If branch already exists, do nothing
-          git show-ref --quiet --verify -- refs/remotes/origin/kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }} || {
-            git checkout -b kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
+          # If branch does not exist, do nothing
+          git show-ref --quiet --verify -- refs/remotes/origin/kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }} && {
+            git checkout kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
             # Point the kommander-applications ref to the k-apps branch
-            sed -i 's/KOMMANDER_APPLICATIONS_REF ?= main/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}/' Makefile
+            sed -i 's/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}/KOMMANDER_APPLICATIONS_REF ?= main/' Makefile
             git add Makefile
             if output=$(git status --porcelain) && [ ! -z "$output" ]; then
-              git commit -v -m "build: Point kommander-applications ref to ${{ needs.get-kapps-branch-name.outputs.branch_name }}"
+              git commit -v -m "build: Point kommander-applications ref back to main"
               git push --force-with-lease --set-upstream origin kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
             fi
           }


### PR DESCRIPTION
**What problem does this PR solve?**:
Adds a new workflow that updates the same kommander branch (created from `open-kommander-pr` label) to point the k-apps ref in the Makefile back to `main`, when the k-apps PR is merged.

I tested this on my fork of kommander-applications -- see this kommander PR that was opened and then updated: https://github.com/mesosphere/kommander/pull/2294

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.d2iq.com/browse/D2IQ-92487

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
