### PR TITLE
fix: use default value for useSecret configuration

### DIFF
--- a/services/velero/3.3.0/defaults/cm.yaml
+++ b/services/velero/3.3.0/defaults/cm.yaml
@@ -20,7 +20,6 @@ data:
         config:
           region: "fallback"
     credentials:
-      useSecret: false
       # This is created by rook-ceph-cluster service. A ConfigMap and a Secret with same name as bucket are created.
       extraSecretRef: dkp-velero
     annotations:


### PR DESCRIPTION
**What problem does this PR solve?**:
This PR solves a potential upgrade problem if Velero is configured to use AWS S3 for storage. In 2.3, `useSecret` was set to `true` (the default in the chart). In 2.4, we set it to `false` so an existing configuration that relied on that being `true` would break upon upgrade. 

We can keep the chart default value of `true` and also still be able to leverage `extraSecretRef` to load the Ceph creds into Velero via env vars. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
