### PR TITLE
feat: bump kustomize-controller concurrency to 15

### DIFF
--- a/hack/flux/flux-update-kustomization.yaml
+++ b/hack/flux/flux-update-kustomization.yaml
@@ -12,6 +12,9 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --no-remote-bases=true
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --concurrent=15
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/memory
         value: 150Mi
@@ -20,7 +23,7 @@ patches:
         value: 250m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
-        value: 2000m
+        value: 2500m
   - target:
       group: apps
       version: v1

--- a/services/kommander-flux/0.38.2/templates/apps_v1_deployment_kustomize-controller.yaml
+++ b/services/kommander-flux/0.38.2/templates/apps_v1_deployment_kustomize-controller.yaml
@@ -30,6 +30,7 @@ spec:
         - --log-encoding=json
         - --enable-leader-election
         - --no-remote-bases=true
+        - --concurrent=15
         env:
         - name: RUNTIME_NAMESPACE
           valueFrom:
@@ -55,7 +56,7 @@ spec:
             port: healthz
         resources:
           limits:
-            cpu: 2000m
+            cpu: 2500m
             memory: 1Gi
           requests:
             cpu: 250m


### PR DESCRIPTION
**What problem does this PR solve?**:
Increases the `kustomize-controller` concurrency to 15, mainly to speed up the installation process. We have a ton of kustomizations (half of which are just ConfigMaps), so an easy win for speeding up the installation process is to increase the concurrency from 4 to 15. In a few tests, this saved 10-15 minutes while waiting for all the platform applications to be ready.

I made this change on the daily and saw some CPU spikes so I've bumped that as a extra precaution (memory seemed fine):

<img width="1258" alt="Screen Shot 2023-01-23 at 2 13 01 PM" src="https://user-images.githubusercontent.com/27781468/214137467-f76ddf65-44cb-49c7-9181-c35df95711fc.png">
<img width="1278" alt="Screen Shot 2023-01-23 at 2 13 09 PM" src="https://user-images.githubusercontent.com/27781468/214137470-87411d1e-5db0-440b-962c-106c13e28185.png">



**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-95122

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [x] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [x] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
