### PR TITLE
fix: license mapping (2.3)

### DIFF
--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: mesosphere/dkp-infra-tools
-          ref: licenses/v0.0.5
+          ref: licenses/v0.0.6
           path: dkp-infra-tools
           token: ${{ secrets.MERGEBOT_TOKEN }}
       - name: Download Bloodhound CLI
@@ -32,5 +32,8 @@ jobs:
           ./bloodhound --no-validation --list-images > images.txt
       - name: Run validation
         uses: ./dkp-infra-tools/licenses
+        env:
+          GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
         with:
           image-list: images.txt
+          check-sources: 'true'

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -132,7 +132,7 @@ resources:
     sources:
       - url: https://github.com/traefik/traefik
         ref: v${image_tag}
-        license_path: LICENSE
+        license_path: LICENSE.md
   - container_image: docker.io/mesosphere/capimate:v2.3.0
     sources:
       - url: https://github.com/mesosphere/konvoy2
@@ -375,12 +375,10 @@ resources:
     sources:
       - url: https://github.com/mesosphere/kubeaddons-extrasteps
         ref: ${image_tag}
-        license_path: LICENSE
   - container_image: docker.io/mesosphere/insights:v0.2.3
     sources:
       - url: https://github.com/mesosphere/dkp-insights
         ref: ${image_tag}
-        license_path: LICENSE
   - container_image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.4.1
     sources:
       - url: https://github.com/kubernetes/kube-state-metrics
@@ -394,7 +392,7 @@ resources:
   - container_image: docker.io/grafana/grafana:8.4.5
     sources:
       - url: https://github.com/grafana/grafana
-        ref: ${image_tag}
+        ref: v${image_tag}
         license_path: LICENSE
         notice_path: NOTICE.md
   - container_image: docker.io/nvidia/k8s-device-plugin:v0.9.0
@@ -411,7 +409,7 @@ resources:
   - container_image: docker.io/nvidia/dcgm-exporter:2.2.9-2.4.1-ubuntu20.04
     sources:
       - url: https://github.com/NVIDIA/dcgm-exporter
-        ref: ${image_tag}
+        ref: ${image_tag%-ubuntu20.04}
         license_path: LICENSE
   - container_image: docker.io/minio/operator:v4.4.25
     sources:


### PR DESCRIPTION
**What problem does this PR solve?**:
Fixes for `release-2.3` branch.

* Bumps license validation tool to `v0.0.6`
* Fixes discovered validation mappings when running tool with `check-sources` flag.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-91611

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
