### PR TITLE
fix: patch gatekeeper deployment to support FIPS clusters

### DIFF
--- a/services/gatekeeper/3.9.1/release/release.yaml
+++ b/services/gatekeeper/3.9.1/release/release.yaml
@@ -29,6 +29,21 @@ spec:
     - kind: ConfigMap
       name: gatekeeper-overrides
       optional: true
+  postRenderers:
+    - kustomize:
+        # Gatekeeper set the min TLS version to 1.3 in 3.8.0 but FIPS enabled clusters do not support TLS 1.3,
+        # In 3.9.1, the --tls-min-version flag is not configurable, so we
+        # are applying the fix as a patch to avoid forking the gatekeeper chart.
+        # Once 3.10 is release, we can remove this patch and set the TLS version in the helm values
+        patchesJson6902:
+          - target:
+              version: v1
+              kind: Deployment
+              name: gatekeeper-controller-manager
+            patch:
+              - op: add
+                path: /spec/template/spec/containers/0/args/-
+                value: --tls-min-version=1.2
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease


### PR DESCRIPTION
**What problem does this PR solve?**:
This is a forward port of https://github.com/mesosphere/kommander-applications/pull/642.

Once gatekeeper 3.10 is released, we can remove this patch and use helm values to set the TLS version

(https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.10.0-beta.2)

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-93143

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
