### PR TITLE
chore: erasure coded replication for ceph object store

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -26,12 +26,12 @@ kommander-e2e:
 	@if [ -d $(KOMMANDER_E2E_DIR) ] ; then \
 		cd $(KOMMANDER_E2E_DIR) && \
 			git fetch origin && \
-			git reset --hard tga/ceph-defaults ; \
+			git reset --hard origin/main ; \
 	else \
 		mkdir -p $(KOMMANDER_E2E_DIR) && \
 			git clone -q https://github.com/mesosphere/kommander-e2e.git $(KOMMANDER_E2E_DIR) && \
 			cd $(KOMMANDER_E2E_DIR) && \
-			git checkout tga/ceph-defaults ; \
+			git checkout main ; \
 	fi
 
 .PHONY: test.e2e.install

--- a/make/test.mk
+++ b/make/test.mk
@@ -26,12 +26,12 @@ kommander-e2e:
 	@if [ -d $(KOMMANDER_E2E_DIR) ] ; then \
 		cd $(KOMMANDER_E2E_DIR) && \
 			git fetch origin && \
-			git reset --hard origin/main ; \
+			git reset --hard tga/ceph-defaults ; \
 	else \
 		mkdir -p $(KOMMANDER_E2E_DIR) && \
 			git clone -q https://github.com/mesosphere/kommander-e2e.git $(KOMMANDER_E2E_DIR) && \
 			cd $(KOMMANDER_E2E_DIR) && \
-			git checkout main ; \
+			git checkout tga/ceph-defaults ; \
 	fi
 
 .PHONY: test.e2e.install

--- a/services/project-grafana-loki/0.48.6/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.48.6/defaults/cm.yaml
@@ -18,7 +18,11 @@ data:
         bucketName: proj-loki-${releaseNamespace}
         storageClassName: dkp-object-store
         additionalConfig:
-          maxSize: "20G"
+          # We emit 200MB per workspace per day with audit logs disabled.
+          # We also have a default retention period 7days.
+          # This is NOT definitive but this translates to 200 x 7 ~ at most 1.5G per week per project (since workspace log data is a superset of project log data).
+          # This value can be configured by user during project deployment according to their project needs (e.g.: if a project has lot of noisy user created workloads).
+          maxSize: "5G"
     ####################################################################
     ## END of dkp specific config overrides                           ##
     ####################################################################

--- a/services/rook-ceph-cluster/1.10.3/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.10.3/defaults/cm.yaml
@@ -57,7 +57,7 @@ data:
       storage:
         storageClassDeviceSets:
           - name: rook-ceph-osd-set1
-            count: 3
+            count: 4
             portable: false
             encrypted: false
             placement:
@@ -83,12 +83,15 @@ data:
                         - rook-ceph-osd
                         - rook-ceph-osd-prepare
             volumeClaimTemplates:
+              # If there are some faster devices and some slower devices, it is more efficient to use
+              # separate metadata, wal, and data devices.
+              # Refer https://rook.io/docs/rook/v1.10/CRDs/Cluster/pvc-cluster/#dedicated-metadata-and-wal-device-for-osd-on-pvc
               - metadata:
                   name: data
                 spec:
                   resources:
                     requests:
-                      storage: 20Gi
+                      storage: 40Gi
                   # Use the default storage class configured in cluster.
                   # not setting storageClass to let it fall to environment default
                   # OSD Requires Block storage.
@@ -123,16 +126,36 @@ data:
         # see https://github.com/rook/rook/blob/master/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md#object-store-settings for available configuration
         spec:
           metadataPool:
+            failureDomain: osd
+            # Must use replicated pool ONLY. Erasure coding is not supported.
             replicated:
-              size: 1
+              size: 3
           dataPool:
-            replicated:
-              size: 1
+            # The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map
+            failureDomain: osd
+            # Data pool can use either replication OR erasure coding. Consider the following example scenarios:
+            # - Replication:
+            #   - Smallest possible replicas count is 2 for HA. count: 3 is more commonly used.
+            #   - With replication of size: 2, we store 2 copies of data and this tolerates loss of one copy of data.
+            #   - 50% Storage efficiency in this scenario with fault tolerance of 1 out 4 nodes (loss in number of storage nodes hosts or OSDs).
+            # - ErasureCoded:
+            #   - Slices an object into k data fragments and computes m parity fragments.
+            #   - The k + m = n fragments are spread across n Storage Nodes to provide data protection.
+            #   - At least k out of n fragments (could be parity or could be data fragments) are needed for recreation of data. This means we can afford to lose at most m fragments.
+            #   - Smallest possible count is k = 2, m = 1 i.e., n = k + m = 3. Works only if there are at least n = 3 storage nodes (hosts or OSDs).
+            #   - Storage overhead is m / k percentage.
+            #   - Example configurations: (DKP docs recommend that a cluster has at least a 4 nodes):
+            #     - With 3 data chunks and 1 parity chunks (which is what shipped in 2.3.x with MinIO), we can afford to lose up to 1 chunk. 1/3 = 33% Storage overhead and fault tolerance of 1 out of 4 nodes.
+            #     - With 6 data chunks and 2 parity chunks its same as above but this needs 8 OSDs (DKP Cluster need not have 8 nodes - Each node can have more than 1 OSD).
+            #
+            erasureCoded:
+              dataChunks: 3
+              codingChunks: 1
           preservePoolsOnDelete: false
           gateway:
             port: 80
             # securePort: 443
-            instances: 1
+            instances: 2
             priorityClassName: system-cluster-critical
             resources:
               limits:


### PR DESCRIPTION
**What problem does this PR solve?**:

Add erasure coded config for object store dataPool - See https://ceph.io/en/news/blog/2015/ceph-erasure-coding-overhead-in-a-nutshell/ to understand more about storage overhead.

With this PR we have parity with 2.3.x:
- Default capacity of storage is 160G. (we have 33% storage overhead, so this is ~106G usable space.)
  - For reference, In 2.3.x we shipped with 80G x 3 (1xvelero, 1xgrafana-loki, 1xproject-grafana-loki) = 240G total space. And storage overhead was 50% so we had 120G usable space.
- Bumps the number of replicas for rados gateway pods. these are responsible for providing the S3 API on top of OSDs(object storage daemons that are responsible for raw storage).
- Caps the project logging at 5G. This is easily overridable by user when deploying project logging stack. I picked this value so that we should be able to deploy multiple projects easily.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
