### PR TITLE
feat: post release bumps

### DIFF
--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -10,9 +10,9 @@
     "interactive": false,
     "fix_version_map": {
       "main": "Kommander 2.4.0",
-      "release-2.3": "Kommander 2.3.1",
+      "release-2.1": "Kommander 2.1.4",
       "release-2.2": "Kommander 2.2.3",
-      "release-2.1": "Kommander 2.1.3"
+      "release-2.3": "Kommander 2.3.1"
     },
     "jira_regex": "((?:COPS|D2IQ)-\\d+)"
   },


### PR DESCRIPTION
Post-release bumps are PRs created by [gh-dkp](https://github.com/mesosphere/gh-dkp/)
to adjust repositories after releases.
