### PR TITLE
build(deps): use go 1.19

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,7 @@
 awscli 2.9.0
 flux2 0.36.0 # FREEZE flux upgrade is handled by this script hack/flux/update-flux.sh
 github-cli 2.20.2
-golang 1.18.1
+golang 1.19.3
 kustomize 4.5.7
 pre-commit 2.20.0
 yq 4.30.4

--- a/hack/release/go.mod
+++ b/hack/release/go.mod
@@ -1,6 +1,6 @@
 module github.com/mesosphere/kommander-applications/hack/release
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1


### PR DESCRIPTION
**What problem does this PR solve?**:

Bump go version to 1.19 for release hack

**Which issue(s) does this PR fix?**:

--

**Special notes for your reviewer**:

--


**Does this PR introduce a user-facing change?**:

--

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).


Depends on #831 
