### PR TITLE
fix: explicitly set null for the sc

### DIFF
--- a/services/rook-ceph-cluster/1.10.1/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.10.1/defaults/cm.yaml
@@ -30,7 +30,7 @@ data:
         volumeClaimTemplate:
           spec:
             # Use the default storage class configured in cluster.
-            storageClassName: ""
+            storageClassName: null
             volumeMode: FileSystem
             resources:
               requests:
@@ -82,7 +82,7 @@ data:
                     requests:
                       storage: 20Gi
                   # Use the default storage class configured in cluster.
-                  storageClassName: ""
+                  storageClassName: null
                   # OSD Requires Block storage.
                   volumeMode: Block
                   accessModes:

--- a/services/rook-ceph-cluster/1.10.1/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.10.1/defaults/cm.yaml
@@ -30,7 +30,7 @@ data:
         volumeClaimTemplate:
           spec:
             # Use the default storage class configured in cluster.
-            storageClassName: null
+            # not setting storageClass to let it fall to environment default
             volumeMode: FileSystem
             resources:
               requests:
@@ -82,7 +82,7 @@ data:
                     requests:
                       storage: 20Gi
                   # Use the default storage class configured in cluster.
-                  storageClassName: null
+                  # not setting storageClass to let it fall to environment default
                   # OSD Requires Block storage.
                   volumeMode: Block
                   accessModes:


### PR DESCRIPTION
**What problem does this PR solve?**:
to make both linter and ceph happy

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
encountered this problem in CI, where the pvc of s3 bucket fails to bound due to storageclass being `""`

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [x] No License Change (or NA).
