### PR TITLE
feat: Enable "lazy" connector initialization in dex

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -155,7 +155,7 @@ resources:
     sources:
       - url: https://github.com/mesosphere/dex-k8s-authenticator
         ref: ${image_tag}
-  - container_image: docker.io/mesosphere/dex:v2.31.0-d2iq
+  - container_image: docker.io/mesosphere/dex:v2.35.1-d2iq.1
     sources:
       - url: https://github.com/mesosphere/dex
         ref: ${image_tag}

--- a/services/dex/2.10.0/defaults/cm.yaml
+++ b/services/dex/2.10.0/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
   values.yaml: |-
     ---
     image: mesosphere/dex
-    imageTag: v2.31.0-d2iq
+    imageTag: v2.35.1-d2iq.1
     resources:
       requests:
         cpu: 100m

--- a/services/dex/2.10.0/defaults/cm.yaml
+++ b/services/dex/2.10.0/defaults/cm.yaml
@@ -56,6 +56,7 @@ data:
       oauth2:
         skipApprovalScreen: true
       staticClients: []
+      lazyInitConnectors: true
     certIssuerRef:
       kind: ${certificateIssuerKind:=Issuer}
       name: ${certificateIssuerName}


### PR DESCRIPTION
**What problem does this PR solve?**:
Allows dex server to start even if one or more connectors is misconfigured.

This change does not affect any other dex functionality, and we want to automatically apply this fix, so I'm not bumping the chart version.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-95346

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
dex: Allow server to start even if one or more connector is misconfigured.
```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [x] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [x] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
