### PR TITLE
chore: Set output of github actions in the new way

### DIFF
--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -19,11 +19,11 @@ jobs:
       base_branch_name: ${{ steps.base-branch-name.outputs.base_branch_name }}
     steps:
       - id: branch-name
-        run: echo "::set-output name=branch_name::${{ github.head_ref }}"
+        run: echo "branch_name=${{ github.head_ref }}" >> $GITHUB_OUTPUT
       - id: escaped-branch-name
-        run: echo "::set-output name=escaped_branch_name::$(echo ${{ github.head_ref }} | sed -e 's/\//\\\//g')"
+        run: echo "escaped_branch_name=$(echo ${{ github.head_ref }} | sed -e 's/\//\\\//g')" >> $GITHUB_OUTPUT
       - id: base-branch-name
-        run: echo "::set-output name=base_branch_name::${{ github.base_ref }}"
+        run: echo "base_branch_name=${{ github.base_ref }}" >> $GITHUB_OUTPUT
       - name: Check output branch-name
         run: echo ${{ steps.branch-name.outputs.branch_name }}
       - name: Check output escaped-branch-name
@@ -71,7 +71,7 @@ jobs:
             if output=$(git status --porcelain) && [ ! -z "$output" ]; then
               git commit -v -m "build: Update kommander-applications ref for testing"
               git push --force-with-lease --set-upstream origin kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }}
-              echo "::set-output name=created_new_branch::true"
+              echo "created_new_branch=true" >> $GITHUB_OUTPUT
             fi
           }
 

--- a/.github/workflows/kommander-revert-kapps-ref.yaml
+++ b/.github/workflows/kommander-revert-kapps-ref.yaml
@@ -19,11 +19,11 @@ jobs:
       base_branch_name: ${{ steps.base-branch-name.outputs.base_branch_name }}
     steps:
       - id: branch-name
-        run: echo "::set-output name=branch_name::${{ github.head_ref }}"
+        run: echo "branch_name=${{ github.head_ref }}" >> $GITHUB_OUTPUT
       - id: escaped-branch-name
-        run: echo "::set-output name=escaped_branch_name::$(echo ${{ github.head_ref }} | sed -e 's/\//\\\//g')"
+        run: echo "escaped_branch_name=$(echo ${{ github.head_ref }} | sed -e 's/\//\\\//g')" >> $GITHUB_OUTPUT
       - id: base-branch-name
-        run: echo "::set-output name=base_branch_name::${{ github.base_ref }}"
+        run: echo "base_branch_name=${{ github.base_ref }}" >> $GITHUB_OUTPUT
       - name: Check output branch-name
         run: echo ${{ steps.branch-name.outputs.branch_name }}
       - name: Check output escaped-branch-name


### PR DESCRIPTION
**What problem does this PR solve?**:

Following GITHUB deprication of set-output command, I'm changing our jobs:

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
