### PR TITLE
feat: Add new nvidia-gpu-operator app

### DIFF
--- a/common/helm-repositories/kustomization.yaml
+++ b/common/helm-repositories/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
   - gatekeeper.yaml
   - cert-manager.yaml
   - bitnami.yaml
+  - nvidia.yaml

--- a/common/helm-repositories/nvidia.yaml
+++ b/common/helm-repositories/nvidia.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: helm.ngc.nvidia.com-nvidia
+  namespace: kommander-flux
+spec:
+  interval: 10m
+  timeout: 1m
+  url: "${helmMirrorURL:=https://helm.ngc.nvidia.com/nvidia}"

--- a/services/nvidia-gpu-operator/1.11.1/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/1.11.1/defaults/cm.yaml
@@ -13,4 +13,4 @@ data:
     toolkit:
       version: v1.10.0-centos7
     gfd:
-      enabled: false
+      enabled: true

--- a/services/nvidia-gpu-operator/1.11.1/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/1.11.1/defaults/cm.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nvidia-gpu-operator-1.11.1-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |-
+    nfd:
+      enabled: false
+    driver:
+      enabled: false
+    toolkit:
+      version: v1.10.0-centos7
+    gfd:
+      enabled: false

--- a/services/nvidia-gpu-operator/1.11.1/defaults/kustomization.yaml
+++ b/services/nvidia-gpu-operator/1.11.1/defaults/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cm.yaml

--- a/services/nvidia-gpu-operator/1.11.1/helmrelease.yaml
+++ b/services/nvidia-gpu-operator/1.11.1/helmrelease.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: nvidia-gpu-operator-helmrelease
+  namespace: ${releaseNamespace}
+spec:
+  force: false
+  prune: true
+  wait: true
+  interval: 6h
+  retryInterval: 1m
+  path: ./services/nvidia-gpu-operator/1.11.1/helmrelease
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 1m
+  # passing releaseNamespace to 2nd level configuration files for ability to configure namespace correctly in attached clusters
+  # Using `substituteFrom` with `substitution-vars` creates 2nd level resources in `kommander` namespace instead of workspace ns
+  postBuild:
+    substitute:
+      releaseNamespace: ${releaseNamespace}

--- a/services/nvidia-gpu-operator/1.11.1/helmrelease/nvidia.yaml
+++ b/services/nvidia-gpu-operator/1.11.1/helmrelease/nvidia.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: nvidia-gpu-operator
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: gpu-operator
+      sourceRef:
+        kind: HelmRepository
+        name: helm.ngc.nvidia.com-nvidia
+        namespace: kommander-flux
+      version: v1.11.1
+  interval: 15s
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+  releaseName: nvidia-gpu-operator
+  valuesFrom:
+    - kind: ConfigMap
+      name: nvidia-gpu-operator-1.11.1-d2iq-defaults
+  targetNamespace: ${releaseNamespace}

--- a/services/nvidia-gpu-operator/1.11.1/kustomization.yaml
+++ b/services/nvidia-gpu-operator/1.11.1/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/services/nvidia-gpu-operator/metadata.yaml
+++ b/services/nvidia-gpu-operator/metadata.yaml
@@ -1,0 +1,33 @@
+displayName: NVIDIA GPU Operator
+description: NVIDIA Data Center GPU Manager (DCGM) manages and monitors NVIDIA datacentre GPUs in cluster environments.
+category:
+  - monitoring
+type: platform
+scope:
+  - workspace
+certifications:
+  - certified
+  - supported
+  - airgapped
+overview: |-
+  # Overview
+  NVIDIA Data Center GPU Manager (DCGM) is a suite of tools for managing and monitoring NVIDIA datacenter GPUs in cluster environments. It includes active health monitoring, comprehensive diagnostics, system alerts and governance policies including power and clock management.
+
+  ## Key Features
+  ### GPU Diagnostics and System Validation
+  Effectively identify failures, performance degradations, power inefficiencies and their root causes.
+
+  ### GPU Telemetry
+  Gather rich set of GPU telemetry to explain job behavior, identifying opportunities to drive utilization and efficiencies, and determining root causes of potential application performance issues.
+
+  ### Active GPU Health Monitoring
+  Use low-overhead, non-invasive health monitoring while jobs are running without impact to application behavior and performance.
+
+  ### Integration with Management Ecosystem
+  Easily deploy a DCGM based monitoring solution in a Kubernetes cluster environment. Out of the box integration with various ISV solutions such as Bright Cluster Manager, IBM Spectrum LSF and open-source tools such as Prometheus, collected.
+
+  ## More Information
+  - [developer.nvidia.com/dcgm](https://developer.nvidia.com/dcgm)
+  - [NVIDIA DCGM Documentation](https://docs.nvidia.com/datacenter/dcgm/)
+  - [NVIDIA DCGM - GitHub](https://github.com/NVIDIA/DCGM)
+icon: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMDAiIGhlaWdodD0iMzAwIj48cGF0aCBkPSJNMTE5LjA4IDExNy42NzF2LTE0LjQzM2w0LjI1NS0uMjJjMzkuNDY5LTEuMjM5IDY1LjM1OCAzMy45MTUgNjUuMzU4IDMzLjkxNXMtMjcuOTY0IDM4Ljg0Mi01Ny45NDggMzguODQyYy00LjMxNiAwLTguMTg2LS42OTktMTEuNjY1LTEuODY2VjEzMC4xNWMxNS4zNjQgMS44NTUgMTguNDUyIDguNjQyIDI3LjY4OSAyNC4wMzlsMjAuNTQ0LTE3LjMyM3MtMTQuOTk1LTE5LjY2OC00MC4yNzMtMTkuNjY4Yy0yLjc1MiAwLTUuMzg0LjE5My03Ljk2LjQ3M20wLTQ3LjY3MXYyMS41NTdhOTAuMTY1IDkwLjE2NSAwIDAgMSA0LjI1NS0uMjUzYzU0Ljg4OC0xLjg1IDkwLjY0MSA0NS4wMDcgOTAuNjQxIDQ1LjAwN3MtNDEuMDcxIDQ5Ljk0NS04My44NTkgNDkuOTQ1Yy0zLjkxOSAwLTcuNTkxLS4zNjMtMTEuMDM3LS45NzR2MTMuMzI3YzIuOTQ1LjM3NCA2LjAwNi41OTQgOS4xOTMuNTk0IDM5LjgxNiAwIDY4LjYxMS0yMC4zMzUgOTYuNDk4LTQ0LjQwMSA0LjYxOCAzLjcwNSAyMy41NDQgMTIuNzA1IDI3LjQ0MSAxNi42NTItMjYuNTE2IDIyLjE5NS04OC4zMDIgNDAuMDg2LTEyMy4zMjggNDAuMDg2LTMuMzc0IDAtNi42MjItLjIwNC05LjgwNC0uNTEydjE4LjcyN2gxNTEuMzM3VjcwSDExOS4wOHptMCAxMDMuOTA4djExLjM3M2MtMzYuODMyLTYuNTYyLTQ3LjA1NS00NC44NDctNDcuMDU1LTQ0Ljg0N3MxNy42ODctMTkuNTkxIDQ3LjA1NS0yMi43NjJ2MTIuNDc5Yy0uMDI3IDAtLjAzOC0uMDA2LS4wNjEtLjAwNi0xNS40MDgtMS44NS0yNy40NTIgMTIuNTQ1LTI3LjQ1MiAxMi41NDVzNi43NDkgMjQuMjQzIDI3LjUxMyAzMS4yMTdtLTY1LjQxMy0zNS4xMzFzMjEuODI2LTMyLjIwOCA2NS40MTMtMzUuNTM5di0xMS42OEM3MC44MDMgOTUuNDI3IDI5IDEzNi4zMSAyOSAxMzYuMzFzMjMuNjc2IDY4LjQ1MiA5MC4wOCA3NC43MTZ2LTEyLjQxOWMtNDguNzI4LTYuMTMyLTY1LjQxMy01OS44MzEtNjUuNDEzLTU5LjgzMSIgZmlsbD0iIzc3YjkwMCIvPjwvc3ZnPg==


### PR DESCRIPTION
**What problem does this PR solve?**:
Adds new `nvidia-gpu-operator` app which will be used instead of `nvidia` starting in 2.4

**The metadata.yaml file needs to be updated with new copy** --> https://jira.d2iq.com/browse/D2IQ-92963

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.d2iq.com/browse/D2IQ-92632

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
I referenced https://docs.google.com/document/d/1Jj5SU1cz4TBZ0sUnczSCxq2cZtCeWMwdmR0I9LJ9PNk/edit and used the values passed into the `helm install` command there to set our defaults cm

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
