### PR TITLE
build: Add workflow for stale prs

### DIFF
--- a/.github/workflows/stale-prs.yaml
+++ b/.github/workflows/stale-prs.yaml
@@ -1,0 +1,21 @@
+name: Close Stale PRs
+
+on:
+  schedule:
+    - cron: "0 15 * * 1-5"
+  workflow_dispatch: ~
+
+jobs:
+  stale:
+    name: Close Stale PRs
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          days-before-pr-stale: 30
+          days-before-pr-close: 10


### PR DESCRIPTION
**What problem does this PR solve?**:
Add workflow to mark PRs stale after 30d of inactivity, and to automatically close them if no activity is seen on it for another 10d

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
