### PR TITLE
fix: Fix capimate image to be last stable (2.4)

### DIFF
--- a/hack/release/pkg/constants/constants.go
+++ b/hack/release/pkg/constants/constants.go
@@ -1,9 +1,9 @@
 package constants
 
 const (
-	KommanderAppPath     = "./services/kommander/"
-	KommanderAppMgmtPath = "./services/kommander-appmanagement/"
-  CAPIMateDefaultVersion = "v0.0.0-dev.0"
+	KommanderAppPath       = "./services/kommander/"
+	KommanderAppMgmtPath   = "./services/kommander-appmanagement/"
+	CAPIMateDefaultVersion = "v2.4.0"
 	// SemverRegexp validates any semver (taken verbatim from semver specs).
 	SemverRegexp = `v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?` //nolint:lll // it's not readable anyway
 )

--- a/hack/release/pkg/updatecapimate/updatecapimate_test.go
+++ b/hack/release/pkg/updatecapimate/updatecapimate_test.go
@@ -41,10 +41,10 @@ func TestUpdateCAPIMateVersionsSuccessfully(t *testing.T) {
 	afterFile, err := os.ReadFile(afterUpdateFiles[0])
 	assert.Nil(t, err)
 
-	assert.Contains(t, string(beforeFile), "tag: v0.0.0-dev.0")
+	assert.Contains(t, string(beforeFile), "tag: v2.4.0")
 	assert.NotContains(t, string(beforeFile), "tag: v1.0.0")
 	assert.Contains(t, string(afterFile), "tag: v1.0.0")
-	assert.NotContains(t, string(afterFile), "tag: v0.0.0-dev.0")
+	assert.NotContains(t, string(afterFile), "tag: v2.4.0")
 
 }
 

--- a/services/kommander/0.4.1/defaults/cm.yaml
+++ b/services/kommander/0.4.1/defaults/cm.yaml
@@ -84,7 +84,7 @@ data:
         graphqlPath: /dkp/kommander/dashboard/graphql
     capimate:
       image:
-        tag: v0.0.0-dev.0
+        tag: v2.4.0
     attached:
       prerequisites:
         defaultApps:


### PR DESCRIPTION
**What problem does this PR solve?**:
for release branches, pin the capimate image to the latest stable release. when konvoy starts releasing dailies from release branches, we can adjust these to be the relevant dev versions

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
