### PR TITLE
build: pin dkp cli version in release-2.3 branch

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -23,7 +23,9 @@ kommander-e2e:
 
 .PHONY: test.e2e.install
 test.e2e.install: kommander-e2e ; $(info $(M) running end-to-end kommander install test from kommander-e2e)
+	# If we don't pin the DKP CLI version here, it will default to 0.0.0-dev and version agnostic CLI will do unexpected stuff (e.g.: such as installing ceph in 2.3)
 	cd $(KOMMANDER_E2E_DIR) && \
+        E2E_COMMANDS_DKP="https://downloads.mesosphere.com/dkp/v2.3.1/dkp_v2.3.1_linux_amd64.tar.gz" \
 		E2E_TIMEOUT=$(E2E_TIMEOUT) \
 		E2E_KINDEST_IMAGE=$(E2E_KINDEST_IMAGE) \
 		E2E_KIND_LVM_ENABLED=false \
@@ -34,7 +36,9 @@ test.e2e.install: kommander-e2e ; $(info $(M) running end-to-end kommander insta
 
 .PHONY: test.e2e.upgrade.singlecluster
 test.e2e.upgrade.singlecluster: kommander-e2e ; $(info $(M) running end-to-end kommander upgrade $(UPGRADE_FROM_VERSION) to $(GIT_COMMIT) test from kommander-e2e)
+	# If we don't pin the DKP CLI version here, it will default to 0.0.0-dev and version agnostic CLI will do unexpected stuff (e.g.: such as installing ceph in 2.3)
 	cd $(KOMMANDER_E2E_DIR) && \
+		E2E_COMMANDS_DKP="https://downloads.mesosphere.com/dkp/v2.3.1/dkp_v2.3.1_linux_amd64.tar.gz" \
 		E2E_TEST_PATH="feature/upgrade/suites/kind/singlecluster" \
 		E2E_TIMEOUT=$(E2E_TIMEOUT) \
 		E2E_KINDEST_IMAGE=$(E2E_KINDEST_IMAGE) \


### PR DESCRIPTION
**What problem does this PR solve?**:

CI is currently failing in release branch as we try to use `v0.0.0-dev` version of CLI in release branch which is unsupported even with the version agnostic CLI.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
