### PR TITLE
fix: Override KPS tlsMinVersion to 1.2

### DIFF
--- a/services/kube-prometheus-stack/40.0.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/40.0.0/defaults/cm.yaml
@@ -11,6 +11,8 @@ data:
       prometheus.kommander.d2iq.io/select: "true"
     prometheusOperator:
       logLevel: warn
+      tls:
+        tlsMinVersion: VersionTLS12
       admissionWebhooks:
         patch:
           image:

--- a/services/velero/metadata.yaml
+++ b/services/velero/metadata.yaml
@@ -14,7 +14,7 @@ overview: |-
   Velero is an open source tool for safely backing up and restoring resources in a Kubernetes cluster, performing disaster recovery, and migrating resources and persistent volumes to another Kubernetes cluster.
 
   Velero offers key data protection features, such as scheduled backups, retention schedules, and pre- or post-backup hooks for custom actions. The tool can help protect data stored in persistent volumes and makes your entire Kubernetes cluster more resilient.
-  
+
   ## Dependency on Rook Ceph Cluster
   In previous versions of DKP (2.3.x), Velero was configured to deploy a standalone MinIO upon demand. In DKP 2.4.x and above, MinIO is replaced with Rook Ceph Cluster as the default Backend.
   If you plan to use Velero with Ceph, you must explicitly install Rook Ceph Cluster to use Velero (E.g.: on-prem clusters). It is recommended to use a storage backend that is outside your DKP cluster for production environments (so that the availability of backups is detached from cluster availability).


### PR DESCRIPTION
**What problem does this PR solve?**:
KPS prometheus-operator was using tls1.3 by default, set `tlsMinVersion` to 1.2

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-93914

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
