### PR TITLE
chore: simply wait for CRDs instead of operator

### DIFF
--- a/services/rook-ceph-cluster/1.10.3/kustomization.yaml
+++ b/services/rook-ceph-cluster/1.10.3/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - object-bucket-claims.yaml
+  - pre-install.yaml
   - rook-ceph-cluster.yaml
   - grafana-dashboards

--- a/services/rook-ceph-cluster/1.10.3/pre-install.yaml
+++ b/services/rook-ceph-cluster/1.10.3/pre-install.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: rook-ceph-cluster-pre-install
+  namespace: ${releaseNamespace}
+spec:
+  force: true
+  prune: true
+  wait: true
+  interval: 6h
+  retryInterval: 1m
+  path: ./services/rook-ceph-cluster/1.10.3/pre-install
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 1m
+  postBuild:
+    substitute:
+      releaseNamespace: ${releaseNamespace}

--- a/services/rook-ceph-cluster/1.10.3/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.10.3/pre-install/ceph-crd-check.yaml
@@ -1,0 +1,55 @@
+# Ceph operator could be in a different namespace and in order to reuse an operator in different namespace, we simply wait for CRDs.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ceph-crd-check
+  namespace: ${releaseNamespace}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ceph-crd-check
+  namespace: ${releaseNamespace}
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ceph-crd-check
+  namespace: ${releaseNamespace}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ceph-crd-check
+subjects:
+  - kind: ServiceAccount
+    name: ceph-crd-check
+    namespace: ${releaseNamespace}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ceph-crd-check
+  namespace: ${releaseNamespace}
+spec:
+  template:
+    metadata:
+      name: ceph-crd-check
+    spec:
+      serviceAccountName: ceph-crd-check
+      restartPolicy: OnFailure
+      containers:
+        - name: kubectl
+          image: bitnami/kubectl:1.24.6
+          command:
+            - sh
+            - -c
+            - |
+              while ! kubectl wait --for condition=established --timeout=30s crd/cephclusters.ceph.rook.io ;
+              do
+                sleep 30
+              done

--- a/services/rook-ceph-cluster/1.10.3/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.10.3/pre-install/ceph-crd-check.yaml
@@ -3,13 +3,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ceph-crd-check
+  name: check-dkp-ceph-crd
   namespace: ${releaseNamespace}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ceph-crd-check
+  name: check-dkp-ceph-crd
   namespace: ${releaseNamespace}
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
@@ -19,28 +19,28 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ceph-crd-check
+  name: check-dkp-ceph-crd
   namespace: ${releaseNamespace}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ceph-crd-check
+  name: check-dkp-ceph-crd
 subjects:
   - kind: ServiceAccount
-    name: ceph-crd-check
+    name: check-dkp-ceph-crd
     namespace: ${releaseNamespace}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: ceph-crd-check
+  name: check-dkp-ceph-crd
   namespace: ${releaseNamespace}
 spec:
   template:
     metadata:
-      name: ceph-crd-check
+      name: check-dkp-ceph-crd
     spec:
-      serviceAccountName: ceph-crd-check
+      serviceAccountName: check-dkp-ceph-crd
       restartPolicy: OnFailure
       containers:
         - name: kubectl

--- a/services/rook-ceph-cluster/1.10.3/rook-ceph-cluster.yaml
+++ b/services/rook-ceph-cluster/1.10.3/rook-ceph-cluster.yaml
@@ -5,9 +5,8 @@ metadata:
   namespace: ${releaseNamespace}
 spec:
   dependsOn:
-    # There can only be one operator per cluster.
-    # There can only be one CephCluster per namespace.
-    - name: rook-ceph
+    # There can only be one operator per cluster, just ensure CRDs are present, no need to wait for actual operator Deployment.
+    - name: rook-ceph-cluster-pre-install
       namespace: ${workspaceNamespace}
   force: false
   prune: true


### PR DESCRIPTION
Backport of #819 

**What problem does this PR solve?**:

To reuse an existing ceph operator, this PR removes the dependson for ceph cluster with a pre install CRD presence check.

**Which issue(s) does this PR fix?**:

https://d2iq.atlassian.net/browse/D2IQ-94295

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
