### PR TITLE
fix: kommander-ui licenses variable name

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -129,7 +129,7 @@ resources:
         license_path: LICENSE
   - container_image: docker.io/library/traefik:2.8.7
     sources:
-      - url: https://github.com/traefik/traefik-library-image
+      - url: https://github.com/traefik/traefik
         ref: v${image_tag}
         license_path: LICENSE
   - container_image: docker.io/mesosphere/capimate:v2.3.0

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -157,10 +157,10 @@ resources:
       - url: https://github.com/prymitive/karma
         ref: ${image_tag%-d2iq-server-name}
         license_path: LICENSE
-  - container_image: docker.io/mesosphere/kommander:${kommander-ui}
+  - container_image: docker.io/mesosphere/kommander:${kommander_ui}
     sources:
       - url: https://github.com/mesosphere/kommander-ui
-        ref: v${kommander-ui}
+        ref: v${image_tag}
   - container_image: docker.io/mesosphere/kubetunnel-controller:v0.0.14
     sources:
       - url: https://github.com/mesosphere/kubetunnel


### PR DESCRIPTION
**What problem does this PR solve?**:
PR https://github.com/mesosphere/kommander-applications/pull/765 introduced var for `kommander-ui`. The envsubst library that `licenses` CLI uses for variable substituion https://github.com/drone/envsubst supports functions https://github.com/drone/envsubst#supported-functions where `${var-default}` means default variable value if not provided.

This PR fixes incorrect `${kommander-ui}` replacement var with `${kommander_ui}`.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
JIRA: https://d2iq.atlassian.net/browse/D2IQ-91611

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
