### PR TITLE
feat: bump cluster observer to `1.1.0`

### DIFF
--- a/services/kommander/0.5.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
+++ b/services/kommander/0.5.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-kommander-auditing-pipeline-charts
         namespace: kommander-flux
-      version: 1.0.3
+      version: 1.1.0
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:

Bumping cluster observer to https://github.com/mesosphere/kommander-auditing-pipeline/releases/tag/1.1.0

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://d2iq.atlassian.net/browse/D2IQ-94892

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [x] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [x] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
