### PR TITLE
build: Sign commits in gh workflows

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -16,10 +16,22 @@ jobs:
         || (github.event.action == 'closed')
       )
     steps:
-      - name: Set a username
-        run: git config --global user.name d2iq-mergebot
-      - name: Set an email
-        run: git config --global user.email ci-mergebot@d2iq.com
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+      - name: Set up Git
+        run: |
+          git config user.email ci-mergebot@d2iq.com
+          git config user.name d2iq-mergebot
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
       - name: Backport Action
         uses: sqren/backport-github-action@v8.4.2
         with:

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -42,12 +42,24 @@ jobs:
           ssh-key: ${{ secrets.KOMM_PRIVATE_SSH_KEY }}
           path: 'kommander'
           fetch-depth: '0'
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+          workdir: 'kommander'
+
       - name: Update kommander-applications ref on new branch
         id: update-ref
         run: |
           cd kommander
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config user.name d2iq-mergebot
+          git config user.email ci-mergebot@d2iq.com
+          git config user.signingKey ${{ secrets.GPG_KEY_ID }}
           # Use same base as k-apps (main or release branch)
           git checkout ${{ needs.get-kapps-branch-name.outputs.base_branch_name }}
           # If branch already exists, do nothing
@@ -62,6 +74,7 @@ jobs:
               echo "::set-output name=created_new_branch::true"
             fi
           }
+
       - name: Create comment
         if: steps.update-ref.outputs.created_new_branch == 'true'
         uses: peter-evans/create-or-update-comment@v2

--- a/.github/workflows/kommander-revert-kapps-ref.yaml
+++ b/.github/workflows/kommander-revert-kapps-ref.yaml
@@ -42,11 +42,23 @@ jobs:
           ssh-key: ${{ secrets.KOMM_PRIVATE_SSH_KEY }}
           path: 'kommander'
           fetch-depth: '0'
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+          workdir: 'kommander'
+
       - name: Revert kommander-applications ref back to ${{ needs.get-kapps-branch-name.outputs.base_branch_name }} on kommander branch
         run: |
           cd kommander
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config user.name d2iq-mergebot
+          git config user.email ci-mergebot@d2iq.com
+          git config user.signingKey ${{ secrets.GPG_KEY_ID }}
           # If branch does not exist, do nothing
           git show-ref --quiet --verify -- refs/remotes/origin/kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }} && {
             git checkout kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }}

--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -17,6 +17,24 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
 
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+
+      - name: Set up Git
+        run: |
+          git config user.email ci-mergebot@d2iq.com
+          git config user.name d2iq-mergebot
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
+
       - name: Automatic Rebase
         uses: cirrus-actions/rebase@1.7
         env:

--- a/.github/workflows/update-service-labeler.yaml
+++ b/.github/workflows/update-service-labeler.yaml
@@ -18,14 +18,6 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Git
-        run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
-        env:
-          GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v4
         with:
@@ -40,8 +32,14 @@ jobs:
         run: make workflow-labeler-yaml-update
       - name: Commit and push changes
         run: |
+          git config user.email ci-mergebot@d2iq.com
+          git config user.name d2iq-mergebot
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
           git add .github/service-labeler.yaml
           if output=$(git status --porcelain) && [ ! -z "$output" ]; then
             git commit -v -m "build: Updated .github/service-labeler.yaml"
             git push --force-with-lease
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}


### PR DESCRIPTION
**What problem does this PR solve?**:
Now that we have GPG secrets in the repo, use them to sign commits in GH workflows

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
Was able to test service-labeler and komm pr workflows on this branch
<img width="906" alt="image" src="https://user-images.githubusercontent.com/5897740/194449240-cec59a52-b926-48b2-887b-be0a8745cbc4.png">
<img width="815" alt="image" src="https://user-images.githubusercontent.com/5897740/194449401-c3035126-660b-4981-97d1-5f77eb310e2f.png">


but rebase is still using `main`, will have to try it once this merges.


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
