### PR TITLE
[release-2.2][BACKPORT] feat: Change kommander apps variable names

### DIFF
--- a/hack/release/cmd/postrelease/postrelease.go
+++ b/hack/release/cmd/postrelease/postrelease.go
@@ -35,6 +35,26 @@ func init() { //nolint:gochecknoinits // Initializing cobra application.
 			if err := chartversion.UpdateChartVersions(kommanderApplicationsRepo, chartVersion.Original()); err != nil {
 				return err
 			}
+<<<<<<< HEAD
+=======
+
+			if err := appversion.SetKommanderAppsVersion(
+				cmd.Context(),
+				kommanderApplicationsRepo,
+				chartVersionToAppVersion(chartVersion),
+			); err != nil {
+				return err
+			}
+
+			if _, err := appversion.ReplaceContent(
+				cmd.Context(),
+				kommanderApplicationsRepo,
+				chartVersionToAppVersion(chartVersion),
+			); err != nil {
+				return err
+			}
+
+>>>>>>> 4049909... feat: Change kommander apps variable names
 			fmt.Fprintf(cmd.OutOrStdout(), "Updated Kommander chart version to %s", chartVersion)
 			return nil
 		},

--- a/hack/release/pkg/appversion/appversion.go
+++ b/hack/release/pkg/appversion/appversion.go
@@ -1,0 +1,169 @@
+package appversion
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/constants"
+)
+
+var (
+	ErrVersionNotFound = errors.New("cannot detect existing kommander app version")
+
+	// kommander-0.4.0-d2iq-defaults
+	// kommander-0.4.0-overrides
+	varNames = regexp.MustCompile(
+		`(?P<prefix>kommander(-appmanagement)?-)` +
+			constants.SemverRegexp +
+			`(?P<suffix>(-d2iq-defaults)|(-overrides))`,
+	)
+)
+
+func SetKommanderAppsVersion(ctx context.Context, dir string, version string) error {
+	kommanderPath := filepath.Join(dir, constants.KommanderAppPath)
+	dirs, err := os.ReadDir(kommanderPath)
+	if err != nil {
+		return err
+	}
+
+	var oldVersion string
+	for _, d := range dirs {
+		if d.IsDir() {
+			oldVersion = d.Name()
+			break
+		}
+	}
+
+	if oldVersion == "" {
+		return ErrVersionNotFound
+	}
+
+	for _, componentDir := range []string{constants.KommanderAppPath, constants.KommanderAppMgmtPath} {
+		if err := move(ctx,
+			dir,
+			filepath.Join(componentDir, oldVersion),
+			filepath.Join(componentDir, version),
+		); err != nil {
+			return fmt.Errorf("error while moving directories: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ReplaceContent replaces version inside files
+func ReplaceContent(ctx context.Context, dir, version string) (int, error) {
+	kommanderPath := filepath.Clean(constants.KommanderAppPath)
+
+	changes := 0
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, _ error) error {
+		relPath, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+
+		if relPath == "." {
+			return nil
+		}
+
+		if d.IsDir() {
+			if !strings.HasPrefix(kommanderPath, relPath) && !strings.HasPrefix(relPath, kommanderPath) {
+				return filepath.SkipDir
+			}
+		}
+
+		if !d.Type().IsRegular() || filepath.Ext(d.Name()) != ".yaml" {
+			return nil
+		}
+
+		newChanges, err := replaceContentInFile(ctx, path, version)
+		changes += newChanges
+
+		return err
+	})
+
+	return changes, err
+}
+
+func replaceContentInFile(ctx context.Context, file string, version string) (int, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	fscanner := bufio.NewScanner(f)
+	output := &bytes.Buffer{}
+
+	changes := 0
+	for fscanner.Scan() {
+		text := fscanner.Text()
+
+		newText := varNames.ReplaceAllStringFunc(text, func(match string) string {
+			newValue, ok := replaceInString(match, version)
+			if ok {
+				changes++
+				return newValue
+			}
+			return match
+		})
+
+		fmt.Fprintln(output, newText)
+	}
+
+	f.Close()
+
+	if changes > 0 {
+		f, err = os.Create(file)
+		if err != nil {
+			return 0, err
+		}
+		defer f.Close()
+
+		_, err = io.Copy(f, output)
+		return changes, err
+	}
+
+	return changes, nil
+}
+
+func move(ctx context.Context, dir, oldVersion, newVersion string) error {
+	cmd := exec.CommandContext(ctx,
+		"git",
+		"mv",
+		oldVersion,
+		newVersion,
+	)
+	cmd.Dir = dir
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("git mv command failed: %s", string(output))
+		return err
+	}
+
+	return nil
+}
+
+func replaceInString(input, replace string) (string, bool) {
+	prefixIndex := varNames.SubexpIndex("prefix")
+	suffixIndex := varNames.SubexpIndex("suffix")
+
+	match := varNames.FindStringSubmatch(input)
+	if len(match) < suffixIndex {
+		return "", false
+	}
+
+	return match[prefixIndex] + replace + match[suffixIndex], true
+}

--- a/hack/release/pkg/appversion/appversion_test.go
+++ b/hack/release/pkg/appversion/appversion_test.go
@@ -1,0 +1,83 @@
+package appversion
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMove(t *testing.T) {
+	dir := fetchRepo(t)
+
+	newVersion := "0.99.99"
+	err := SetKommanderAppsVersion(context.Background(), dir, newVersion)
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(dir, constants.KommanderAppPath, newVersion))
+	assert.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dir, constants.KommanderAppMgmtPath, newVersion))
+	assert.NoError(t, err)
+}
+
+func TestReplaceContent(t *testing.T) {
+	dir := fetchRepo(t)
+	changes, err := ReplaceContent(context.Background(), dir, "0.99.99")
+	require.NoError(t, err)
+	assert.Equal(t, 5, changes)
+}
+
+func fetchRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	cmd := exec.Command("git", "clone", strings.Repeat("../", 4), dir)
+	require.NoError(t, cmd.Run())
+
+	return dir
+}
+
+func TestRegexps(t *testing.T) {
+	prefixIndex := varNames.SubexpIndex("prefix")
+	suffixIndex := varNames.SubexpIndex("suffix")
+
+	cases := []struct {
+		input  string
+		prefix string
+		suffix string
+	}{
+		{
+			input:  "kommander-0.4.0-d2iq-defaults",
+			prefix: "kommander-",
+			suffix: "-d2iq-defaults",
+		},
+		{
+			input:  "kommander-0.4.0-overrides",
+			prefix: "kommander-",
+			suffix: "-overrides",
+		},
+		{
+			input:  "kommander-appmanagement-0.4.0-d2iq-defaults",
+			prefix: "kommander-appmanagement-",
+			suffix: "-d2iq-defaults",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			result := varNames.FindStringSubmatch(c.input)
+			require.GreaterOrEqual(t, len(result), suffixIndex)
+			assert.Equal(t, c.prefix, result[prefixIndex])
+			assert.Equal(t, c.suffix, result[suffixIndex])
+
+			reconstructed := result[prefixIndex] + "0.4.0" + result[suffixIndex]
+			assert.Equal(t, c.input, reconstructed)
+		})
+	}
+}

--- a/hack/release/pkg/constants/constants.go
+++ b/hack/release/pkg/constants/constants.go
@@ -1,0 +1,9 @@
+package constants
+
+const (
+	KommanderAppPath     = "./services/kommander/"
+	KommanderAppMgmtPath = "./services/kommander-appmanagement/"
+
+	// SemverRegexp validates any semver (taken verbatim from semver specs).
+	SemverRegexp = `v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?` //nolint:lll // it's not readable anyway
+)


### PR DESCRIPTION
This is a backport of the following PR:

https://github.com/mesosphere/kommander-applications/pull/515



**What problem does this PR solve?**:
Change content of kommander apps files

**Which issue(s) does this PR fix?**:
https://jira.d2iq.com/browse/D2IQ-91716


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
Before merging, conflicts in the following files need to be resolved: 
hack/release/pkg/appversion/appversion.go
hack/release/cmd/postrelease/postrelease.go
hack/release/pkg/constants/constants.go
hack/release/pkg/appversion/appversion_test.go
