### PR TITLE
chore: bump reloader image in licenses

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -190,7 +190,7 @@ resources:
       - url: https://github.com/ceph/ceph-container
         ref: 3ba0f095be759493a04a571a28c5ba53112cd5d3
         license_path: LICENSE
-  - container_image: docker.io/stakater/reloader:v0.0.121
+  - container_image: docker.io/stakater/reloader:v0.0.124
     sources:
       - url: https://github.com/stakater/Reloader
         ref: ${image_tag}


### PR DESCRIPTION
**What problem does this PR solve?**:

License check is failing on main and this fixes it

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
