### PR TITLE
feat: Bump helm-controller mem limits to 2Gi

### DIFF
--- a/services/kommander-flux/0.33.0/templates/apps_v1_deployment_helm-controller.yaml
+++ b/services/kommander-flux/0.33.0/templates/apps_v1_deployment_helm-controller.yaml
@@ -54,7 +54,7 @@ spec:
         resources:
           limits:
             cpu: 1000m
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 64Mi


### PR DESCRIPTION
**What problem does this PR solve?**:
![image](https://user-images.githubusercontent.com/5897740/190525578-2beafe03-9a88-4d09-9661-3f88f928276e.png)

The helm controller has been OOMKilled a few times now on the daily, there is a significant spike at the start when everything is getting deployed. This has caused some unfortunately timed apps to get stuck. Let's increase the mem limits to 2Gi and see if this prevents the OOMKills from happening so frequently

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
