### PR TITLE
build: bump bloodhound to 0.8.1

### DIFF
--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -18,9 +18,9 @@ skip_types:
   - constraints.gatekeeper.sh/v1beta1
 
 # load additional CRDs (URLs of CRD yaml files)
-additional_crds: []
+additional_crds:
   # because the istio-chart is just referencing the istio-controller, so it doesn't contain the CRDs
-  # - https://raw.githubusercontent.com/istio/istio/1.9.1/manifests/charts/base/crds/crd-all.gen.yaml
+  - https://raw.githubusercontent.com/istio/istio/1.11.5/manifests/charts/base/crds/crd-all.gen.yaml
 
 # set values for substitution variables (e.g. ${releaseNamespace}) in the resources
 substitution_vars:

--- a/make/validate.mk
+++ b/make/validate.mk
@@ -1,4 +1,4 @@
-DKP_BLOODHOUND_VERSION ?= 0.2.1
+DKP_BLOODHOUND_VERSION ?= 0.8.1
 DKP_BLOODHOUND_BIN := $(LOCAL_DIR)/bin/dkp-bloodhound_v$(DKP_BLOODHOUND_VERSION)
 
 $(DKP_BLOODHOUND_BIN):
@@ -8,4 +8,4 @@ $(DKP_BLOODHOUND_BIN):
 
 .PHONY: validate-manifests
 validate-manifests: $(DKP_BLOODHOUND_BIN)
-	$(DKP_BLOODHOUND_BIN) . --skip-applications=kaptain,grafana-loki,project-grafana-loki,project-logging
+	$(DKP_BLOODHOUND_BIN)


### PR DESCRIPTION
**What problem does this PR solve?**:
Bump outdated bloodhound on `release-2.2`, which leads to failing checks

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
