### PR TITLE
chore: high cpu limits to avoid throttling

### DIFF
--- a/services/rook-ceph-cluster/1.10.3/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.10.3/defaults/cm.yaml
@@ -22,6 +22,15 @@ data:
         image: quay.io/ceph/ceph:v17.2.3
       dataDirHostPath: /var/lib/rook
 
+      resources:
+        mgr-sidecar:
+          limits:
+            cpu: "1"
+            memory: 500Mi
+          requests:
+            cpu: "100m"
+            memory: "40Mi"
+
       mon:
         count: 3
         # Mons should only be allowed on the same node for test environments where data loss is acceptable.
@@ -125,12 +134,20 @@ data:
             # securePort: 443
             instances: 1
             priorityClassName: system-cluster-critical
+            resources:
+              limits:
+                cpu: "2000m"
+                memory: "2Gi"
+              requests:
+                cpu: "1000m"
+                memory: "1Gi"
           healthCheck:
             bucket:
               interval: 60s
         storageClass:
           enabled: true
           name: dkp-object-store # Defined once per namespace
+          reclaimPolicy: Delete
 
     monitoring:
       # TODO(takirala): enable monitoring

--- a/services/rook-ceph/1.10.3/defaults/cm.yaml
+++ b/services/rook-ceph/1.10.3/defaults/cm.yaml
@@ -7,10 +7,18 @@ data:
   values.yaml: |
     ---
     crds:
-      # CRDs are not installed with "crds" directory and If this flag isdisabled post-install, the cluster may be DESTROYED.
+      # CRDs are not installed with "crds" directory and If this flag is disabled post-install, the cluster may be DESTROYED.
       # If the CRDs are deleted in this case, see the disaster recovery guide to restore them.
       # https://rook.io/docs/rook/latest/Troubleshooting/disaster-recovery/#restoring-crds-after-deletion
       enabled: true
+
+    resources:
+      limits:
+        cpu: 750m
+        memory: 768Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
 
     # Whether rook watches its current namespace for CRDs or the entire cluster, defaults to false
     currentNamespaceOnly: true


### PR DESCRIPTION
**What problem does this PR solve?**:

Resolves following polaris warning given by insights in daily cluster. I just bumped the value to a "next" reasonable threshold, no scaletesting or any other performance gauging was done to come up with these numbers:

```
$ k get insights -nkommander -ogo-template='{{range .items}}{{.spec.severity}} : {{.spec.description}}{{"\n"}}{{end}}' | grep ceph  | sort | grep -i cpu 
Critical : 65% throttling of CPU in namespace kommander for container watch-active in pod rook-ceph-mgr-b-785d77958d-4jmfw.<br>- 1 out of 1 pods in ReplicaSet **rook-ceph-mgr-b-785d77958d** in namespace **kommander** have an issue of this kind.
Notice : 29.79% throttling of CPU in namespace kommander for container rook-ceph-operator in pod rook-ceph-operator-5797b47886-nbp5w.<br>- 1 out of 1 pods in ReplicaSet **rook-ceph-operator-5797b47886** in namespace **kommander** have an issue of this kind.
Warning : 31.03% throttling of CPU in namespace kommander for container rook-ceph-operator in pod rook-ceph-operator-5797b47886-nbp5w.<br>- 1 out of 1 pods in ReplicaSet **rook-ceph-operator-5797b47886** in namespace **kommander** have an issue of this kind.
Warning : Polaris audit of Deployment kommander/rook-ceph-rgw-dkp-object-store-a, container rgw: CPU limits should be set
Warning : Polaris audit of Deployment kommander/rook-ceph-rgw-dkp-object-store-a, container rgw: CPU requests should be set
```

We can revisit these values after enabling prometheus metrics for ceph https://d2iq.atlassian.net/browse/D2IQ-93139.

Refer to the defaults in https://github.com/rook/rook/blob/master/deploy/charts/rook-ceph-cluster/values.yaml#L237-L292 and https://github.com/rook/rook/blob/master/deploy/charts/rook-ceph/values.yaml#L18-L24

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

Partially addresses https://d2iq.atlassian.net/browse/D2IQ-93353

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [x] No License Change (or NA).
