### PR TITLE
chore: Switch cert-manager helmrelease order

### DIFF
--- a/services/cert-manager/1.7.1/release/release.yaml
+++ b/services/cert-manager/1.7.1/release/release.yaml
@@ -2,33 +2,6 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
-  name: cert-manager-crds
-  namespace: ${releaseNamespace}
-spec:
-  chart:
-    spec:
-      chart: cert-manager-crds
-      sourceRef:
-        kind: HelmRepository
-        name: mesosphere.github.io-charts-stable
-        namespace: kommander-flux
-      version: "v1.7.1"
-  interval: 15s
-  install:
-    remediation:
-      retries: 30
-    createNamespace: true
-    crds: CreateReplace
-  upgrade:
-    remediation:
-      retries: 30
-    crds: CreateReplace
-  releaseName: cert-manager-crds
-  targetNamespace: cert-manager
----
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
-kind: HelmRelease
-metadata:
   name: cert-manager
   namespace: ${releaseNamespace}
 spec:
@@ -51,4 +24,31 @@ spec:
     remediation:
       retries: 30
   releaseName: cert-manager
+  targetNamespace: cert-manager
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: cert-manager-crds
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: cert-manager-crds
+      sourceRef:
+        kind: HelmRepository
+        name: mesosphere.github.io-charts-stable
+        namespace: kommander-flux
+      version: "v1.7.1"
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+    createNamespace: true
+    crds: CreateReplace
+  upgrade:
+    remediation:
+      retries: 30
+    crds: CreateReplace
+  releaseName: cert-manager-crds
   targetNamespace: cert-manager


### PR DESCRIPTION
**What problem does this PR solve?**:
Changes the ordering of the helmreleases for cert-manager so that dkp-bloodhound picks up the "primary" helmrelease first (the one that points to the upstream helm chart). This is because there's no way for our automated chart bump tool to know which of the two is the main one (without doing an explicit check).

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.d2iq.com/browse/D2IQ-92952

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
