### PR TITLE
build: use pre-built Docker image for license check

### DIFF
--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -16,13 +16,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Checkout dkp-infra-tools
-        uses: actions/checkout@v3
-        with:
-          repository: mesosphere/dkp-infra-tools
-          ref: licenses/v0.0.6
-          path: dkp-infra-tools
-          token: ${{ secrets.MERGEBOT_TOKEN }}
       - name: Download Bloodhound CLI
         run: |
           curl -fsSL https://downloads.mesosphere.io/dkp-bloodhound/dkp-bloodhound_${BLOODHOUND_VERSION}_linux_amd64.tar.gz | tar xz -O > bloodhound
@@ -31,9 +24,8 @@ jobs:
         run: |
           ./bloodhound --no-validation --list-images > images.txt
       - name: Run validation
-        uses: ./dkp-infra-tools/licenses
+        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.7
+        with:
+          args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=github
         env:
           GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
-        with:
-          image-list: images.txt
-          check-sources: 'true'


### PR DESCRIPTION
**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-94119

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
