### PR TITLE
chore: decrease velero capacity

### DIFF
--- a/services/rook-ceph-cluster/1.10.3/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.10.3/defaults/cm.yaml
@@ -254,7 +254,7 @@ data:
         storageClassName: dkp-object-store
         enableOBCHealthCheck: true
         additionalConfig:
-          maxSize: "40G"
+          maxSize: "20G"
       grafana-loki:
         enabled: true
         bucketName: dkp-loki
@@ -262,7 +262,7 @@ data:
         enableOBCHealthCheck: true
         additionalConfig:
           # maxObjects:
-          maxSize: "50G"
+          maxSize: "80G"
     #################################################################
     ## END of dkp specific config overrides                        ##
     #################################################################

--- a/services/rook-ceph-cluster/1.10.3/grafana-dashboards/rook-ceph-osd.json
+++ b/services/rook-ceph-cluster/1.10.3/grafana-dashboards/rook-ceph-osd.json
@@ -1540,7 +1540,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "Platform Apps / Rook Ceph - OSD (Single)",
+  "title": "Platform Apps / Rook Ceph - OSD",
   "uid": "Fj5fAfzik123",
   "version": 1,
   "weekStart": ""

--- a/services/rook-ceph-cluster/1.10.3/grafana-dashboards/rook-ceph-osd.json
+++ b/services/rook-ceph-cluster/1.10.3/grafana-dashboards/rook-ceph-osd.json
@@ -1540,7 +1540,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "Platform Apps / Ceph - OSD (Single)",
+  "title": "Platform Apps / Rook Ceph - OSD (Single)",
   "uid": "Fj5fAfzik123",
   "version": 1,
   "weekStart": ""


### PR DESCRIPTION
**What problem does this PR solve?**:

Adjusting velero bucket size from 40G to 20G.

A single backup of a 50 node cluster took 10Mb:

![image](https://user-images.githubusercontent.com/2296947/200056746-78592386-8f0e-4c5a-9ded-ef327319c0f3.png)

Even if we create a hourly backups (which is very aggressive), 20G should save backups for close to 90days. 

Increases the grafana-loki bucket size so we have more room to grow there.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
