### PR TITLE
ci: Add DNM label to bump PRs requiring komm pr

### DIFF
--- a/.github/services-pr-labeler.yaml
+++ b/.github/services-pr-labeler.yaml
@@ -16,5 +16,24 @@ open-kommander-pr:
   - services/traefik-forward-auth/**
   - services/traefik-forward-auth-mgmt/**
 
+# this should be the same list as above open-kommander-pr
+do-not-merge/testing:
+  - services/cert-manager/**
+  - services/external-dns/**
+  - services/fluent-bit/**
+  - services/istio/**
+  - services/jaeger/**
+  - services/kiali/**
+  - services/kube-oidc-proxy/**
+  - services/logging-operator/**
+  - services/project-grafana-logging/**
+  - services/project-grafana-loki/**
+  - services/project-logging/**
+  - services/reloader/**
+  - services/rook-ceph/**
+  - services/rook-ceph-cluster/**
+  - services/traefik-forward-auth/**
+  - services/traefik-forward-auth-mgmt/**
+
 ok-to-test:
   - services/**/*


### PR DESCRIPTION
**What problem does this PR solve?**:
Block PRs from getting merged if they have corresponding kommander PRs that require tests to pass first.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
