### PR TITLE
fix: use default fluentd image

### DIFF
--- a/services/logging-operator/3.17.10/defaults/cm.yaml
+++ b/services/logging-operator/3.17.10/defaults/cm.yaml
@@ -57,8 +57,6 @@ data:
     tls:
       enabled: true
     fluentd:
-      configReloaderImage:
-        tag: v0.7.1
       image:
         # Explicitly use the default image. This should be updated when logging-operator is upgraded.
         repository: ghcr.io/banzaicloud/fluentd


### PR DESCRIPTION
**What problem does this PR solve?**:
The logging-operator [switch to using a new repository](https://github.com/banzaicloud/logging-operator/pull/1108/files#diff-911a398d9218f00dc5749daedc4d64b64f16f2f8b010c898dc28393b3454fd0dR134) for the config-reloader image so we should use that by default. 

We bumped the logging-operator which changed the default repo but since we override the tag, its trying to pull the wrong image.

More context: https://mesosphere.slack.com/archives/C03P4F14M7E/p1671204117585399

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
