### PR TITLE
feat: enable multiple flush thread

### DIFF
--- a/services/logging-operator/3.17.9/defaults/cm.yaml
+++ b/services/logging-operator/3.17.9/defaults/cm.yaml
@@ -51,6 +51,7 @@ data:
               retry_max_times: 5
               flush_mode: interval
               flush_interval: 10s
+              flush_thread_count: 8
             extra_labels:
               log_source: kubernetes_container
     tls:

--- a/services/project-logging/1.0.3/project-logging.yaml
+++ b/services/project-logging/1.0.3/project-logging.yaml
@@ -28,3 +28,4 @@ spec:
       retry_max_times: 5
       flush_mode: interval
       flush_interval: 10s
+      flush_thread_count: 8


### PR DESCRIPTION
to help exploit the whole CPU

**What problem does this PR solve?**:
when log workload ramps up, fluentd might still not utilize the whole CPU. This helps 

details: https://docs.fluentd.org/deployment/performance-tuning-single-process#use-flush_thread_count-parameter

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-93354

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
