### PR TITLE
ci: migrate manifest validation to mage and GHA

### DIFF
--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -1,0 +1,32 @@
+name: Manifests
+
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  validate-manifests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install tools
+        uses: asdf-vm/actions/install@v1
+
+      - name: Run manifest validation
+        env:
+          MAGEFILE_VERBOSE: true
+        run: ./mage manifests:validate

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,11 +4,14 @@ go 1.19
 
 replace github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220414164044-61404de7df1a+incompatible
 
-require github.com/mesosphere/daggers v0.4.0
+require (
+	dagger.io/dagger v0.4.0
+	github.com/caarlos0/env/v6 v6.10.1
+	github.com/mesosphere/daggers v0.4.0
+)
 
 require (
 	cloud.google.com/go v0.81.0 // indirect
-	dagger.io/dagger v0.4.0 // indirect
 	github.com/Khan/genqlient v0.5.0 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -67,6 +67,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
+github.com/caarlos0/env/v6 v6.10.1 h1:t1mPSxNpei6M5yAeu1qtRdPAK29Nbcf/n3G7x+b3/II=
+github.com/caarlos0/env/v6 v6.10.1/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5Zu0ddvwc=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/magefiles/targets.go
+++ b/magefiles/targets.go
@@ -8,4 +8,7 @@ import (
 
 	// mage:import lint
 	_ "github.com/mesosphere/daggers/mage/precommit"
+
+	// mage:import manifests
+	_ "github.com/mesosphere/kommander-applications/magefiles/targets/bloodhound"
 )

--- a/magefiles/targets/bloodhound/dagger.go
+++ b/magefiles/targets/bloodhound/dagger.go
@@ -1,0 +1,98 @@
+package bloodhound
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"dagger.io/dagger"
+
+	"github.com/mesosphere/daggers/dagger/options"
+)
+
+const (
+	// url template for downloading bloodhound cli
+	bloodhoundURLTemplate = "https://downloads.mesosphere.io/dkp-bloodhound/dkp-bloodhound_v%s_linux_amd64.tar.gz"
+
+	// standard source path.
+	srcDir = "/src"
+)
+
+// Run runs the ginkgo run command with given options.
+func Run(ctx context.Context, client *dagger.Client, workdir *dagger.Directory, opts ...Option) (string, error) {
+	cfg, err := loadConfigFromEnv()
+	if err != nil {
+		return "", err
+	}
+
+	for _, o := range opts {
+		cfg = o(cfg)
+	}
+
+	container, err := getContainer(ctx, client, &cfg)
+	if err != nil {
+		return "", err
+	}
+
+	args := []string{"dkp-bloodhound"}
+
+	if cfg.Verbose > 0 {
+		args = append(args, fmt.Sprintf("--verbose=%d", cfg.Verbose))
+	}
+
+	args = append(args, cfg.Args...)
+
+	container = container.
+		WithMountedDirectory(srcDir, workdir).
+		WithWorkdir(srcDir).
+		WithEnvVariable("CACHE_BUSTER", time.Now().String()). // Workaround for stop caching after this step
+		Exec(dagger.ContainerExecOpts{Args: args})
+
+	output, err := container.Stdout().Contents(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(output), nil
+}
+
+// getContainer returns a dagger container instance with bloodhound cli as entrypoint.
+func getContainer(ctx context.Context, client *dagger.Client, cfg *config) (*dagger.Container, error) {
+	var err error
+
+	// Source url for downloading the bloodhound cli.
+	srcURL := fmt.Sprintf(bloodhoundURLTemplate, cfg.BloodHoundVersion)
+
+	// Destination file to download tar file contains Github CLI
+	dstFile := "/tmp/bloodhound_linux_amd64.tar.gz"
+
+	var customizers []options.ContainerCustomizer
+
+	customizers = append(customizers, options.DownloadFile(srcURL, dstFile))
+
+	container := client.
+		Container().From("debian:bullseye-slim").
+		Exec(dagger.ContainerExecOpts{Args: []string{"sh", "-c", "apt-get update && apt-get install -y curl"}}).
+		Exec(dagger.ContainerExecOpts{Args: []string{"sh", "-c", "rm -rf /var/lib/apt/lists/*"}})
+
+	for _, customizer := range customizers {
+		container, err = customizer(container, client)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	container = container.
+		Exec(dagger.ContainerExecOpts{Args: []string{"tar", "-xf", dstFile, "-C", "/usr/local/bin/"}}).
+		Exec(dagger.ContainerExecOpts{Args: []string{"ls", "-la", "/usr/local/bin"}}).
+		Exec(dagger.ContainerExecOpts{Args: []string{"chmod", "+x", "/usr/local/bin/dkp-bloodhound"}}).
+		Exec(dagger.ContainerExecOpts{Args: []string{"rm", "-rf", "/tmp/*"}})
+
+	_, err = container.ExitCode(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return container, nil
+}

--- a/magefiles/targets/bloodhound/doc.go
+++ b/magefiles/targets/bloodhound/doc.go
@@ -1,0 +1,2 @@
+// Package bloodhound provides a command line interface to the Bloodhound CLI.
+package bloodhound

--- a/magefiles/targets/bloodhound/mage.go
+++ b/magefiles/targets/bloodhound/mage.go
@@ -1,0 +1,37 @@
+package bloodhound
+
+import (
+	"context"
+
+	"dagger.io/dagger"
+
+	"github.com/magefile/mage/mg"
+
+	loggerdagger "github.com/mesosphere/daggers/dagger/logger"
+)
+
+// Validate runs the bloodhound to validate the manifests.
+func Validate(ctx context.Context) error {
+	logger, err := loggerdagger.NewLogger(true)
+	if err != nil {
+		return err
+	}
+
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(logger))
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	var opts []Option
+
+	if mg.Verbose() || mg.Debug() {
+		opts = append(opts, WithVerbose(4))
+	}
+	_, err = Run(ctx, client, client.Host().Workdir(), opts...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/magefiles/targets/bloodhound/options.go
+++ b/magefiles/targets/bloodhound/options.go
@@ -1,0 +1,48 @@
+package bloodhound
+
+import (
+	"github.com/caarlos0/env/v6"
+)
+
+type config struct {
+	BloodHoundVersion string   `env:"VERSION,notEmpty" envDefault:"0.8.1"`
+	Args              []string `env:"ARGS" envSeparator:" "`
+	Verbose           int      `env:"VERBOSE"`
+}
+
+func loadConfigFromEnv() (config, error) {
+	cfg := config{}
+
+	if err := env.Parse(&cfg, env.Options{Prefix: "BLOODHOUND_"}); err != nil {
+		return cfg, err
+	}
+
+	return cfg, nil
+}
+
+// Option is a function that configures the precommit checks.
+type Option func(config) config
+
+// WithBloodHoundVersion sets the bloodhound cli version to use for the container.
+func WithBloodHoundVersion(version string) Option {
+	return func(c config) config {
+		c.BloodHoundVersion = version
+		return c
+	}
+}
+
+// WithArgs sets the arguments to pass to github cli.
+func WithArgs(args ...string) Option {
+	return func(c config) config {
+		c.Args = args
+		return c
+	}
+}
+
+// WithVerbose sets the verbose level to use for the container.
+func WithVerbose(verbose int) Option {
+	return func(c config) config {
+		c.Verbose = verbose
+		return c
+	}
+}


### PR DESCRIPTION
**What problem does this PR solve?**:

Migrates `make validate-manifests`  to GHA and mage

**Which issue(s) does this PR fix?**:

--

**Special notes for your reviewer**:

--

**Does this PR introduce a user-facing change?**:

--

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
