### PR TITLE
chore: app version bump reminder in pull req template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,4 +33,4 @@ parties (Like Product, Legal for example) need to be notified when such a change
 -->
 
 - [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
-- [ ] If a chart is changed or app configuration is signficantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
+- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,11 +25,12 @@ If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug f
 
 ```
 
-**If the PR adds a version bump, does it add a breaking change in License**:
+**Checklist**
 <!--
 For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
 that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
 parties (Like Product, Legal for example) need to be notified when such a change happens.
 -->
 
-- [ ] No License Change (or NA).
+- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
+- [ ] If a chart is changed or app configuration is signficantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).


### PR DESCRIPTION
**What problem does this PR solve?**:

Updates pull request template to remind ourselves to bump the app version if/when needed.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
