### PR TITLE
fix: bump velero aws plugin for compatibility

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -205,7 +205,7 @@ resources:
       - url: https://github.com/thanos-io/thanos
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: docker.io/velero/velero-plugin-for-aws:v1.1.0
+  - container_image: docker.io/velero/velero-plugin-for-aws:v1.5.2
     sources:
       - url: https://github.com/vmware-tanzu/velero-plugin-for-aws
         ref: ${image_tag}

--- a/services/velero/3.3.0/defaults/cm.yaml
+++ b/services/velero/3.3.0/defaults/cm.yaml
@@ -36,7 +36,7 @@ data:
           servicemonitor.kommander.mesosphere.io/path: "metrics"
     initContainers:
       - name: velero-plugin-for-aws
-        image: velero/velero-plugin-for-aws:v1.1.0
+        image: velero/velero-plugin-for-aws:v1.5.2
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - mountPath: /target


### PR DESCRIPTION
This is a backport of the following PR:

https://github.com/mesosphere/kommander-applications/pull/808



Co-Authored-by: <mikolajb@gmail.com>

**What problem does this PR solve?**:

https://d2iq.atlassian.net/browse/D2IQ-94272

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
