### PR TITLE
chore: Bump DKP Insights to v0.3.0-beta.1

### DIFF
--- a/services/dkp-insights-management/0.3.0/defaults/cm.yaml
+++ b/services/dkp-insights-management/0.3.0/defaults/cm.yaml
@@ -9,7 +9,7 @@ data:
     image:
       registry: "docker.io"
       repository: "mesosphere/insights-management"
-      tag: "v0.3.0-dev"
+      tag: "v0.3.0-beta.1"
       imagePullPolicy: "IfNotPresent"
     managementCM:
       insightsTTL: 72h

--- a/services/dkp-insights-management/0.3.0/helmrelease/helmrelease.yaml
+++ b/services/dkp-insights-management/0.3.0/helmrelease/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-dkp-insights-charts-management
         namespace: kommander-flux
-      version: v0.3.0-dev
+      version: v0.3.0-beta.1
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:

Set DKP Insights Management to use `v0.3.0-beta.1` charts and images for the Beta release.

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [X] No License Change (or NA).
