### PR TITLE
test: disable lvm in release-2.3

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -26,6 +26,7 @@ test.e2e.install: kommander-e2e ; $(info $(M) running end-to-end kommander insta
 	cd $(KOMMANDER_E2E_DIR) && \
 		E2E_TIMEOUT=$(E2E_TIMEOUT) \
 		E2E_KINDEST_IMAGE=$(E2E_KINDEST_IMAGE) \
+		E2E_KIND_LVM_ENABLED=false \
 		E2E_TEST_PATH="feature/install/suites/kindcluster" \
 		E2E_KOMMANDER_APPLICATIONS_REPOSITORY="github.com/mesosphere/kommander-applications.git?ref=$(GIT_COMMIT)" \
 		VERBOSE=$(VERBOSE) \
@@ -37,6 +38,7 @@ test.e2e.upgrade.singlecluster: kommander-e2e ; $(info $(M) running end-to-end k
 		E2E_TEST_PATH="feature/upgrade/suites/kind/singlecluster" \
 		E2E_TIMEOUT=$(E2E_TIMEOUT) \
 		E2E_KINDEST_IMAGE=$(E2E_KINDEST_IMAGE) \
+		E2E_KIND_LVM_ENABLED=false \
 		E2E_KOMMANDER_APPLICATIONS_REPOSITORY="github.com/mesosphere/kommander-applications.git?ref=$(UPGRADE_FROM_VERSION)" \
 		E2E_KOMMANDER_APPLICATIONS_REPOSITORY_TO_UPGRADE="github.com/mesosphere/kommander-applications.git?ref=$(GIT_COMMIT)" \
 		E2E_KINDEST_IMAGE=$(E2E_KINDEST_IMAGE) \


### PR DESCRIPTION
**What problem does this PR solve?**:

No need to create lvms in release-2.3 as ceph was first introduced in 2.4

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
