### PR TITLE
chore: use data unit for panels that counts bytes

### DIFF
--- a/services/logging-operator/3.17.9/grafana-dashboards/logging-stack-stress.json
+++ b/services/logging-operator/3.17.9/grafana-dashboards/logging-stack-stress.json
@@ -490,7 +490,8 @@
                   "value": 80
                 }
               ]
-            }
+            },
+          "unit": "bytes"
           },
           "overrides": []
         },
@@ -520,7 +521,7 @@
               "uid": "$datasource"
             },
             "editorMode": "code",
-            "expr": "max_over_time(fluentd_output_status_buffer_total_bytes[1m])/1000000",
+            "expr": "max_over_time(fluentd_output_status_buffer_total_bytes[1m])",
             "legendFormat": "{{namespace}}/{{pod}}",
             "range": true,
             "refId": "A"
@@ -1178,7 +1179,8 @@
                   "value": 80
                 }
               ]
-            }
+            },
+            "unit": "binBps"
           },
           "overrides": []
         },


### PR DESCRIPTION
**What problem does this PR solve?**:
fix the y axis labels to pick up kb/mb/gb unit

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
related to https://d2iq.atlassian.net/browse/D2IQ-93354

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
