### PR TITLE
chore: adds a container entry for kubectl 1.24.1 in license

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -24,6 +24,11 @@ resources:
   - container_image: docker.io/bitnami/kubectl:1.24.6
     sources:
       - url: https://github.com/bitnami/bitnami-docker-kubectl
+        ref: 1.24.3-debian-11-r4
+        license_path: README.md
+  - container_image: docker.io/bitnami/kubectl:1.24.1
+    sources:
+      - url: https://github.com/bitnami/bitnami-docker-kubectl
         ref: 1.24.1-debian-11-r7
         license_path: README.md
   - container_image: docker.io/bitnami/memcached:1.6.15-debian-11-r8


### PR DESCRIPTION
**What problem does this PR solve?**:
It solves the failing CI job for checking licenses. Introduces a new entry for `kubectl` 1.24.1, since `bloodhound` is generating image list with entries of both `kubectl` 1.24.6 and 1.24.1

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
