### PR TITLE
fix: make sure to reload upon s3 secret refresh

### DIFF
--- a/services/grafana-loki/0.48.6/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.6/defaults/cm.yaml
@@ -8,6 +8,8 @@ data:
   values.yaml: |
     loki:
       ingesterFullname: loki-ingester
+      annotations:
+        secret.reloader.stakater.com/reload: dkp-loki
 
       config: |
         auth_enabled: false

--- a/services/grafana-loki/0.48.6/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.6/defaults/cm.yaml
@@ -8,10 +8,7 @@ data:
   values.yaml: |
     loki:
       ingesterFullname: loki-ingester
-      # upstream chart doesn't apply loki.annotations to all loki deployment/statefulsets
-      # TODO: consider change to use annotations when upstream is fixed.
-      # annotations:
-      podAnnotations:
+      annotations:
         secret.reloader.stakater.com/reload: dkp-loki
 
       config: |

--- a/services/grafana-loki/0.48.6/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.6/defaults/cm.yaml
@@ -8,7 +8,10 @@ data:
   values.yaml: |
     loki:
       ingesterFullname: loki-ingester
-      annotations:
+      # upstream chart doesn't apply loki.annotations to all loki deployment/statefulsets
+      # TODO: consider change to use annotations when upstream is fixed.
+      # annotations:
+      podAnnotations:
         secret.reloader.stakater.com/reload: dkp-loki
 
       config: |

--- a/services/grafana-loki/0.48.6/grafana-loki.yaml
+++ b/services/grafana-loki/0.48.6/grafana-loki.yaml
@@ -30,20 +30,20 @@ spec:
   # TODO: remove this after https://github.com/grafana/helm-charts/issues/1905 is fixed
   postRenderers:
     - kustomize:
-      patchesJson6902:
-        - target:
-            version: v1
-            kind: Deployment
-            name: grafana-loki-loki-distributed-distributor
-          patch:
-            - op: add
-              path: /metadata/annotations/secret.reloader.stakater.com~1reload
-              value: dkp-loki
-        - target:
-            version: apps/v1
-            kind: StatefulSet
-            name: grafana-loki-loki-distributed-ingester
-          patch:
-            - op: add
-              path: /metadata/annotations/secret.reloader.stakater.com~1reload
-              value: dkp-loki
+        patchesJson6902:
+          - target:
+              version: v1
+              kind: Deployment
+              name: grafana-loki-loki-distributed-distributor
+            patch:
+              - op: add
+                path: /metadata/annotations/secret.reloader.stakater.com~1reload
+                value: dkp-loki
+          - target:
+              version: apps/v1
+              kind: StatefulSet
+              name: grafana-loki-loki-distributed-ingester
+            patch:
+              - op: add
+                path: /metadata/annotations/secret.reloader.stakater.com~1reload
+                value: dkp-loki

--- a/services/grafana-loki/0.48.6/grafana-loki.yaml
+++ b/services/grafana-loki/0.48.6/grafana-loki.yaml
@@ -26,3 +26,24 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: grafana-loki-0.48.6-d2iq-defaults
+  # upstream chart doesn't apply loki.annotations to all loki deployment/statefulsets
+  # TODO: remove this after https://github.com/grafana/helm-charts/issues/1905 is fixed
+  postRenders:
+    - kustomize:
+      patchesJson6902:
+        - target:
+          version: v1
+          kind: Deployment
+          name: grafana-loki-loki-distributed-distributor
+        patch:
+          - op: add
+            path: /metadata/annotations/secret.reloader.stakater.com~1reload
+            value: dkp-loki
+        - target:
+          version: apps/v1
+          kind: StatefulSet
+          name: grafana-loki-loki-distributed-ingester
+        patch:
+          - op: add
+            path: /metadata/annotations/secret.reloader.stakater.com~1reload
+            value: dkp-loki

--- a/services/grafana-loki/0.48.6/grafana-loki.yaml
+++ b/services/grafana-loki/0.48.6/grafana-loki.yaml
@@ -34,7 +34,7 @@ spec:
           - target:
               version: v1
               kind: Deployment
-              name: grafana-loki-loki-distributed-distributor
+              name: grafana-loki-loki-distributed-compactor
             patch:
               - op: add
                 path: /metadata/annotations/secret.reloader.stakater.com~1reload

--- a/services/grafana-loki/0.48.6/grafana-loki.yaml
+++ b/services/grafana-loki/0.48.6/grafana-loki.yaml
@@ -32,18 +32,18 @@ spec:
     - kustomize:
       patchesJson6902:
         - target:
-          version: v1
-          kind: Deployment
-          name: grafana-loki-loki-distributed-distributor
-        patch:
-          - op: add
-            path: /metadata/annotations/secret.reloader.stakater.com~1reload
-            value: dkp-loki
+            version: v1
+            kind: Deployment
+            name: grafana-loki-loki-distributed-distributor
+          patch:
+            - op: add
+              path: /metadata/annotations/secret.reloader.stakater.com~1reload
+              value: dkp-loki
         - target:
-          version: apps/v1
-          kind: StatefulSet
-          name: grafana-loki-loki-distributed-ingester
-        patch:
-          - op: add
-            path: /metadata/annotations/secret.reloader.stakater.com~1reload
-            value: dkp-loki
+            version: apps/v1
+            kind: StatefulSet
+            name: grafana-loki-loki-distributed-ingester
+          patch:
+            - op: add
+              path: /metadata/annotations/secret.reloader.stakater.com~1reload
+              value: dkp-loki

--- a/services/grafana-loki/0.48.6/grafana-loki.yaml
+++ b/services/grafana-loki/0.48.6/grafana-loki.yaml
@@ -32,7 +32,7 @@ spec:
     - kustomize:
         patchesJson6902:
           - target:
-              version: v1
+              version: apps/v1
               kind: Deployment
               name: grafana-loki-loki-distributed-compactor
             patch:

--- a/services/grafana-loki/0.48.6/grafana-loki.yaml
+++ b/services/grafana-loki/0.48.6/grafana-loki.yaml
@@ -30,20 +30,16 @@ spec:
   # TODO: remove this after https://github.com/grafana/helm-charts/issues/1905 is fixed
   postRenderers:
     - kustomize:
-        patchesJson6902:
-          - target:
-              version: apps/v1
-              kind: Deployment
-              name: grafana-loki-loki-distributed-compactor
-            patch:
-              - op: add
-                path: /metadata/annotations/secret.reloader.stakater.com~1reload
-                value: dkp-loki
-          - target:
-              version: apps/v1
-              kind: StatefulSet
+        patchesStrategicMerge:
+          - apiVersion: apps/v1
+            kind: StatefulSet
+            metadata:
               name: grafana-loki-loki-distributed-ingester
-            patch:
-              - op: add
-                path: /metadata/annotations/secret.reloader.stakater.com~1reload
-                value: dkp-loki
+              annotations:
+                secret.reloader.stakater.com/reload: dkp-loki
+          - apiVersion: apps/v1
+            kind: Deployment
+            metadata:
+              name: grafana-loki-loki-distributed-compactor
+              annotations:
+                secret.reloader.stakater.com/reload: dkp-loki

--- a/services/grafana-loki/0.48.6/grafana-loki.yaml
+++ b/services/grafana-loki/0.48.6/grafana-loki.yaml
@@ -28,7 +28,7 @@ spec:
       name: grafana-loki-0.48.6-d2iq-defaults
   # upstream chart doesn't apply loki.annotations to all loki deployment/statefulsets
   # TODO: remove this after https://github.com/grafana/helm-charts/issues/1905 is fixed
-  postRenders:
+  postRenderers:
     - kustomize:
       patchesJson6902:
         - target:

--- a/services/project-grafana-loki/0.48.6/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.48.6/defaults/cm.yaml
@@ -25,7 +25,10 @@ data:
 
     loki:
       ingesterFullname: loki-ingester
-      annotations:
+      # upstream chart doesn't apply loki.annotations to all loki deployment/statefulsets
+      # TODO: consider change to use that after upstream is fixed.
+      # annotations:
+      podAnnotations:
         secret.reloader.stakater.com/reload: proj-loki-${releaseNamespace}
 
       config: |

--- a/services/project-grafana-loki/0.48.6/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.48.6/defaults/cm.yaml
@@ -25,6 +25,8 @@ data:
 
     loki:
       ingesterFullname: loki-ingester
+      annotations:
+        secret.reloader.stakater.com/reload: proj-loki-${releaseNamespace}
 
       config: |
         auth_enabled: false

--- a/services/project-grafana-loki/0.48.6/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.48.6/defaults/cm.yaml
@@ -25,10 +25,7 @@ data:
 
     loki:
       ingesterFullname: loki-ingester
-      # upstream chart doesn't apply loki.annotations to all loki deployment/statefulsets
-      # TODO: consider change to use that after upstream is fixed.
-      # annotations:
-      podAnnotations:
+      annotations:
         secret.reloader.stakater.com/reload: proj-loki-${releaseNamespace}
 
       config: |

--- a/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
+++ b/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
@@ -28,7 +28,7 @@ spec:
       name: project-grafana-loki-0.48.6-d2iq-defaults
   # upstream chart doesn't apply loki.annotations to all loki deployment/statefulsets
   # TODO: remove this after https://github.com/grafana/helm-charts/issues/1905 is fixed
-  postRenders:
+  postRenderers:
     - kustomize:
       patchesJson6902:
         - target:

--- a/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
+++ b/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
@@ -34,7 +34,7 @@ spec:
           - target:
               version: v1
               kind: Deployment
-              name: grafana-loki-loki-distributed-distributor
+              name: project-grafana-loki-loki-distributed-distributor
             patch:
               - op: add
                 path: /metadata/annotations/secret.reloader.stakater.com~1reload
@@ -42,7 +42,7 @@ spec:
           - target:
               version: apps/v1
               kind: StatefulSet
-              name: grafana-loki-loki-distributed-ingester
+              name: project-grafana-loki-loki-distributed-ingester
             patch:
               - op: add
                 path: /metadata/annotations/secret.reloader.stakater.com~1reload

--- a/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
+++ b/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
@@ -32,18 +32,18 @@ spec:
     - kustomize:
       patchesJson6902:
         - target:
-          version: v1
-          kind: Deployment
-          name: grafana-loki-loki-distributed-distributor
-        patch:
-          - op: add
-            path: /metadata/annotations/secret.reloader.stakater.com~1reload
-            value: proj-loki-${releaseNamespace}
+            version: v1
+            kind: Deployment
+            name: grafana-loki-loki-distributed-distributor
+          patch:
+            - op: add
+              path: /metadata/annotations/secret.reloader.stakater.com~1reload
+              value: proj-loki-${releaseNamespace}
         - target:
-          version: apps/v1
-          kind: StatefulSet
-          name: grafana-loki-loki-distributed-ingester
-        patch:
-          - op: add
-            path: /metadata/annotations/secret.reloader.stakater.com~1reload
-            value: proj-loki-${releaseNamespace}
+            version: apps/v1
+            kind: StatefulSet
+            name: grafana-loki-loki-distributed-ingester
+          patch:
+            - op: add
+              path: /metadata/annotations/secret.reloader.stakater.com~1reload
+              value: proj-loki-${releaseNamespace}

--- a/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
+++ b/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
@@ -34,7 +34,7 @@ spec:
           - target:
               version: v1
               kind: Deployment
-              name: project-grafana-loki-loki-distributed-distributor
+              name: project-grafana-loki-loki-distributed-compactor
             patch:
               - op: add
                 path: /metadata/annotations/secret.reloader.stakater.com~1reload

--- a/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
+++ b/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
@@ -32,7 +32,7 @@ spec:
     - kustomize:
         patchesJson6902:
           - target:
-              version: v1
+              version: apps/v1
               kind: Deployment
               name: project-grafana-loki-loki-distributed-compactor
             patch:

--- a/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
+++ b/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
@@ -26,3 +26,24 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: project-grafana-loki-0.48.6-d2iq-defaults
+  # upstream chart doesn't apply loki.annotations to all loki deployment/statefulsets
+  # TODO: remove this after https://github.com/grafana/helm-charts/issues/1905 is fixed
+  postRenders:
+    - kustomize:
+      patchesJson6902:
+        - target:
+          version: v1
+          kind: Deployment
+          name: grafana-loki-loki-distributed-distributor
+        patch:
+          - op: add
+            path: /metadata/annotations/secret.reloader.stakater.com~1reload
+            value: proj-loki-${releaseNamespace}
+        - target:
+          version: apps/v1
+          kind: StatefulSet
+          name: grafana-loki-loki-distributed-ingester
+        patch:
+          - op: add
+            path: /metadata/annotations/secret.reloader.stakater.com~1reload
+            value: proj-loki-${releaseNamespace}

--- a/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
+++ b/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
@@ -30,20 +30,20 @@ spec:
   # TODO: remove this after https://github.com/grafana/helm-charts/issues/1905 is fixed
   postRenderers:
     - kustomize:
-      patchesJson6902:
-        - target:
-            version: v1
-            kind: Deployment
-            name: grafana-loki-loki-distributed-distributor
-          patch:
-            - op: add
-              path: /metadata/annotations/secret.reloader.stakater.com~1reload
-              value: proj-loki-${releaseNamespace}
-        - target:
-            version: apps/v1
-            kind: StatefulSet
-            name: grafana-loki-loki-distributed-ingester
-          patch:
-            - op: add
-              path: /metadata/annotations/secret.reloader.stakater.com~1reload
-              value: proj-loki-${releaseNamespace}
+        patchesJson6902:
+          - target:
+              version: v1
+              kind: Deployment
+              name: grafana-loki-loki-distributed-distributor
+            patch:
+              - op: add
+                path: /metadata/annotations/secret.reloader.stakater.com~1reload
+                value: proj-loki-${releaseNamespace}
+          - target:
+              version: apps/v1
+              kind: StatefulSet
+              name: grafana-loki-loki-distributed-ingester
+            patch:
+              - op: add
+                path: /metadata/annotations/secret.reloader.stakater.com~1reload
+                value: proj-loki-${releaseNamespace}

--- a/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
+++ b/services/project-grafana-loki/0.48.6/project-grafana-loki.yaml
@@ -30,20 +30,16 @@ spec:
   # TODO: remove this after https://github.com/grafana/helm-charts/issues/1905 is fixed
   postRenderers:
     - kustomize:
-        patchesJson6902:
-          - target:
-              version: apps/v1
-              kind: Deployment
-              name: project-grafana-loki-loki-distributed-compactor
-            patch:
-              - op: add
-                path: /metadata/annotations/secret.reloader.stakater.com~1reload
-                value: proj-loki-${releaseNamespace}
-          - target:
-              version: apps/v1
-              kind: StatefulSet
+        patchesStrategicMerge:
+          - apiVersion: apps/v1
+            kind: StatefulSet
+            metadata:
               name: project-grafana-loki-loki-distributed-ingester
-            patch:
-              - op: add
-                path: /metadata/annotations/secret.reloader.stakater.com~1reload
-                value: proj-loki-${releaseNamespace}
+              annotations:
+                secret.reloader.stakater.com/reload: proj-loki-${releaseNamespace}
+          - apiVersion: apps/v1
+            kind: Deployment
+            metadata:
+              name: project-grafana-loki-loki-distributed-compactor
+              annotations:
+                secret.reloader.stakater.com/reload: proj-loki-${releaseNamespace}

--- a/services/velero/3.3.0/defaults/cm.yaml
+++ b/services/velero/3.3.0/defaults/cm.yaml
@@ -23,6 +23,8 @@ data:
       useSecret: false
       # This is created by rook-ceph-cluster service. A ConfigMap and a Secret with same name as bucket are created.
       extraSecretRef: dkp-velero
+    annotations:
+      secret.reloader.stakater.com/reload: dkp-velero
     schedules:
       default:
         schedule: "0 0 * * *"


### PR DESCRIPTION
**What problem does this PR solve?**:
not sure why the looks like the s3 bucket secret can change after kommander install.

**Which issue(s) does this PR fix?**:
https://d2iq.atlassian.net/browse/D2IQ-92639

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
