### PR TITLE
chore: bump label limit in workspace loki

### DIFF
--- a/services/grafana-loki/0.48.6/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.6/defaults/cm.yaml
@@ -56,7 +56,7 @@ data:
           ingestion_burst_size_mb: 10
           per_stream_rate_limit: 10MB
           per_stream_rate_limit_burst: 15MB
-          # defaults to 30, but ceph components populate ton of limits that need us to bump this limit.
+          # defaults to 30, but ceph components populates 30+ labels that need us to bump this limit.
           max_label_names_per_series: 40
         schema_config:
           configs:

--- a/services/grafana-loki/0.48.6/defaults/cm.yaml
+++ b/services/grafana-loki/0.48.6/defaults/cm.yaml
@@ -56,6 +56,8 @@ data:
           ingestion_burst_size_mb: 10
           per_stream_rate_limit: 10MB
           per_stream_rate_limit_burst: 15MB
+          # defaults to 30, but ceph components populate ton of limits that need us to bump this limit.
+          max_label_names_per_series: 40
         schema_config:
           configs:
             - from: 2020-09-07


### PR DESCRIPTION
**What problem does this PR solve?**:

@cwyl02 found this error in the scale test environment:

```
2022-11-08 15:37:34 +0000 [warn]: #0 [clusterflow:small-7tkv6-k88ck:cluster-containers:clusteroutput:small-7tkv6-k88ck:loki] failed to write post to http://grafana-loki-loki-distributed-gateway.small-7tkv6-k88ck.svc.cluster.local/loki/api/v1/push (400 Bad Request entry for stream '{app="rook-ceph-osd", app_kubernetes_io_component="cephclusters.ceph.rook.io", app_kubernetes_io_created_by="rook-ceph-operator", app_kubernetes_io_instance="3", app_kubernetes_io_managed_by="rook-ceph-operator", app_kubernetes_io_name="ceph-osd", app_kubernetes_io_part_of="dkp-ceph-cluster", ceph_daemon_id="3", ceph_daemon_type="osd", ceph_osd_id="3", ceph_rook_io_DeviceSet="rook-ceph-osd-set1", ceph_rook_io_pvc="rook-ceph-osd-set1-data-0xqgcj", ceph_version="17.2.3-0", container="osd", container_id="8b19ea554e189eb5ed693437487c94291617df5794fc2c752b6cd6e0d1516e5e", failure_domain="rook-ceph-osd-set1-data-0xqgcj", fluentd_thread="flush_thread_1", host="ip-10-0-101-113.us-west-2.compute.internal", log_source="kubernetes_container", namespace="small-7tkv6-k88ck", osd="3", pod="rook-ceph-osd-3-6f9577766c-v2wwl", pod_id="601f5389-4787-4d49-a807-1db72daf6236", pod_template_hash="6f9577766c", portable="true", rook_cluster="small-7tkv6-k88ck", rook_io_operator_namespace="small-7tkv6-k88ck", rook_version="v1.10.3", topology_location_host="rook-ceph-osd-set1-data-0xqgcj", topology_location_region="us-west-2", topology_location_root="default", topology_location_zone="us-west-2a"}' has 32 label names; limit 30
)
```

Since there is no way to workaround this error for a user, we should bump the label limit.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
