### PR TITLE
build: Improve kommander branch workflow

### DIFF
--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -58,7 +58,7 @@ jobs:
             sed -i 's/KOMMANDER_APPLICATIONS_REF ?= main/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}/' Makefile
             git add Makefile
             if output=$(git status --porcelain) && [ ! -z "$output" ]; then
-              git commit -v -m "build: Point kommander-applications ref to ${{ needs.get-kapps-branch-name.outputs.branch_name }}"
+              git commit -v -m "build: Update kommander-applications ref for testing"
               git push --force-with-lease --set-upstream origin kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
             fi
           }

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -45,6 +45,7 @@ jobs:
           path: 'kommander'
           fetch-depth: '0'
       - name: Update kommander-applications ref on new branch
+        id: update-ref
         run: |
           cd kommander
           git config user.name "${GITHUB_ACTOR}"
@@ -60,5 +61,15 @@ jobs:
             if output=$(git status --porcelain) && [ ! -z "$output" ]; then
               git commit -v -m "build: Update kommander-applications ref for testing"
               git push --force-with-lease --set-upstream origin kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
+              echo "::set-output name=created_new_branch::true"
             fi
           }
+      - name: Create comment
+        if: steps.update-ref.outputs.created_new_branch == 'true'
+        uses: peter-evans/create-or-update-comment@v2
+        env:
+          GH_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ✅ Created Kommander branch to test kommander-applications changes: https://github.com/mesosphere/kommander/tree/kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}


### PR DESCRIPTION
**What problem does this PR solve?**:
- Use static commit message in case the message is too long
- Add step to post a comment with link to kommander branch (next iteration can be figuring out how to get the kommander PR #)

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
