### PR TITLE
chore: added capimate and automation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 [![Coverage Status](https://coveralls.io/repos/github/mesosphere/kommander-applications/badge.svg?branch=main)](https://coveralls.io/github/mesosphere/kommander-applications?branch=main)
 
 # kommander-applications
+
+This repo is dedicated to storing the HelmRelease and other info needed for Kommander's Applications.
+
+### Pre Commit
+
+This repo uses https://pre-commit.com/ to run pre-commit hooks. Please install pre-commit and run `pre-commit install` in the root directory before committing.
+
+### Running Tests
+
+You can run tests with `make go-test`. If your tests do not meet a certain coverage threshold, your build will fail.

--- a/hack/release/cmd/prerelease/prerelease.go
+++ b/hack/release/cmd/prerelease/prerelease.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/chartversion"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/updatecapimate"
 	"github.com/spf13/cobra"
 )
 
@@ -22,17 +23,23 @@ func init() { //nolint:gochecknoinits // Initializing cobra application.
 		Short: "Handles pre-release tasks for kommander-applications (i.e. updating Kommander chart versions)",
 		Args:  cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chartVersion := Cmd.Flag(versionFlagName).Value.String()
+			chartVersionString := Cmd.Flag(versionFlagName).Value.String()
 			kommanderApplicationsRepo := Cmd.Flag(repoFlagName).Value.String()
 			if _, err := os.Stat(kommanderApplicationsRepo); os.IsNotExist(err) {
 				return err
 			}
 
-			err := chartversion.UpdateChartVersions(kommanderApplicationsRepo, chartVersion)
+			err := chartversion.UpdateChartVersions(kommanderApplicationsRepo, chartVersionString)
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Updated Kommander chart version to %s", chartVersion)
+			fmt.Fprintf(cmd.OutOrStdout(), "Updated Kommander chart version to %s", chartVersionString)
+
+			err = updatecapimate.UpdateCAPIMateVersion(kommanderApplicationsRepo, chartVersionString)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Updated CAPIMate version to %s", chartVersionString)
 			return nil
 		},
 	}

--- a/hack/release/pkg/constants/constants.go
+++ b/hack/release/pkg/constants/constants.go
@@ -3,7 +3,7 @@ package constants
 const (
 	KommanderAppPath     = "./services/kommander/"
 	KommanderAppMgmtPath = "./services/kommander-appmanagement/"
-
+  CAPIMateDefaultVersion = "v0.0.0-dev.0"
 	// SemverRegexp validates any semver (taken verbatim from semver specs).
 	SemverRegexp = `v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?` //nolint:lll // it's not readable anyway
 )

--- a/hack/release/pkg/updatecapimate/updatecapimate.go
+++ b/hack/release/pkg/updatecapimate/updatecapimate.go
@@ -1,0 +1,36 @@
+package updatecapimate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/constants"
+)
+
+func UpdateCAPIMateVersion(kommanderApplicationsRepo, containerImageVersion string) error {
+	pathToCM := filepath.Join(constants.KommanderAppPath, "*/*/cm.yaml")
+	matches, err := filepath.Glob(filepath.Join(kommanderApplicationsRepo, pathToCM))
+	if err != nil {
+		return err
+	}
+	if len(matches) != 1 {
+		return fmt.Errorf("incorrect number of matches found. There should be 1 match. %s (verify the kommander-applications repo path is correct)", pathToCM)
+	}
+
+	chartFilePath := matches[0]
+
+	read, err := os.ReadFile(chartFilePath)
+	if err != nil {
+		return err
+	}
+	newContents := strings.Replace(string(read), constants.CAPIMateDefaultVersion, containerImageVersion, -1)
+
+	err = os.WriteFile(chartFilePath, []byte(newContents), 0)
+	if err != nil {
+		return err
+	}
+
+  return nil
+}

--- a/hack/release/pkg/updatecapimate/updatecapimate_test.go
+++ b/hack/release/pkg/updatecapimate/updatecapimate_test.go
@@ -1,0 +1,58 @@
+package updatecapimate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/constants"
+	cp "github.com/otiai10/copy"
+	"github.com/stretchr/testify/assert"
+)
+
+const rootDir = "../../../../"
+
+func TestUpdateCAPIMateVersionsSuccessfully(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "prerelease")
+	assert.Nil(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Make a copy of the current repo state to modify
+	err = cp.Copy(rootDir, tmpDir)
+	assert.Nil(t, err)
+
+	updateToVersion := "v1.0.0"
+	err = UpdateCAPIMateVersion(tmpDir, updateToVersion)
+	assert.Nil(t, err)
+
+	// Path to the file we want to update
+	pathToChart := filepath.Join(constants.KommanderAppPath, "*/*/cm.yaml")
+
+	beforeUpdateFiles, err := filepath.Glob(filepath.Join(rootDir, pathToChart))
+	assert.Nil(t, err)
+
+	// Get the tmp file that holds CAPIMate info
+	afterUpdateFiles, err := filepath.Glob(filepath.Join(tmpDir, pathToChart))
+	assert.Nil(t, err)
+
+	beforeFile, err := os.ReadFile(beforeUpdateFiles[0])
+	assert.Nil(t, err)
+
+	afterFile, err := os.ReadFile(afterUpdateFiles[0])
+	assert.Nil(t, err)
+
+	assert.Contains(t, string(beforeFile), "tag: v0.0.0-dev.0")
+	assert.NotContains(t, string(beforeFile), "tag: v1.0.0")
+	assert.Contains(t, string(afterFile), "tag: v1.0.0")
+	assert.NotContains(t, string(afterFile), "tag: v0.0.0-dev.0")
+
+}
+
+func TestUpdateCAPIMateVersionsFailsWhenItCannotFindCM(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "prerelease")
+	assert.Nil(t, err)
+	defer os.RemoveAll(tmpDir)
+	updateToVersion := "v1.0.0"
+	err = UpdateCAPIMateVersion(tmpDir, updateToVersion)
+	assert.ErrorContains(t, err, "verify the kommander-applications repo path")
+}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -9,6 +9,7 @@ ignore:
   - docker.io/mesosphere/kommander2-licensing-controller-manager
   - docker.io/mesosphere/kommander2-licensing-webhook
   - docker.io/mesosphere/grafana-plugins:v0.0.1
+  - docker.io/mesosphere/capimate
 resources:
   - container_image: cr.fluentbit.io/fluent/fluent-bit:1.9.9
     sources:

--- a/services/kommander/0.4.0/defaults/cm.yaml
+++ b/services/kommander/0.4.0/defaults/cm.yaml
@@ -82,6 +82,9 @@ data:
           traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth@kubernetescrd"
         path: /dkp/kommander/dashboard
         graphqlPath: /dkp/kommander/dashboard/graphql
+    capimate:
+      image:
+        tag: v0.0.0-dev.0
     attached:
       prerequisites:
         defaultApps:


### PR DESCRIPTION
Closes D2IQ-93749

**What problem does this PR solve?**:
This adds CAPIMate to kommander applications and automatically updates it when pre release is ran.

**Which issue(s) does this PR fix?**:
https://d2iq.atlassian.net/browse/D2IQ-93749

**Special notes for your reviewer**:
To test this, run:
`cd hack/release`
`go run main.go pre-release --repo ~/Documents/d2iq/kommander-applications --version v2.4.0`

Note that the CAPIMate tag in the `cm.yaml` has been updated to 2.4.0

- [x] No License Change (or NA).
