### PR TITLE
fix: add license variables to fix install-e2e check

### DIFF
--- a/make/ci.mk
+++ b/make/ci.mk
@@ -36,6 +36,8 @@ ci.docker.run: ci.docker.ensure ; $(info $(M) Runs the build in the CI Docker im
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v /etc/docker/certs.d:/etc/docker/certs.d \
 		$(if $(GORELEASER_DEBUG),-e GORELEASER_DEBUG=$(GORELEASER_DEBUG)) \
+		$(if $(E2E_DKP_ESSENTIAL_LICENSE),-e E2E_DKP_ESSENTIAL_LICENSE=$(E2E_DKP_ESSENTIAL_LICENSE)) \
+		$(if $(E2E_DKP_ENTERPRISE_LICENSE),-e E2E_DKP_ENTERPRISE_LICENSE=$(E2E_DKP_ENTERPRISE_LICENSE)) \
 		$(if $(SLACK_WEBHOOK),-e SLACK_WEBHOOK=$(SLACK_WEBHOOK)) \
 		$(if $(DOCKER_USERNAME),-e DOCKER_USERNAME=$(DOCKER_USERNAME)) \
 		$(if $(DOCKER_PASSWORD),-e DOCKER_PASSWORD=$(DOCKER_PASSWORD)) \

--- a/make/test.mk
+++ b/make/test.mk
@@ -41,6 +41,8 @@ test.e2e.install: kommander-e2e ; $(info $(M) running end-to-end kommander insta
 		E2E_KINDEST_IMAGE=$(E2E_KINDEST_IMAGE) \
 		E2E_TEST_PATH="feature/install/suites/kindcluster" \
 		E2E_KOMMANDER_APPLICATIONS_REPOSITORY="github.com/mesosphere/kommander-applications.git?ref=$(GIT_COMMIT)" \
+		E2E_DKP_ESSENTIAL_LICENSE=$(E2E_DKP_ESSENTIAL_LICENSE) \
+		E2E_DKP_ENTERPRISE_LICENSE=$(E2E_DKP_ENTERPRISE_LICENSE) \
 		VERBOSE=$(VERBOSE) \
 		make test.e2e
 


### PR DESCRIPTION
**What problem does this PR solve?**:

This problem fixes some missing variables in the install-e2e pipeline.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
