### PR TITLE
build: Improve workflows to support release branches

### DIFF
--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -56,7 +56,7 @@ jobs:
           git show-ref --quiet --verify -- refs/remotes/origin/kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }} || {
             git checkout -b kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
             # Point the kommander-applications ref to the k-apps branch
-            sed -i 's/KOMMANDER_APPLICATIONS_REF ?= main/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}/' Makefile
+            sed -i 's/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}/' Makefile
             git add Makefile
             if output=$(git status --porcelain) && [ ! -z "$output" ]; then
               git commit -v -m "build: Update kommander-applications ref for testing"

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -53,14 +53,14 @@ jobs:
           # Use same base as k-apps (main or release branch)
           git checkout ${{ needs.get-kapps-branch-name.outputs.base_branch_name }}
           # If branch already exists, do nothing
-          git show-ref --quiet --verify -- refs/remotes/origin/kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }} || {
-            git checkout -b kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
+          git show-ref --quiet --verify -- refs/remotes/origin/kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }} || {
+            git checkout -b kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }}
             # Point the kommander-applications ref to the k-apps branch
             sed -i 's/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}/' Makefile
             git add Makefile
             if output=$(git status --porcelain) && [ ! -z "$output" ]; then
               git commit -v -m "build: Update kommander-applications ref for testing"
-              git push --force-with-lease --set-upstream origin kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
+              git push --force-with-lease --set-upstream origin kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }}
               echo "::set-output name=created_new_branch::true"
             fi
           }
@@ -72,4 +72,4 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ✅ Created Kommander branch to test kommander-applications changes: https://github.com/mesosphere/kommander/tree/kapps/${{ needs.get-kapps-branch-name.outputs.branch_name }}
+            ✅ Created Kommander branch to test kommander-applications changes: https://github.com/mesosphere/kommander/tree/kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }}

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -17,9 +17,6 @@ jobs:
       escaped_branch_name: ${{ steps.escaped-branch-name.outputs.escaped_branch_name }}
       base_branch_name: ${{ steps.base-branch-name.outputs.base_branch_name }}
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
       - id: branch-name
         run: echo "::set-output name=branch_name::${{ github.head_ref }}"
       - id: escaped-branch-name

--- a/.github/workflows/kommander-revert-kapps-ref.yaml
+++ b/.github/workflows/kommander-revert-kapps-ref.yaml
@@ -16,9 +16,6 @@ jobs:
       branch_name: ${{ steps.branch-name.outputs.branch_name }}
       escaped_branch_name: ${{ steps.escaped-branch-name.outputs.escaped_branch_name }}
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
       - id: branch-name
         run: echo "::set-output name=branch_name::${{ github.head_ref }}"
       - id: escaped-branch-name


### PR DESCRIPTION
**What problem does this PR solve?**:
Improve workflows to support release branches, not just changes against `main`
- Instead of hardcoding the k-apps ref to `main` to sub in the Makefile, should use the base branch
- Include base branch in kommander branch name, to be used to create kommander PRs against (instead of creating them all against `main` -- kommander workflow updates: https://github.com/mesosphere/kommander/pull/2357)

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
