### PR TITLE
chore: bump license check

### DIFF
--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: mesosphere/dkp-infra-tools
-          ref: licenses/v0.0.1
+          ref: licenses/v0.0.3
           path: dkp-infra-tools
           token: ${{ secrets.MERGEBOT_TOKEN }}
       - name: Download Bloodhound CLI


### PR DESCRIPTION
**What problem does this PR solve?**:
This update pulls in additional checks for unused image-source mappings and no longer suggests used image versions as upgradable.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-93766

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
