### PR TITLE
[release-2.2][BACKPORT] feat: Move kommander apps into a new directory

### DIFF
--- a/hack/release/cmd/postrelease/postrelease.go
+++ b/hack/release/cmd/postrelease/postrelease.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/appversion"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/chartversion"
 	"github.com/spf13/cobra"
 )
@@ -35,6 +36,15 @@ func init() { //nolint:gochecknoinits // Initializing cobra application.
 			if err := chartversion.UpdateChartVersions(kommanderApplicationsRepo, chartVersion.Original()); err != nil {
 				return err
 			}
+
+			if err := appversion.SetKommanderAppsVersion(
+				cmd.Context(),
+				kommanderApplicationsRepo,
+				chartVersionToAppVersion(chartVersion),
+			); err != nil {
+				return err
+			}
+
 			fmt.Fprintf(cmd.OutOrStdout(), "Updated Kommander chart version to %s", chartVersion)
 			return nil
 		},
@@ -51,4 +61,8 @@ func init() { //nolint:gochecknoinits // Initializing cobra application.
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func chartVersionToAppVersion(ver *semver.Version) string {
+	return fmt.Sprintf("0.%d.%d", ver.Minor(), ver.Patch())
 }

--- a/hack/release/pkg/appversion/appversion.go
+++ b/hack/release/pkg/appversion/appversion.go
@@ -1,0 +1,65 @@
+package appversion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/constants"
+)
+
+var ErrVersionNotFound = errors.New("cannot detect existing kommander app version")
+
+func SetKommanderAppsVersion(ctx context.Context, dir string, version string) error {
+	kommanderPath := filepath.Join(dir, constants.KommanderAppPath)
+	dirs, err := os.ReadDir(kommanderPath)
+	if err != nil {
+		return err
+	}
+
+	var oldVersion string
+	for _, d := range dirs {
+		if d.IsDir() {
+			oldVersion = d.Name()
+			break
+		}
+	}
+
+	if oldVersion == "" {
+		return ErrVersionNotFound
+	}
+
+	for _, componentDir := range []string{constants.KommanderAppPath, constants.KommanderAppMgmtPath} {
+		if err := move(ctx,
+			dir,
+			filepath.Join(componentDir, oldVersion),
+			filepath.Join(componentDir, version),
+		); err != nil {
+			return fmt.Errorf("error while moving directories: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func move(ctx context.Context, dir, oldVersion, newVersion string) error {
+	cmd := exec.CommandContext(ctx,
+		"git",
+		"mv",
+		oldVersion,
+		newVersion,
+	)
+	cmd.Dir = dir
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("git mv command failed: %s", string(output))
+		return err
+	}
+
+	return nil
+}

--- a/hack/release/pkg/appversion/appversion_test.go
+++ b/hack/release/pkg/appversion/appversion_test.go
@@ -1,0 +1,29 @@
+package appversion
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMove(t *testing.T) {
+	dir := t.TempDir()
+	cmd := exec.Command("git", "clone", strings.Repeat("../", 4), dir)
+	require.NoError(t, cmd.Run())
+
+	newVersion := "0.99.99"
+	err := SetKommanderAppsVersion(context.Background(), dir, newVersion)
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(dir, constants.KommanderAppPath, newVersion))
+	assert.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dir, constants.KommanderAppMgmtPath, newVersion))
+	assert.NoError(t, err)
+}

--- a/hack/release/pkg/chartversion/chartversion.go
+++ b/hack/release/pkg/chartversion/chartversion.go
@@ -7,12 +7,14 @@ import (
 	"strings"
 
 	"github.com/drone/envsubst"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/constants"
 )
 
-const (
-	kommanderChartVersionTemplate          = "${kommanderChartVersion:=%s}"
-	kommanderHelmReleasePathPattern        = "./services/kommander/*/kommander.yaml"
-	kommanderAppMgmtHelmReleasePathPattern = "./services/kommander-appmanagement/*/kommander-appmanagement.yaml"
+const kommanderChartVersionTemplate = "${kommanderChartVersion:=%s}"
+
+var (
+	kommanderHelmReleasePathPattern        = filepath.Join(constants.KommanderAppPath, "*/kommander.yaml")
+	kommanderAppMgmtHelmReleasePathPattern = filepath.Join(constants.KommanderAppMgmtPath, "*/kommander-appmanagement.yaml")
 )
 
 func UpdateChartVersions(kommanderApplicationsRepo, chartVersion string) error {

--- a/hack/release/pkg/constants/constants.go
+++ b/hack/release/pkg/constants/constants.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	KommanderAppPath     = "./services/kommander/"
+	KommanderAppMgmtPath = "./services/kommander-appmanagement/"
+)


### PR DESCRIPTION
This is a backport of the following PR:

https://github.com/mesosphere/kommander-applications/pull/514



Depends on #513

**What problem does this PR solve?**:
Moving kommander apps to new directories

**Which issue(s) does this PR fix?**:
https://jira.d2iq.com/browse/D2IQ-91716


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [x] No License Change (or NA).
