### PR TITLE
feat: set dkp-insights-management `airgapped.enabled` from kommander var

### DIFF
--- a/services/dkp-insights-management/0.3.0/defaults/cm.yaml
+++ b/services/dkp-insights-management/0.3.0/defaults/cm.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: ${releaseNamespace}
 data:
   values.yaml: |
+    airgapped:
+      enabled: ${airgappedEnabled}
     image:
       registry: "docker.io"
       repository: "mesosphere/insights-management"


### PR DESCRIPTION
**What problem does this PR solve?**:
This makes DKP Insights aware of whether they should run in an airgapped mode or not.

**Which issue(s) does this PR fix?**:
https://d2iq.atlassian.net/browse/D2IQ-92403

**Special notes for your reviewer**:
This PR is a port of the airgapped flag propagation already working in the dev app (one in the `dkp-insights` repo) to a production app.

**Does this PR introduce a user-facing change?**:
On its own, no.

**Checklist**

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
