### PR TITLE
fix: Use archive full index bitnami helmrepo url

### DIFF
--- a/common/helm-repositories/bitnami.yaml
+++ b/common/helm-repositories/bitnami.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   interval: 10m
   timeout: 1m
-  url: "${helmMirrorURL:=https://charts.bitnami.com/bitnami/}"
+  url: "${helmMirrorURL:=https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami}"


### PR DESCRIPTION
**What problem does this PR solve?**:
https://github.com/bitnami/charts/issues/10833
> On June 2nd, the Helm chart index stored at https://charts.bitnami.com/bitnami was truncated only containing entries for the latest 6 months (from January 2022 on).

> 🔧 Where can I find the full index.yaml?
The whole index.yaml is being generated and stored in GitHub, not in the CDN. You can find it in the [archive-full-index branch](https://github.com/bitnami/charts/tree/archive-full-index). If you want to keep using older versions and the size or speed is not critical, feel free to use this one.

> $ helm repo add bitnami-full-index https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
"bitnami-full-index" has been added to your repositories

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-94925

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
