### PR TITLE
[release-2.2][BACKPORT] feat: Add post-release command

### DIFF
--- a/hack/release/cmd/postrelease/postrelease.go
+++ b/hack/release/cmd/postrelease/postrelease.go
@@ -1,0 +1,54 @@
+package postrelease
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/chartversion"
+	"github.com/spf13/cobra"
+)
+
+var Cmd *cobra.Command //nolint:gochecknoglobals // Cobra commands are global.
+
+const (
+	versionFlagName = "version"
+	repoFlagName    = "repo"
+)
+
+func init() { //nolint:gochecknoinits // Initializing cobra application.
+	Cmd = &cobra.Command{
+		Use:   "post-release",
+		Short: "Handles post-release tasks for kommander-applications (i.e. updating Kommander chart versions)",
+		Args:  cobra.MaximumNArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			chartVersion, err := semver.NewVersion(Cmd.Flag(versionFlagName).Value.String())
+			if err != nil {
+				return fmt.Errorf("cannot parse given version: %w", err)
+			}
+			kommanderApplicationsRepo := Cmd.Flag(repoFlagName).Value.String()
+			if _, err := os.Stat(kommanderApplicationsRepo); os.IsNotExist(err) {
+				return err
+			}
+
+			if err := chartversion.UpdateChartVersions(kommanderApplicationsRepo, chartVersion.Original()); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Updated Kommander chart version to %s", chartVersion)
+			return nil
+		},
+	}
+	Cmd.Flags().String(versionFlagName, "", "the new Kommander chart version")
+	Cmd.Flags().String(repoFlagName, "", "the path to the local kommander-applications repository to modify")
+
+	err := Cmd.MarkFlagRequired(versionFlagName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = Cmd.MarkFlagRequired(repoFlagName)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/hack/release/cmd/prerelease/prerelease.go
+++ b/hack/release/cmd/prerelease/prerelease.go
@@ -4,22 +4,16 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
-	"strings"
 
-	"github.com/drone/envsubst"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/chartversion"
 	"github.com/spf13/cobra"
 )
 
 var Cmd *cobra.Command //nolint:gochecknoglobals // Cobra commands are global.
 
 const (
-	versionFlagName               = "version"
-	repoFlagName                  = "repo"
-	kommanderChartVersionTemplate = "${kommanderChartVersion:=%s}"
-
-	kommanderHelmReleasePathPattern        = "./services/kommander/*/kommander.yaml"
-	kommanderAppMgmtHelmReleasePathPattern = "./services/kommander-appmanagement/*/kommander-appmanagement.yaml"
+	versionFlagName = "version"
+	repoFlagName    = "repo"
 )
 
 func init() { //nolint:gochecknoinits // Initializing cobra application.
@@ -33,8 +27,8 @@ func init() { //nolint:gochecknoinits // Initializing cobra application.
 			if _, err := os.Stat(kommanderApplicationsRepo); os.IsNotExist(err) {
 				return err
 			}
-			fullChartVersion := fmt.Sprintf(kommanderChartVersionTemplate, chartVersion)
-			err := updateChartVersions(kommanderApplicationsRepo, fullChartVersion)
+
+			err := chartversion.UpdateChartVersions(kommanderApplicationsRepo, chartVersion)
 			if err != nil {
 				return err
 			}
@@ -54,48 +48,4 @@ func init() { //nolint:gochecknoinits // Initializing cobra application.
 	if err != nil {
 		log.Fatal(err)
 	}
-}
-
-func updateChartVersions(kommanderApplicationsRepo, chartVersion string) error {
-	kommanderHelmReleasePaths := []string{kommanderHelmReleasePathPattern, kommanderAppMgmtHelmReleasePathPattern}
-	for _, helmReleasePath := range kommanderHelmReleasePaths {
-		// Find the HelmRelease
-		matches, err := filepath.Glob(filepath.Join(kommanderApplicationsRepo, helmReleasePath))
-		if err != nil {
-			return err
-		}
-		if len(matches) == 0 {
-			return fmt.Errorf("no matches found for HelmRelease path %s (verify the kommander-applications repo path is correct)", helmReleasePath)
-		}
-		if len(matches) > 1 {
-			return fmt.Errorf("found > 1 match for HelmRelease path %s (there should only be one match)", helmReleasePath)
-		}
-		helmReleaseFilePath := matches[0]
-
-		// Update the kommanderChartVersion value
-		parsedFile, err := envsubst.ParseFile(helmReleaseFilePath)
-		if err != nil {
-			return err
-		}
-		subVars := map[string]string{
-			"kommanderChartVersion": chartVersion,
-			"releaseNamespace":      "${releaseNamespace}",
-		}
-		updatedFile, err := parsedFile.Execute(func(s string) string {
-			return subVars[s]
-		})
-		if err != nil {
-			return err
-		}
-
-		if !strings.Contains(updatedFile, chartVersion) {
-			return fmt.Errorf("failed to update Kommander HelmRelease chart version")
-		}
-
-		err = os.WriteFile(helmReleaseFilePath, []byte(updatedFile), 0644)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/hack/release/cmd/root.go
+++ b/hack/release/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/mesosphere/kommander-applications/hack/release/cmd/postrelease"
 	"github.com/mesosphere/kommander-applications/hack/release/cmd/prerelease"
 )
 
@@ -14,6 +15,7 @@ var rootCmd *cobra.Command //nolint:gochecknoglobals // Cobra commands are globa
 func init() { //nolint:gochecknoinits // Initializing cobra application.
 	rootCmd = &cobra.Command{}
 	rootCmd.AddCommand(prerelease.Cmd)
+	rootCmd.AddCommand(postrelease.Cmd)
 }
 
 func Execute(ctx context.Context) {

--- a/hack/release/go.mod
+++ b/hack/release/go.mod
@@ -3,6 +3,7 @@ module github.com/mesosphere/kommander-applications/hack/release
 go 1.18
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/drone/envsubst v1.0.3
 	github.com/fluxcd/helm-controller/api v0.22.1
 	github.com/otiai10/copy v1.7.0

--- a/hack/release/go.sum
+++ b/hack/release/go.sum
@@ -47,6 +47,8 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/hack/release/pkg/chartversion/chartversion.go
+++ b/hack/release/pkg/chartversion/chartversion.go
@@ -1,0 +1,62 @@
+package chartversion
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/drone/envsubst"
+)
+
+const (
+	kommanderChartVersionTemplate          = "${kommanderChartVersion:=%s}"
+	kommanderHelmReleasePathPattern        = "./services/kommander/*/kommander.yaml"
+	kommanderAppMgmtHelmReleasePathPattern = "./services/kommander-appmanagement/*/kommander-appmanagement.yaml"
+)
+
+func UpdateChartVersions(kommanderApplicationsRepo, chartVersion string) error {
+	chartVersion = fmt.Sprintf(kommanderChartVersionTemplate, chartVersion)
+
+	kommanderHelmReleasePaths := []string{kommanderHelmReleasePathPattern, kommanderAppMgmtHelmReleasePathPattern}
+	for _, helmReleasePath := range kommanderHelmReleasePaths {
+		// Find the HelmRelease
+		matches, err := filepath.Glob(filepath.Join(kommanderApplicationsRepo, helmReleasePath))
+		if err != nil {
+			return err
+		}
+		if len(matches) == 0 {
+			return fmt.Errorf("no matches found for HelmRelease path %s (verify the kommander-applications repo path is correct)", helmReleasePath)
+		}
+		if len(matches) > 1 {
+			return fmt.Errorf("found > 1 match for HelmRelease path %s (there should only be one match)", helmReleasePath)
+		}
+		helmReleaseFilePath := matches[0]
+
+		// Update the kommanderChartVersion value
+		parsedFile, err := envsubst.ParseFile(helmReleaseFilePath)
+		if err != nil {
+			return err
+		}
+		subVars := map[string]string{
+			"kommanderChartVersion": chartVersion,
+			"releaseNamespace":      "${releaseNamespace}",
+		}
+		updatedFile, err := parsedFile.Execute(func(s string) string {
+			return subVars[s]
+		})
+		if err != nil {
+			return err
+		}
+
+		if !strings.Contains(updatedFile, chartVersion) {
+			return fmt.Errorf("failed to update Kommander HelmRelease chart version")
+		}
+
+		err = os.WriteFile(helmReleaseFilePath, []byte(updatedFile), 0644)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/hack/release/pkg/chartversion/chartversion_test.go
+++ b/hack/release/pkg/chartversion/chartversion_test.go
@@ -1,4 +1,4 @@
-package prerelease
+package chartversion
 
 import (
 	"fmt"
@@ -25,8 +25,8 @@ func TestUpdateChartVersionsSuccessfully(t *testing.T) {
 	err = cp.Copy(rootDir, tmpDir)
 	assert.Nil(t, err)
 
-	updateToVersion := fmt.Sprintf(kommanderChartVersionTemplate, "v1.0.0")
-	err = updateChartVersions(tmpDir, updateToVersion)
+	updateToVersion := "v1.0.0"
+	err = UpdateChartVersions(tmpDir, updateToVersion)
 	assert.Nil(t, err)
 
 	kommanderHelmReleasePaths := []string{kommanderHelmReleasePathPattern, kommanderAppMgmtHelmReleasePathPattern}
@@ -63,7 +63,10 @@ func TestUpdateChartVersionsSuccessfully(t *testing.T) {
 			// Validate that .spec.chart.spec.version is the only field that changes
 			assert.Equal(t, []string{"Spec", "Chart", "Spec", "Version"}, change.Path, "expected .spec.chart.spec.version to be the only field that changed in the Kommander HelmRelease")
 			// Validate that the updated version is what we expect
-			assert.Equal(t, updateToVersion, change.To, "expected the chart version to be updated to %s, but got %s", updateToVersion, change.To)
+			assert.Equal(t,
+				fmt.Sprintf(kommanderChartVersionTemplate, updateToVersion),
+				change.To,
+				"expected the chart version to be updated to %s, but got %s", updateToVersion, change.To)
 		}
 	}
 }
@@ -86,7 +89,7 @@ func TestUpdateChartVersionsPathChanged(t *testing.T) {
 	err = os.Rename(matches[0], filepath.Join(filepath.Dir(matches[0]), "test.yaml"))
 	assert.Nil(t, err)
 
-	err = updateChartVersions(tmpDir, updateToVersion)
+	err = UpdateChartVersions(tmpDir, updateToVersion)
 	assert.Error(t, err, "expected chart version update to fail as the filename changed")
 }
 
@@ -119,6 +122,6 @@ func TestUpdateChartVersionsVersionFormatChanged(t *testing.T) {
 	err = os.WriteFile(matches[0], []byte(updatedFile), 0644)
 	assert.Nil(t, err)
 
-	err = updateChartVersions(tmpDir, updateToVersion)
+	err = UpdateChartVersions(tmpDir, updateToVersion)
 	assert.Error(t, err, "expected chart version update to fail as the chart version was changed to something unexpected")
 }


### PR DESCRIPTION
This is a backport of the following PR:

https://github.com/mesosphere/kommander-applications/pull/513

Depends on #511


**What problem does this PR solve?**:

Ref. https://d2iq.atlassian.net/browse/D2IQ-92812?atlOrigin=eyJpIjoiZTQ1Y2I3NTNkN2UzNGU0Zjg2MDM4N2E0OTQ0NjRkMTgiLCJwIjoiaiJ9

**Which issue(s) does this PR fix?**:
- https://jira.d2iq.com/browse/D2IQ-91716

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [x] No License Change (or NA).
