### PR TITLE
fix: use variable for kommander ui container license mapping

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -157,10 +157,10 @@ resources:
       - url: https://github.com/prymitive/karma
         ref: ${image_tag%-d2iq-server-name}
         license_path: LICENSE
-  - container_image: docker.io/mesosphere/kommander:8.191.1
+  - container_image: docker.io/mesosphere/kommander:${kommander-ui}
     sources:
       - url: https://github.com/mesosphere/kommander-ui
-        ref: v${image_tag}
+        ref: v${kommander-ui}
   - container_image: docker.io/mesosphere/kubetunnel-controller:v0.0.14
     sources:
       - url: https://github.com/mesosphere/kubetunnel


### PR DESCRIPTION
**What problem does this PR solve?**:
The version of `kommander` container image is defined and updated in the `kommander` repository. This repository refers to `kommander` chart rolling version that changes its definition without event related to the `kommander-applciations` repo. This way the `kommander-ui` license mapping will go out of sync. 

This PR replaces static `kommander-ui` version with `${kommander-ui}` variable that will be provided when generating scan definition.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
JIRA: https://d2iq.atlassian.net/browse/D2IQ-91611

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
