### PR TITLE
build: Add workflow to open kommander pr

### DIFF
--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -1,0 +1,75 @@
+name: "Create Kommander Branch"
+
+on:
+ pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  get-kapps-branch-name:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'open-kommander-pr')
+    outputs:
+      branch_name: ${{ steps.branch-name.outputs.branch_name }}
+      escaped_branch_name: ${{ steps.escaped-branch-name.outputs.escaped_branch_name }}
+      base_branch_name: ${{ steps.base-branch-name.outputs.base_branch_name }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - id: branch-name
+        run: echo "::set-output name=branch_name::${{ github.head_ref }}"
+      - id: escaped-branch-name
+        run: echo "::set-output name=escaped_branch_name::$(echo ${{ github.head_ref }} | sed -e 's/\//\\\//g')"
+      - id: base-branch-name
+        run: echo "::set-output name=base_branch_name::${{ github.base_ref }}"
+      - name: Check output branch-name
+        run: echo ${{ steps.branch-name.outputs.branch_name }}
+      - name: Check output escaped-branch-name
+        run: echo ${{ steps.escaped-branch-name.outputs.escaped_branch_name }}
+      - name: Check output base-branch-name
+        run: echo ${{ steps.base-branch-name.outputs.base_branch_name }}
+
+  create-kommander-branch:
+    runs-on: ubuntu-latest
+    needs: get-kapps-branch-name
+    if: contains(github.event.pull_request.labels.*.name, 'open-kommander-pr')
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: 'mesosphere/kommander'
+          ssh-key: ${{ secrets.KOMM_PRIVATE_SSH_KEY }}
+          path: 'kommander'
+          fetch-depth: '0'
+      - name: Update kommander-applications ref on new branch
+        id: update-ref
+        run: |
+          cd kommander
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          # Use same base as k-apps (main or release branch)
+          git checkout ${{ needs.get-kapps-branch-name.outputs.base_branch_name }}
+          # If branch already exists, do nothing
+          git show-ref --quiet --verify -- refs/remotes/origin/kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }} || {
+            git checkout -b kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
+            # Point the kommander-applications ref to the k-apps branch
+            sed -i 's/KOMMANDER_APPLICATIONS_REF ?= main/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}/' Makefile
+            git add Makefile
+            if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+              git commit -v -m "build: Update kommander-applications ref for testing"
+              git push --force-with-lease --set-upstream origin kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
+              echo "::set-output name=created_new_branch::true"
+            fi
+          }
+      - name: Create comment
+        if: steps.update-ref.outputs.created_new_branch == 'true'
+        uses: peter-evans/create-or-update-comment@v2
+        env:
+          GH_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ✅ Created Kommander branch to test kommander-applications changes: https://github.com/mesosphere/kommander/tree/kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -1,8 +1,9 @@
 name: "Create Kommander Branch"
 
 on:
- pull_request:
+  pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
+  workflow_dispatch: {}
 
 permissions:
   pull-requests: write

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -56,7 +56,7 @@ jobs:
           git show-ref --quiet --verify -- refs/remotes/origin/kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }} || {
             git checkout -b kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
             # Point the kommander-applications ref to the k-apps branch
-            sed -i 's/KOMMANDER_APPLICATIONS_REF ?= main/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}/' Makefile
+            sed -i 's/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}/' Makefile
             git add Makefile
             if output=$(git status --porcelain) && [ ! -z "$output" ]; then
               git commit -v -m "build: Update kommander-applications ref for testing"

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -17,9 +17,6 @@ jobs:
       escaped_branch_name: ${{ steps.escaped-branch-name.outputs.escaped_branch_name }}
       base_branch_name: ${{ steps.base-branch-name.outputs.base_branch_name }}
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
       - id: branch-name
         run: echo "::set-output name=branch_name::${{ github.head_ref }}"
       - id: escaped-branch-name
@@ -53,14 +50,14 @@ jobs:
           # Use same base as k-apps (main or release branch)
           git checkout ${{ needs.get-kapps-branch-name.outputs.base_branch_name }}
           # If branch already exists, do nothing
-          git show-ref --quiet --verify -- refs/remotes/origin/kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }} || {
-            git checkout -b kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
+          git show-ref --quiet --verify -- refs/remotes/origin/kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }} || {
+            git checkout -b kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }}
             # Point the kommander-applications ref to the k-apps branch
             sed -i 's/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}/' Makefile
             git add Makefile
             if output=$(git status --porcelain) && [ ! -z "$output" ]; then
               git commit -v -m "build: Update kommander-applications ref for testing"
-              git push --force-with-lease --set-upstream origin kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
+              git push --force-with-lease --set-upstream origin kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }}
               echo "::set-output name=created_new_branch::true"
             fi
           }
@@ -72,4 +69,4 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ✅ Created Kommander branch to test kommander-applications changes: https://github.com/mesosphere/kommander/tree/kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
+            ✅ Created Kommander branch to test kommander-applications changes: https://github.com/mesosphere/kommander/tree/kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }}

--- a/.github/workflows/kommander-revert-kapps-ref.yaml
+++ b/.github/workflows/kommander-revert-kapps-ref.yaml
@@ -1,0 +1,57 @@
+name: "Revert k-apps ref"
+
+on:
+ pull_request:
+    types: [closed]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  get-kapps-branch-name:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'open-kommander-pr')
+    outputs:
+      branch_name: ${{ steps.branch-name.outputs.branch_name }}
+      escaped_branch_name: ${{ steps.escaped-branch-name.outputs.escaped_branch_name }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - id: branch-name
+        run: echo "::set-output name=branch_name::${{ github.head_ref }}"
+      - id: escaped-branch-name
+        run: echo "::set-output name=escaped_branch_name::$(echo ${{ github.head_ref }} | sed -e 's/\//\\\//g')"
+      - name: Check output branch-name
+        run: echo ${{ steps.branch-name.outputs.branch_name }}
+      - name: Check output escaped-branch-name
+        run: echo ${{ steps.escaped-branch-name.outputs.escaped_branch_name }}
+
+  update-kommander-branch:
+    runs-on: ubuntu-latest
+    needs: get-kapps-branch-name
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'open-kommander-pr')
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: 'mesosphere/kommander'
+          ssh-key: ${{ secrets.KOMM_PRIVATE_SSH_KEY }}
+          path: 'kommander'
+          fetch-depth: '0'
+      - name: Revert kommander-applications ref back to main on kommander branch
+        run: |
+          cd kommander
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          # If branch does not exist, do nothing
+          git show-ref --quiet --verify -- refs/remotes/origin/kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }} && {
+            git checkout kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
+            # Point the kommander-applications ref to the k-apps branch
+            sed -i 's/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}/KOMMANDER_APPLICATIONS_REF ?= main/' Makefile
+            git add Makefile
+            if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+              git commit -v -m "build: Point kommander-applications ref back to main"
+              git push --force-with-lease --set-upstream origin kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
+            fi
+          }

--- a/.github/workflows/kommander-revert-kapps-ref.yaml
+++ b/.github/workflows/kommander-revert-kapps-ref.yaml
@@ -16,9 +16,6 @@ jobs:
       branch_name: ${{ steps.branch-name.outputs.branch_name }}
       escaped_branch_name: ${{ steps.escaped-branch-name.outputs.escaped_branch_name }}
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
       - id: branch-name
         run: echo "::set-output name=branch_name::${{ github.head_ref }}"
       - id: escaped-branch-name

--- a/.github/workflows/kommander-revert-kapps-ref.yaml
+++ b/.github/workflows/kommander-revert-kapps-ref.yaml
@@ -1,8 +1,9 @@
 name: "Revert k-apps ref"
 
 on:
- pull_request:
+  pull_request:
     types: [closed]
+  workflow_dispatch: {}
 
 permissions:
   pull-requests: write
@@ -15,20 +16,25 @@ jobs:
     outputs:
       branch_name: ${{ steps.branch-name.outputs.branch_name }}
       escaped_branch_name: ${{ steps.escaped-branch-name.outputs.escaped_branch_name }}
+      base_branch_name: ${{ steps.base-branch-name.outputs.base_branch_name }}
     steps:
       - id: branch-name
         run: echo "::set-output name=branch_name::${{ github.head_ref }}"
       - id: escaped-branch-name
         run: echo "::set-output name=escaped_branch_name::$(echo ${{ github.head_ref }} | sed -e 's/\//\\\//g')"
+      - id: base-branch-name
+        run: echo "::set-output name=base_branch_name::${{ github.base_ref }}"
       - name: Check output branch-name
         run: echo ${{ steps.branch-name.outputs.branch_name }}
       - name: Check output escaped-branch-name
         run: echo ${{ steps.escaped-branch-name.outputs.escaped_branch_name }}
+      - name: Check output base-branch-name
+        run: echo ${{ steps.base-branch-name.outputs.base_branch_name }}
 
   update-kommander-branch:
     runs-on: ubuntu-latest
     needs: get-kapps-branch-name
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'open-kommander-pr')
+    if: success()
     steps:
       - uses: actions/checkout@v3
         with:
@@ -36,19 +42,19 @@ jobs:
           ssh-key: ${{ secrets.KOMM_PRIVATE_SSH_KEY }}
           path: 'kommander'
           fetch-depth: '0'
-      - name: Revert kommander-applications ref back to main on kommander branch
+      - name: Revert kommander-applications ref back to ${{ needs.get-kapps-branch-name.outputs.base_branch_name }} on kommander branch
         run: |
           cd kommander
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           # If branch does not exist, do nothing
-          git show-ref --quiet --verify -- refs/remotes/origin/kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }} && {
-            git checkout kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
+          git show-ref --quiet --verify -- refs/remotes/origin/kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }} && {
+            git checkout kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }}
             # Point the kommander-applications ref to the k-apps branch
-            sed -i 's/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}/KOMMANDER_APPLICATIONS_REF ?= main/' Makefile
+            sed -i 's/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/' Makefile
             git add Makefile
             if output=$(git status --porcelain) && [ ! -z "$output" ]; then
-              git commit -v -m "build: Point kommander-applications ref back to main"
-              git push --force-with-lease --set-upstream origin kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
+              git commit -v -m "build: Point kommander-applications ref back to ${{ needs.get-kapps-branch-name.outputs.base_branch_name }}"
+              git push --force-with-lease --set-upstream origin kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }}
             fi
           }


### PR DESCRIPTION
**What problem does this PR solve?**:
Backport the new workflows to create kommander branch if pr is labeled, and revert the k-apps ref when pr is closed

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
