### PR TITLE
fix: use 8.5.14 for grafana-logging

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -86,7 +86,7 @@ resources:
         ref: v${image_tag}
         license_path: LICENSE
         notice_path: NOTICE.md
-    - container_image: docker.io/grafana/grafana:8.5.14
+  - container_image: docker.io/grafana/grafana:8.5.14
     sources:
       - url: https://github.com/grafana/grafana
         ref: v${image_tag}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -86,6 +86,12 @@ resources:
         ref: v${image_tag}
         license_path: LICENSE
         notice_path: NOTICE.md
+    - container_image: docker.io/grafana/grafana:8.5.14
+    sources:
+      - url: https://github.com/grafana/grafana
+        ref: v${image_tag}
+        license_path: LICENSE
+        notice_path: NOTICE.md
   - container_image: docker.io/grafana/grafana:9.1.5
     sources:
       - url: https://github.com/grafana/grafana

--- a/services/grafana-logging/6.38.1/defaults/cm.yaml
+++ b/services/grafana-logging/6.38.1/defaults/cm.yaml
@@ -8,6 +8,12 @@ metadata:
 data:
   values.yaml: |
     ---
+    # overriding the default image due to this issue
+    # https://d2iq.atlassian.net/browse/D2IQ-94038
+    # cause by upstream bug
+    # https://github.com/grafana/grafana/issues/56087
+    image:
+      tag: 8.5.14
     datasources:
       datasources.yaml:
         apiVersion: 1

--- a/services/project-grafana-logging/6.38.1/defaults/cm.yaml
+++ b/services/project-grafana-logging/6.38.1/defaults/cm.yaml
@@ -8,6 +8,12 @@ metadata:
 data:
   values.yaml: |
     ---
+    # overriding the default image due to this issue
+    # https://d2iq.atlassian.net/browse/D2IQ-94038
+    # cause by upstream bug
+    # https://github.com/grafana/grafana/issues/56087
+    image:
+      tag: 8.5.14
     datasources:
       datasources.yaml:
         apiVersion: 1


### PR DESCRIPTION
**What problem does this PR solve?**:
to workaround upstream issue for crash when looking at audit dashboard


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-94038

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
