### PR TITLE
fix: Update dashboard app versions, bump Kiali img

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -337,7 +337,7 @@ resources:
       - url: https://github.com/jetstack/kube-oidc-proxy
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: quay.io/kiali/kiali-operator:v1.52.0
+  - container_image: quay.io/kiali/kiali-operator:v1.57.1
     sources:
       - url: https://github.com/kiali/kiali-operator
         ref: ${image_tag}

--- a/services/centralized-grafana/40.0.0/centralized-grafana.yaml
+++ b/services/centralized-grafana/40.0.0/centralized-grafana.yaml
@@ -44,4 +44,4 @@ data:
   # https://github.com/mesosphere/charts/tree/master/staging/kube-prometheus-stack/charts
   # Then, find the Grafana app version:
   # https://artifacthub.io/packages/helm/grafana/grafana/6.22.0
-  version: "8.4.5"
+  version: "9.1.6"

--- a/services/grafana-logging/6.38.1/grafana.yaml
+++ b/services/grafana-logging/6.38.1/grafana.yaml
@@ -40,7 +40,7 @@ data:
   dashboardLink: "/dkp/logging/grafana"
   docsLink: "https://grafana.com/docs/"
   # Check https://artifacthub.io/packages/helm/grafana/grafana/6.38.1 for app version
-  version: "9.1.5"
+  version: "8.5.14"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/jaeger/2.36.0/helmrelease/release.yaml
+++ b/services/jaeger/2.36.0/helmrelease/release.yaml
@@ -43,7 +43,7 @@ data:
   dashboardLink: "/dkp/jaeger"
   docsLink: "https://istio.io/docs/tasks/telemetry/distributed-tracing/jaeger/"
   # Check https://artifacthub.io/packages/helm/jaegertracing/jaeger-operator/ for app version
-  version: "1.31.0"
+  version: "1.38.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/kiali/1.57.1/defaults/cm.yaml
+++ b/services/kiali/1.57.1/defaults/cm.yaml
@@ -5,10 +5,6 @@ metadata:
   namespace: ${releaseNamespace}
 data:
   values.yaml: |
-    image:
-      repo: quay.io/kiali/kiali-operator
-      tag: v1.52.0
-
     cr:
       create: true
       namespace: ${releaseNamespace}

--- a/services/kiali/1.57.1/kiali.yaml
+++ b/services/kiali/1.57.1/kiali.yaml
@@ -44,7 +44,7 @@ data:
   dashboardLink: "/dkp/kiali"
   docsLink: "https://istio.io/docs/tasks/telemetry/kiali/"
   # Chart version matches app version
-  version: "1.52.0"
+  version: "1.57.1"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/kube-prometheus-stack/40.0.0/helmrelease/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/40.0.0/helmrelease/kube-prometheus-stack.yaml
@@ -78,4 +78,4 @@ data:
   # Since Grafana is a subchart of kube-prometheus-stack, get the version of the Grafana chart dependency at:
   # https://github.com/mesosphere/charts/tree/master/staging/kube-prometheus-stack/charts
   # Then, check https://artifacthub.io/packages/helm/grafana/grafana/ for app version
-  version: "9.1.5"
+  version: "9.1.6"

--- a/services/kubecost/0.28.0/kubecost.yaml
+++ b/services/kubecost/0.28.0/kubecost.yaml
@@ -44,7 +44,7 @@ data:
   dashboardLink: "/dkp/kubecost/frontend/overview.html"
   docsLink: "http://docs.kubecost.com/"
   # From: https://github.com/mesosphere/charts/blob/master/stable/kubecost/Chart.yaml#L2
-  version: "1.94.3"
+  version: "1.97.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/kubernetes-dashboard/5.11.0/kubernetes-dashboard.yaml
+++ b/services/kubernetes-dashboard/5.11.0/kubernetes-dashboard.yaml
@@ -79,4 +79,4 @@ data:
   dashboardLink: "/dkp/kubernetes/"
   docsLink: "https://kubernetes.io/docs/home/"
   # Check https://artifacthub.io/packages/helm/k8s-dashboard/kubernetes-dashboard/ for app version
-  version: "2.4.0"
+  version: "2.7.0"

--- a/services/traefik/10.30.1/traefik.yaml
+++ b/services/traefik/10.30.1/traefik.yaml
@@ -39,7 +39,7 @@ data:
   dashboardLink: "/dkp/traefik/dashboard/"
   docsLink: "https://doc.traefik.io/traefik/v2.5"
   # Check https://artifacthub.io/packages/helm/traefik/traefik for app version
-  version: "2.5.6"
+  version: "2.8.7"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
**What problem does this PR solve?**:
- Just noticed that we are overriding kiali image for some reason, and that the chartbumper missed updating the image. I've removed the image override, not sure why it was there but we should always be using the version deployed with the chart (chart version looks to be aligned with img version).
- Also noticed that we missed bumping most of the app versions we are included in dashboard configmaps.

We'll need to cut another RC with these fixes.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
