### PR TITLE
fix: increase memory requests for helm-controller

### DIFF
--- a/services/kommander-flux/0.35.0/templates/apps_v1_deployment_helm-controller.yaml
+++ b/services/kommander-flux/0.35.0/templates/apps_v1_deployment_helm-controller.yaml
@@ -58,7 +58,7 @@ spec:
             memory: 1Gi
           requests:
             cpu: 100m
-            memory: 64Mi
+            memory: 250Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
**What problem does this PR solve?**:

https://d2iq.atlassian.net/browse/D2IQ-92700

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

After upgrading to flux 0.33.0, the helm controller often got OOMKilled in the daily cluster. Despite these OOM kills no longer happening after the latest flux upgrade, the helm-controller memory consumption stays consistently over the declared requests (2x). This may expose the helm-controller to unwanted OOM restarts (which it may not tolerate well due to a known bug [D2IQ-92045](https://d2iq.atlassian.net/browse/D2IQ-92045) ) if memory is scarce on the local node. This PR increases requests to 250m to reflect the actual memory requirements.

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- The best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [x] No License Change (or NA).
