### PR TITLE
fix: Remove default inhibit-rules from KPS v40.0.0

### DIFF
--- a/services/kube-prometheus-stack/40.0.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/40.0.0/defaults/cm.yaml
@@ -326,6 +326,24 @@ data:
     kubeScheduler:
       enabled: false
     alertmanager:
+      config:
+        global:
+          resolve_timeout: 5m
+        inhibit_rules: []
+        route:
+          group_by: ['namespace']
+          group_wait: 30s
+          group_interval: 5m
+          repeat_interval: 12h
+          receiver: 'null'
+          routes:
+          - receiver: 'null'
+            matchers:
+              - alertname =~ "InfoInhibitor|Watchdog"
+        receivers:
+        - name: 'null'
+        templates:
+        - '/etc/alertmanager/config/*.tmpl'
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
**What problem does this PR solve?**:

This PR adds an override to the KPS default config-map, removing the newly added inhibition rules introduced in this [KPS Upstream PR](https://github.com/prometheus-community/helm-charts/pull/2115).

The reason for removing these inhibitions is that Insights needs Alertmanager to propagate all alerts to its webhook, even if there are `Info` and `Warning` alerts firing when a `Critical` alert is firing. The upstream PR specifically suppresses this behaviour as stated in the upstream PR:

**Which issue(s) does this PR fix?**:

https://d2iq.atlassian.net/browse/D2IQ-93506

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

This PR takes [Mesosphere KPS 40.0.0 chart values](https://github.com/mesosphere/charts/blob/master/staging/kube-prometheus-stack/values.yaml#L167-L208) and sets `inhibit_rules: []`. There are no further changes.

**Does this PR introduce a user-facing change?**:
This PR makes a minor modification to upstream KPS v40.0.0, however KPS v34.9.3 which shipped with DKP v2.3.0 has the following default Alertmanager configuration:
```
  ## Alertmanager configuration directives
  ## ref: https://prometheus.io/docs/alerting/configuration/#configuration-file
  ##      https://prometheus.io/webtools/alerting/routing-tree-editor/
  ##
  config:
    global:
      resolve_timeout: 5m
    route:
      group_by: ['job']
      group_wait: 30s
      group_interval: 5m
      repeat_interval: 12h
      receiver: 'null'
      routes:
      - match:
          alertname: Watchdog
        receiver: 'null'
    receivers:
    - name: 'null'
    templates:
    - '/etc/alertmanager/config/*.tmpl'
```
The above default is very different from [KPS v40.0.0](https://github.com/mesosphere/charts/blob/master/staging/kube-prometheus-stack/values.yaml#L167-L208) scheduled to ship with DKP v2.4.0

Alongside the above inhibition rule, there are significant changes between KPS v34.9.3 and KPS v40.0.0, 
specifically where a `namespaces` matcher is injected by default, there is no way to [turn this off as outlined by this issue](https://github.com/prometheus-operator/prometheus-operator/issues/3737). This can lead to breaking behaviour between DKP v2.3.0 and DKP v2.4.0 versions of KPS.

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [X] No License Change (or NA).
