### PR TITLE
feat: scale tested resources for ceph cluster

### DIFF
--- a/services/fluent-bit/0.20.9/resource-quota.yaml
+++ b/services/fluent-bit/0.20.9/resource-quota.yaml
@@ -16,6 +16,5 @@ spec:
     namespace: kommander-flux
   timeout: 1m
   postBuild:
-    substituteFrom:
-      - kind: ConfigMap
-        name: substitution-vars
+    substitute:
+      releaseNamespace: ${releaseNamespace}

--- a/services/rook-ceph-cluster/1.10.3/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.10.3/defaults/cm.yaml
@@ -163,11 +163,11 @@ data:
             priorityClassName: system-cluster-critical
             resources:
               limits:
-                cpu: "2000m"
-                memory: "2Gi"
-              requests:
-                cpu: "1000m"
+                cpu: "750m"
                 memory: "1Gi"
+              requests:
+                cpu: "250m"
+                memory: "500Mi"
           healthCheck:
             bucket:
               interval: 60s
@@ -179,6 +179,63 @@ data:
     monitoring:
       enabled: true
       createPrometheusRules: true
+
+    resources:
+      mgr:
+        limits:
+          cpu: "250m"
+          memory: "1Gi"
+        requests:
+          cpu: "100m"
+          memory: "512Mi"
+      mon:
+        limits:
+          cpu: "250m"
+          memory: "1Gi"
+        requests:
+          cpu: "100m"
+          memory: "512Mi"
+      osd:
+        limits:
+          cpu: "750m"
+          memory: "2Gi"
+        requests:
+          cpu: "250m"
+          memory: "1Gi"
+      prepareosd:
+        # limits: It is not recommended to set limits on the OSD prepare job since it's a one-time burst for memory
+        # that must be allowed to complete without an OOM kill
+        requests:
+          cpu: "500m"
+          memory: "50Mi"
+      mgr-sidecar:
+        limits:
+          cpu: "500m"
+          memory: "100Mi"
+        requests:
+          cpu: "100m"
+          memory: "40Mi"
+      crashcollector:
+        limits:
+          cpu: "250m"
+          memory: "60Mi"
+        requests:
+          cpu: "100m"
+          memory: "60Mi"
+      logcollector:
+        limits:
+          cpu: "500m"
+          memory: "1Gi"
+        requests:
+          cpu: "100m"
+          memory: "100Mi"
+      cleanup:
+        limits:
+          cpu: "500m"
+          memory: "1Gi"
+        requests:
+          cpu: "500m"
+          memory: "100Mi"
 
     #################################################################
     ## BEGIN DKP specific config overrides                         ##
@@ -196,14 +253,14 @@ data:
         storageClassName: dkp-object-store
         enableOBCHealthCheck: true
         additionalConfig:
-          maxSize: "10G"
+          maxSize: "40G"
       grafana-loki:
         enabled: true
         bucketName: dkp-loki
         storageClassName: dkp-object-store
         enableOBCHealthCheck: true
         additionalConfig:
-          # maxObjects: "1000"
+          # maxObjects:
           maxSize: "50G"
     #################################################################
     ## END of dkp specific config overrides                        ##

--- a/services/rook-ceph-cluster/1.10.3/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.10.3/defaults/cm.yaml
@@ -107,8 +107,6 @@ data:
         useAllNodes: false
 
     ingress:
-      # TODO(takirala): validate ingress is functioning correctly
-      # TODO(takirala): create a docs ticket note on how to access dashboard (fetch secret, base64decode password etc.,)
       dashboard:
         enabled: true
         annotations:


### PR DESCRIPTION
**What problem does this PR solve?**:

- Adjusts limits for CephCluster resources so that the default DKP installation requirement still stay somewhat reasonable (See 
how Ceph is an outlier here - https://d2iq.atlassian.net/wiki/spaces/DENT/pages/68124702/Workspace+Platform+Application+Defaults+and+Resource+Requirements )
- Increases the velero bucket maxSize so that backups size is similar to what was in 2.3.x 

Following screenshots are from @cwyl02's scaletesting cluster:

<details>
<summary>50 Node Cluster With Audit Logs Disabled, 400G (10% filled) space for CephCluster</summary>

OSD
![image](https://user-images.githubusercontent.com/2296947/199842940-17cdb88a-8d45-45cf-b5eb-8890d538b2d3.png)

MGR
![image](https://user-images.githubusercontent.com/2296947/199843022-8cfc2ad5-4553-4815-83cd-439e0be7fc08.png)

MON
![image](https://user-images.githubusercontent.com/2296947/199843107-29c420c2-0bfa-4abf-9fab-320a45fb4335.png)


</details>

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
