### PR TITLE
feat: `ObjectBucketClaim`s from `rook-ceph-cluster` service

### DIFF
--- a/services/rook-ceph-cluster/1.10.3/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.10.3/defaults/cm.yaml
@@ -136,3 +136,26 @@ data:
       # TODO(takirala): enable monitoring
       enabled: false
       createPrometheusRules: false
+
+    #################################################################
+    ## BEGIN DKP specific config overrides                         ##
+    ## This is added as a workaround to use the same configmap for ##
+    ## both rook-ceph-cluster & object-bucket-claims helmreleases. ##
+    #################################################################
+    dkp:
+      velero:
+        enabled: true
+        bucketName: dkp-velero
+        storageClassName: dkp-object-store
+        additionalConfig:
+          maxSize: "10G"
+      grafana-loki:
+        enabled: true
+        bucketName: dkp-loki
+        storageClassName: dkp-object-store
+        additionalConfig:
+          # maxObjects: "1000"
+          maxSize: "50G"
+    #################################################################
+    ## END of dkp specific config overrides                        ##
+    #################################################################

--- a/services/rook-ceph-cluster/1.10.3/helmrelease/dashboard-cm.yaml
+++ b/services/rook-ceph-cluster/1.10.3/helmrelease/dashboard-cm.yaml
@@ -7,7 +7,7 @@ metadata:
     "kommander.d2iq.io/application": "rook-ceph-cluster"
 data:
   name: "Rook Ceph Cluster"
-  dashboardLink: "/dkp/kommander/ceph-dashboard"
+  dashboardLink: "/dkp/kommander/ceph-dashboard/"
   docsLink: "https://docs.ceph.com/en/latest/mgr/dashboard/"
   # Rook Ceph Version can be found at https://github.com/rook/rook/blob/v1.10.3/deploy/charts/rook-ceph-cluster/values.yaml#L72
   version: "17.2.3"

--- a/services/rook-ceph-cluster/1.10.3/object-bucket-claims.yaml
+++ b/services/rook-ceph-cluster/1.10.3/object-bucket-claims.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: object-bucket-claims-helmrelease
+  namespace: ${releaseNamespace}
+spec:
+  dependsOn:
+    # CephCluster needs to be active to activate ObjectBucketClaims
+    - name: rook-ceph-cluster-helmrelease
+      namespace: ${releaseNamespace}
+  force: false
+  prune: true
+  wait: true
+  interval: 6h
+  retryInterval: 1m
+  path: ./services/rook-ceph-cluster/1.10.3/objectbucketclaims
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 1m
+  postBuild:
+    substitute:
+      releaseNamespace: ${releaseNamespace}

--- a/services/rook-ceph-cluster/1.10.3/objectbucketclaims/helmrelease.yaml
+++ b/services/rook-ceph-cluster/1.10.3/objectbucketclaims/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: 0.1.0
+      version: 0.1.1
   interval: 15s
   install:
     crds: CreateReplace

--- a/services/rook-ceph-cluster/1.10.3/objectbucketclaims/helmrelease.yaml
+++ b/services/rook-ceph-cluster/1.10.3/objectbucketclaims/helmrelease.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: object-bucket-claims
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: object-bucket-claim
+      sourceRef:
+        kind: HelmRepository
+        name: mesosphere.github.io-charts-stable
+        namespace: kommander-flux
+      version: 0.1.0
+  interval: 15s
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+    createNamespace: true
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+  releaseName: object-bucket-claims
+  valuesFrom:
+    - kind: ConfigMap
+      name: rook-ceph-cluster-1.10.3-d2iq-defaults
+    - kind: ConfigMap
+      name: rook-ceph-cluster-overrides
+      optional: true
+  targetNamespace: ${releaseNamespace}

--- a/services/rook-ceph-cluster/1.10.3/objectbucketclaims/helmrelease.yaml
+++ b/services/rook-ceph-cluster/1.10.3/objectbucketclaims/helmrelease.yaml
@@ -30,4 +30,7 @@ spec:
     - kind: ConfigMap
       name: rook-ceph-cluster-overrides
       optional: true
+    - kind: ConfigMap
+      name: rook-ceph-cluster-cluster-overrides
+      optional: true
   targetNamespace: ${releaseNamespace}

--- a/services/rook-ceph-cluster/1.10.3/objectbucketclaims/kustomization.yaml
+++ b/services/rook-ceph-cluster/1.10.3/objectbucketclaims/kustomization.yaml
@@ -1,5 +1,5 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - object-bucket-claims.yaml
-  - rook-ceph-cluster.yaml
+- helmrelease.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:

Creates `ObjectBucketClaims` for workspace level loki and velero services by default. The buckets are consumed by loki and velero in their configurations.

TODO:

- [x] Depends on https://github.com/mesosphere/charts/pull/1356
- [x] remove reference to https://takirala.github.io/charts/stable after merging above

 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://d2iq.atlassian.net/browse/D2IQ-92897


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
