### PR TITLE
feat: open-kommander-pr modifies kommander tests for auto bumps

### DIFF
--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -73,8 +73,9 @@ jobs:
             appname=$(echo $appversion | sed -r 's/(.*)(-.*)/\1/')
             semver="(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?"
             for file in $(find ./tests ./docs -type f -print); do
-              if [[ $file == *.(yaml|md) ]]; then
-                sed -r -i "s/$appname-$semver/$appversion/g" $file
+              if [[ $file == (*.yaml|*.md) ]]; then
+                echo $file
+                # sed -r -i "s/$appname-$semver/$appversion/g" $file
               fi
             done
             git add ./tests

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -73,7 +73,7 @@ jobs:
             appname=$(echo $appversion | sed -r 's/(.*)(-.*)/\1/')
             semver="(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?"
             for file in $(find ./tests -type f -print); do
-              sed -i "s/$appname-$semver/$appversion/g" $file
+              sed -r -i "s/$appname-$semver/$appversion/g" $file
             done
             git add ./tests
             if output=$(git status --porcelain) && [ ! -z "$output" ]; then

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -53,8 +53,8 @@ jobs:
           git_tag_gpgsign: true
           workdir: 'kommander'
 
-      - name: Update kommander-applications ref on new branch
-        id: update-ref
+      - name: Make test branch pointing to kommander-applications ref
+        id: make-test-branch
         run: |
           cd kommander
           git config user.name d2iq-mergebot
@@ -84,7 +84,7 @@ jobs:
           }
 
       - name: Create comment
-        if: steps.update-ref.outputs.created_new_branch == 'true'
+        if: steps.make-test-branch.outputs.created_new_branch == 'true'
         uses: peter-evans/create-or-update-comment@v2
         env:
           GH_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -68,6 +68,14 @@ jobs:
             # Point the kommander-applications ref to the k-apps branch
             sed -i 's/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}/' Makefile
             git add Makefile
+            # Update kuttl tests that reference the app being bumped
+            appversion=$(echo ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }} | sed -r 's/(chartbump\/)(.*)/\2/')
+            appname=$(echo $appversion | sed -r '(.*)(-.*)/\1/')
+            semver="(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?"
+            for file in $(find ./tests -type f -print); do
+              sed -i "s/$appname-$semver/$appversion/g" $file
+            done
+            git add ./tests
             if output=$(git status --porcelain) && [ ! -z "$output" ]; then
               git commit -v -m "build: Update kommander-applications ref for testing"
               git push --force-with-lease --set-upstream origin kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }}

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -74,7 +74,7 @@ jobs:
             semver="(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?"
             for file in $(find ./tests ./docs -type f -print); do
               case $file in
-                *".yaml" | *".md") sed -r -i "s/$appname-$semver/$appversion/g" $file;;
+                *".yaml" | *".yaml.tmpl" | *".md") sed -r -i "s/$appname-$semver/$appversion/g" $file;;
               esac
             done
             git add ./tests

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -72,7 +72,7 @@ jobs:
             appversion=$(echo ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }} | sed -r 's/(chartbump\/)(.*)/\2/')
             appname=$(echo $appversion | sed -r 's/(.*)(-.*)/\1/')
             semver="(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?"
-            for file in $(find ./tests -type f -print); do
+            for file in $(find ./tests ./docs -type f -print); do
               sed -r -i "s/$appname-$semver/$appversion/g" $file
             done
             git add ./tests

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -70,7 +70,7 @@ jobs:
             git add Makefile
             # Update kuttl tests that reference the app being bumped
             appversion=$(echo ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }} | sed -r 's/(chartbump\/)(.*)/\2/')
-            appname=$(echo $appversion | sed -r '(.*)(-.*)/\1/')
+            appname=$(echo $appversion | sed -r 's/(.*)(-.*)/\1/')
             semver="(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?"
             for file in $(find ./tests -type f -print); do
               sed -i "s/$appname-$semver/$appversion/g" $file

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -73,10 +73,9 @@ jobs:
             appname=$(echo $appversion | sed -r 's/(.*)(-.*)/\1/')
             semver="(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?"
             for file in $(find ./tests ./docs -type f -print); do
-              if [[ $file == (*.yaml|*.md) ]]; then
-                echo $file
-                # sed -r -i "s/$appname-$semver/$appversion/g" $file
-              fi
+              case $file in
+                *".yaml" | *".md") sed -r -i "s/$appname-$semver/$appversion/g" $file;;
+              esac
             done
             git add ./tests
             if output=$(git status --porcelain) && [ ! -z "$output" ]; then

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -73,7 +73,9 @@ jobs:
             appname=$(echo $appversion | sed -r 's/(.*)(-.*)/\1/')
             semver="(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?"
             for file in $(find ./tests ./docs -type f -print); do
-              sed -r -i "s/$appname-$semver/$appversion/g" $file
+              if [[ $file == *.(yaml|md) ]]; then
+                sed -r -i "s/$appname-$semver/$appversion/g" $file
+              fi
             done
             git add ./tests
             if output=$(git status --porcelain) && [ ! -z "$output" ]; then


### PR DESCRIPTION
**What problem does this PR solve?**:
This automates updating tests and docs where the application name and version are specified to match the following syntax: `{appname}-{semver}` (i.e. `external-dns-1.2.3`).

Note that these cases are not covered in docs since the application name does not match:
```
export EXTERNAL_DNS_VERSION=6.11.3
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-94403

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
See results in test PR (due to this branch name): https://github.com/mesosphere/kommander/pull/2691

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
