### PR TITLE
chore(istio): bump kubectl image

### DIFF
--- a/services/istio/1.14.1/defaults/cm.yaml
+++ b/services/istio/1.14.1/defaults/cm.yaml
@@ -26,4 +26,4 @@ data:
           prometheus.kommander.d2iq.io/select: "true"
     global:
       image: bitnami/kubectl
-      tag: 1.23.6
+      tag: 1.24.1


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumps the kubectl image to be aligned with the other apps

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
