### PR TITLE
fix: do not set kubetools var for kommander

### DIFF
--- a/services/kommander/0.4.0/defaults/cm.yaml
+++ b/services/kommander/0.4.0/defaults/cm.yaml
@@ -73,10 +73,6 @@ data:
         karma-traefik: "0.0.1"
         prometheus-thanos-traefik: "0.0.1"
         thanos: "0.4.7"
-    kubetools:
-      image:
-        repository: bitnami/kubectl
-        tag: 1.24.1
     kommander-ui:
       ingress:
         enabled: true


### PR DESCRIPTION
**What problem does this PR solve?**:
The nightly e2e tests failed because of https://github.com/mesosphere/kommander-applications/pull/687. 

The tests ended up trying to pull `999867407951.dkr.ecr.us-west-2.amazonaws.com/mesosphere/kommander2-kubetools:1.24.1` which doesn't exist. This is because we explicitly set the kubetools image repository in the CLI config file (https://github.com/mesosphere/kommander/blob/main/hack/cli-config-templates/kommander-cli-installer-config-konvoy-template.yaml#L92) but not the image.

To avoid changes to how things are setup, we can just not pass through a kubectl image and rely on our kubetools image.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
