### PR TITLE
feat: Backport post-release script

### DIFF
--- a/hack/release/cmd/postrelease/postrelease.go
+++ b/hack/release/cmd/postrelease/postrelease.go
@@ -1,0 +1,76 @@
+package postrelease
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/appversion"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/chartversion"
+	"github.com/spf13/cobra"
+)
+
+var Cmd *cobra.Command //nolint:gochecknoglobals // Cobra commands are global.
+
+const (
+	versionFlagName = "version"
+	repoFlagName    = "repo"
+)
+
+func init() { //nolint:gochecknoinits // Initializing cobra application.
+	Cmd = &cobra.Command{
+		Use:   "post-release",
+		Short: "Handles post-release tasks for kommander-applications (i.e. updating Kommander chart versions)",
+		Args:  cobra.MaximumNArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			chartVersion, err := semver.NewVersion(Cmd.Flag(versionFlagName).Value.String())
+			if err != nil {
+				return fmt.Errorf("cannot parse given version: %w", err)
+			}
+			kommanderApplicationsRepo := Cmd.Flag(repoFlagName).Value.String()
+			if _, err := os.Stat(kommanderApplicationsRepo); os.IsNotExist(err) {
+				return err
+			}
+
+			if err := chartversion.UpdateChartVersions(kommanderApplicationsRepo, chartVersion.Original()); err != nil {
+				return err
+			}
+
+			if err := appversion.SetKommanderAppsVersion(
+				cmd.Context(),
+				kommanderApplicationsRepo,
+				chartVersionToAppVersion(chartVersion),
+			); err != nil {
+				return err
+			}
+
+			if _, err := appversion.ReplaceContent(
+				cmd.Context(),
+				kommanderApplicationsRepo,
+				chartVersionToAppVersion(chartVersion),
+			); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Updated Kommander chart version to %s", chartVersion)
+			return nil
+		},
+	}
+	Cmd.Flags().String(versionFlagName, "", "the new Kommander chart version")
+	Cmd.Flags().String(repoFlagName, "", "the path to the local kommander-applications repository to modify")
+
+	err := Cmd.MarkFlagRequired(versionFlagName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = Cmd.MarkFlagRequired(repoFlagName)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func chartVersionToAppVersion(ver *semver.Version) string {
+	return fmt.Sprintf("0.%d.%d", ver.Minor(), ver.Patch())
+}

--- a/hack/release/cmd/root.go
+++ b/hack/release/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/mesosphere/kommander-applications/hack/release/cmd/postrelease"
 	"github.com/mesosphere/kommander-applications/hack/release/cmd/prerelease"
 )
 
@@ -14,6 +15,7 @@ var rootCmd *cobra.Command //nolint:gochecknoglobals // Cobra commands are globa
 func init() { //nolint:gochecknoinits // Initializing cobra application.
 	rootCmd = &cobra.Command{}
 	rootCmd.AddCommand(prerelease.Cmd)
+	rootCmd.AddCommand(postrelease.Cmd)
 }
 
 func Execute(ctx context.Context) {

--- a/hack/release/go.mod
+++ b/hack/release/go.mod
@@ -3,6 +3,7 @@ module github.com/mesosphere/kommander-applications/hack/release
 go 1.18
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/drone/envsubst v1.0.3
 	github.com/fluxcd/helm-controller/api v0.22.1
 	github.com/otiai10/copy v1.7.0

--- a/hack/release/go.sum
+++ b/hack/release/go.sum
@@ -47,6 +47,8 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/hack/release/pkg/appversion/appversion.go
+++ b/hack/release/pkg/appversion/appversion.go
@@ -1,0 +1,174 @@
+package appversion
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/constants"
+)
+
+var (
+	ErrVersionNotFound = errors.New("cannot detect existing kommander app version")
+
+	// kommander-0.4.0-d2iq-defaults
+	// kommander-0.4.0-overrides
+	varNames = regexp.MustCompile(
+		`(?P<prefix>kommander(-appmanagement)?-)` +
+			constants.SemverRegexp +
+			`(?P<suffix>(-d2iq-defaults)|(-overrides))`,
+	)
+)
+
+func SetKommanderAppsVersion(ctx context.Context, dir string, version string) error {
+	kommanderPath := filepath.Join(dir, constants.KommanderAppPath)
+	dirs, err := os.ReadDir(kommanderPath)
+	if err != nil {
+		return err
+	}
+
+	var oldVersion string
+	for _, d := range dirs {
+		if d.IsDir() {
+			oldVersion = d.Name()
+			break
+		}
+	}
+
+	if oldVersion == "" {
+		return ErrVersionNotFound
+	}
+
+	if oldVersion == version {
+		// nothing to do
+		return nil
+	}
+
+	for _, componentDir := range []string{constants.KommanderAppPath, constants.KommanderAppMgmtPath} {
+		if err := move(ctx,
+			dir,
+			filepath.Join(componentDir, oldVersion),
+			filepath.Join(componentDir, version),
+		); err != nil {
+			return fmt.Errorf("error while moving directories: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ReplaceContent replaces version inside files
+func ReplaceContent(ctx context.Context, dir, version string) (int, error) {
+	kommanderPath := filepath.Clean(constants.KommanderAppPath)
+
+	changes := 0
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, _ error) error {
+		relPath, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+
+		if relPath == "." {
+			return nil
+		}
+
+		if d.IsDir() {
+			if !strings.HasPrefix(kommanderPath, relPath) && !strings.HasPrefix(relPath, kommanderPath) {
+				return filepath.SkipDir
+			}
+		}
+
+		if !d.Type().IsRegular() || filepath.Ext(d.Name()) != ".yaml" {
+			return nil
+		}
+
+		newChanges, err := replaceContentInFile(ctx, path, version)
+		changes += newChanges
+
+		return err
+	})
+
+	return changes, err
+}
+
+func replaceContentInFile(ctx context.Context, file string, version string) (int, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	fscanner := bufio.NewScanner(f)
+	output := &bytes.Buffer{}
+
+	changes := 0
+	for fscanner.Scan() {
+		text := fscanner.Text()
+
+		newText := varNames.ReplaceAllStringFunc(text, func(match string) string {
+			newValue, ok := replaceInString(match, version)
+			if ok {
+				changes++
+				return newValue
+			}
+			return match
+		})
+
+		fmt.Fprintln(output, newText)
+	}
+
+	f.Close()
+
+	if changes > 0 {
+		f, err = os.Create(file)
+		if err != nil {
+			return 0, err
+		}
+		defer f.Close()
+
+		_, err = io.Copy(f, output)
+		return changes, err
+	}
+
+	return changes, nil
+}
+
+func move(ctx context.Context, dir, oldVersion, newVersion string) error {
+	cmd := exec.CommandContext(ctx,
+		"git",
+		"mv",
+		oldVersion,
+		newVersion,
+	)
+	cmd.Dir = dir
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("git mv command failed: %s", string(output))
+		return err
+	}
+
+	return nil
+}
+
+func replaceInString(input, replace string) (string, bool) {
+	prefixIndex := varNames.SubexpIndex("prefix")
+	suffixIndex := varNames.SubexpIndex("suffix")
+
+	match := varNames.FindStringSubmatch(input)
+	if len(match) < suffixIndex {
+		return "", false
+	}
+
+	return match[prefixIndex] + replace + match[suffixIndex], true
+}

--- a/hack/release/pkg/appversion/appversion_test.go
+++ b/hack/release/pkg/appversion/appversion_test.go
@@ -1,0 +1,83 @@
+package appversion
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMove(t *testing.T) {
+	dir := fetchRepo(t)
+
+	newVersion := "0.99.99"
+	err := SetKommanderAppsVersion(context.Background(), dir, newVersion)
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(dir, constants.KommanderAppPath, newVersion))
+	assert.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dir, constants.KommanderAppMgmtPath, newVersion))
+	assert.NoError(t, err)
+}
+
+func TestReplaceContent(t *testing.T) {
+	dir := fetchRepo(t)
+	changes, err := ReplaceContent(context.Background(), dir, "0.99.99")
+	require.NoError(t, err)
+	assert.Equal(t, 5, changes)
+}
+
+func fetchRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	cmd := exec.Command("git", "clone", strings.Repeat("../", 4), dir)
+	require.NoError(t, cmd.Run())
+
+	return dir
+}
+
+func TestRegexps(t *testing.T) {
+	prefixIndex := varNames.SubexpIndex("prefix")
+	suffixIndex := varNames.SubexpIndex("suffix")
+
+	cases := []struct {
+		input  string
+		prefix string
+		suffix string
+	}{
+		{
+			input:  "kommander-0.4.0-d2iq-defaults",
+			prefix: "kommander-",
+			suffix: "-d2iq-defaults",
+		},
+		{
+			input:  "kommander-0.4.0-overrides",
+			prefix: "kommander-",
+			suffix: "-overrides",
+		},
+		{
+			input:  "kommander-appmanagement-0.4.0-d2iq-defaults",
+			prefix: "kommander-appmanagement-",
+			suffix: "-d2iq-defaults",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			result := varNames.FindStringSubmatch(c.input)
+			require.GreaterOrEqual(t, len(result), suffixIndex)
+			assert.Equal(t, c.prefix, result[prefixIndex])
+			assert.Equal(t, c.suffix, result[suffixIndex])
+
+			reconstructed := result[prefixIndex] + "0.4.0" + result[suffixIndex]
+			assert.Equal(t, c.input, reconstructed)
+		})
+	}
+}

--- a/hack/release/pkg/chartversion/chartversion.go
+++ b/hack/release/pkg/chartversion/chartversion.go
@@ -1,0 +1,64 @@
+package chartversion
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/drone/envsubst"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/constants"
+)
+
+const kommanderChartVersionTemplate = "${kommanderChartVersion:=%s}"
+
+var (
+	kommanderHelmReleasePathPattern        = filepath.Join(constants.KommanderAppPath, "*/kommander.yaml")
+	kommanderAppMgmtHelmReleasePathPattern = filepath.Join(constants.KommanderAppMgmtPath, "*/kommander-appmanagement.yaml")
+)
+
+func UpdateChartVersions(kommanderApplicationsRepo, chartVersion string) error {
+	chartVersion = fmt.Sprintf(kommanderChartVersionTemplate, chartVersion)
+
+	kommanderHelmReleasePaths := []string{kommanderHelmReleasePathPattern, kommanderAppMgmtHelmReleasePathPattern}
+	for _, helmReleasePath := range kommanderHelmReleasePaths {
+		// Find the HelmRelease
+		matches, err := filepath.Glob(filepath.Join(kommanderApplicationsRepo, helmReleasePath))
+		if err != nil {
+			return err
+		}
+		if len(matches) == 0 {
+			return fmt.Errorf("no matches found for HelmRelease path %s (verify the kommander-applications repo path is correct)", helmReleasePath)
+		}
+		if len(matches) > 1 {
+			return fmt.Errorf("found > 1 match for HelmRelease path %s (there should only be one match)", helmReleasePath)
+		}
+		helmReleaseFilePath := matches[0]
+
+		// Update the kommanderChartVersion value
+		parsedFile, err := envsubst.ParseFile(helmReleaseFilePath)
+		if err != nil {
+			return err
+		}
+		subVars := map[string]string{
+			"kommanderChartVersion": chartVersion,
+			"releaseNamespace":      "${releaseNamespace}",
+		}
+		updatedFile, err := parsedFile.Execute(func(s string) string {
+			return subVars[s]
+		})
+		if err != nil {
+			return err
+		}
+
+		if !strings.Contains(updatedFile, chartVersion) {
+			return fmt.Errorf("failed to update Kommander HelmRelease chart version")
+		}
+
+		err = os.WriteFile(helmReleaseFilePath, []byte(updatedFile), 0644)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/hack/release/pkg/chartversion/chartversion_test.go
+++ b/hack/release/pkg/chartversion/chartversion_test.go
@@ -1,0 +1,147 @@
+package chartversion
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/drone/envsubst"
+	"github.com/fluxcd/helm-controller/api/v2beta1"
+	cp "github.com/otiai10/copy"
+	"github.com/r3labs/diff/v3"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/yaml"
+)
+
+const rootDir = "../../../../"
+
+func TestUpdateChartVersionsSuccessfully(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "prerelease")
+	assert.Nil(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Make a copy of the current repo state to modify
+	err = cp.Copy(rootDir, tmpDir)
+	assert.Nil(t, err)
+
+	updateToVersion := "v1.0.0"
+	err = UpdateChartVersions(tmpDir, updateToVersion)
+	assert.Nil(t, err)
+
+	kommanderHelmReleasePaths := []string{kommanderHelmReleasePathPattern, kommanderAppMgmtHelmReleasePathPattern}
+	for _, helmReleasePath := range kommanderHelmReleasePaths {
+		// Get Kommander HR files from the current repo state to validate that changes to the Kommander HelmReleases
+		// are compatible with what this tool expects
+		beforeUpdateFiles, err := filepath.Glob(filepath.Join(rootDir, helmReleasePath))
+		assert.Nil(t, err)
+
+		// Get the tmp Kommander HR files after the chart version has been updated
+		afterUpdateFiles, err := filepath.Glob(filepath.Join(tmpDir, helmReleasePath))
+		assert.Nil(t, err)
+
+		beforeFile, err := os.ReadFile(beforeUpdateFiles[0])
+		assert.Nil(t, err)
+
+		afterFile, err := os.ReadFile(afterUpdateFiles[0])
+		assert.Nil(t, err)
+
+		branchHr := v2beta1.HelmRelease{}
+		err = yaml.Unmarshal(beforeFile, &branchHr)
+		assert.Nil(t, err)
+
+		testHr := v2beta1.HelmRelease{}
+		err = yaml.Unmarshal(afterFile, &testHr)
+		assert.Nil(t, err)
+
+		// Get the diff between the HRs
+		changes, err := diff.Diff(branchHr, testHr)
+		assert.Nil(t, err)
+		assert.NotEmpty(t, changes)
+
+		for _, change := range changes {
+			// Validate that each change is an "update"
+			assert.Equal(t, diff.UPDATE, change.Type, "expected the chart version update to result in an update operation")
+			// Validate that .spec.chart.spec.version is the only field that changes
+			assert.Equal(t, []string{"Spec", "Chart", "Spec", "Version"}, change.Path, "expected .spec.chart.spec.version to be the only field that changed in the Kommander HelmRelease")
+			// Validate that the updated version is what we expect
+			assert.Equal(t,
+				fmt.Sprintf(kommanderChartVersionTemplate, updateToVersion),
+				change.To,
+				"expected the chart version to be updated to %s, but got %s", updateToVersion, change.To)
+		}
+	}
+}
+
+func TestUpdateChartVersionsPathChanged(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "prerelease")
+	assert.Nil(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Make a copy of the current repo state to modify
+	err = cp.Copy(rootDir, tmpDir)
+	assert.Nil(t, err)
+
+	updateToVersion := fmt.Sprintf(kommanderChartVersionTemplate, "v1.0.0")
+	matches, err := filepath.Glob(filepath.Join(tmpDir, kommanderHelmReleasePathPattern))
+	assert.Nil(t, err)
+	assert.Equal(t, len(matches), 1)
+
+	// change the Kommander HelmRelease filename
+	err = os.Rename(matches[0], filepath.Join(filepath.Dir(matches[0]), "test.yaml"))
+	assert.Nil(t, err)
+
+	err = UpdateChartVersions(tmpDir, updateToVersion)
+	assert.Error(t, err, "expected chart version update to fail as the filename changed")
+}
+
+func TestUpdateChartVersionsVersionFormatChanged(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "prerelease")
+	assert.Nil(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Make a copy of the current repo state to modify
+	err = cp.Copy(rootDir, tmpDir)
+	assert.Nil(t, err)
+
+	updateToVersion := fmt.Sprintf(kommanderChartVersionTemplate, "v1.0.0")
+	matches, err := filepath.Glob(filepath.Join(tmpDir, kommanderHelmReleasePathPattern))
+	assert.Nil(t, err)
+	assert.Equal(t, len(matches), 1)
+
+	// Change the chart version to something unexpected that would break the release automation
+	parsedFile, err := envsubst.ParseFile(matches[0])
+	assert.Nil(t, err)
+	subVars := map[string]string{
+		"kommanderChartVersion": "foo",
+		"releaseNamespace":      "${releaseNamespace}",
+	}
+	updatedFile, err := parsedFile.Execute(func(s string) string {
+		return subVars[s]
+	})
+	assert.Nil(t, err)
+
+	err = os.WriteFile(matches[0], []byte(updatedFile), 0644)
+	assert.Nil(t, err)
+
+	err = UpdateChartVersions(tmpDir, updateToVersion)
+	assert.Error(t, err, "expected chart version update to fail as the chart version was changed to something unexpected")
+}
+
+
+func TestUpdateChartVersionsTooManyFiles(t *testing.T) {
+	// Make a new temp dir to copy the repo state into
+	tmpDir, err := os.MkdirTemp("", "prerelease")
+	assert.Nil(t, err)
+	err = cp.Copy(rootDir, tmpDir)
+	assert.Nil(t, err)
+	// Make a new temp dir to put a redundant file in
+	anotherDir, err := os.MkdirTemp(fmt.Sprintf("%s/services/kommander/", tmpDir), "stuff")
+	assert.Nil(t, err)
+	f, err := os.Create(fmt.Sprintf("%s/kommander.yaml", anotherDir))
+	assert.Nil(t, err)
+	defer f.Close()
+	updateToVersion := "v1.0.0"
+	err = UpdateChartVersions(tmpDir, updateToVersion)
+	assert.ErrorContains(t, err, "found > 1 match for HelmRelease path")
+}

--- a/hack/release/pkg/constants/constants.go
+++ b/hack/release/pkg/constants/constants.go
@@ -1,0 +1,9 @@
+package constants
+
+const (
+	KommanderAppPath     = "./services/kommander/"
+	KommanderAppMgmtPath = "./services/kommander-appmanagement/"
+  CAPIMateDefaultVersion = "v0.0.0-dev.0"
+	// SemverRegexp validates any semver (taken verbatim from semver specs).
+	SemverRegexp = `v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?` //nolint:lll // it's not readable anyway
+)

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -424,4 +424,3 @@ resources:
         ref: ${image_tag}
         license_path: LICENSE
         notice_path: NOTICE
-


### PR DESCRIPTION
**What problem does this PR solve?**:
It seems that post-release scripts were not present in release-2.3

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
