### PR TITLE
build: use downloads.d2iq.com

### DIFF
--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Download Bloodhound CLI
         run: |
-          curl -fsSL https://downloads.mesosphere.io/dkp-bloodhound/dkp-bloodhound_${BLOODHOUND_VERSION}_linux_amd64.tar.gz | tar xz -O > bloodhound
+          curl -fsSL https://downloads.d2iq.com/dkp-bloodhound/dkp-bloodhound_${BLOODHOUND_VERSION}_linux_amd64.tar.gz | tar xz -O > bloodhound
           chmod +x bloodhound
       - name: Generate image list
         run: |

--- a/make/release.mk
+++ b/make/release.mk
@@ -1,4 +1,4 @@
-S3_BUCKET ?= "downloads.mesosphere.io"
+S3_BUCKET ?= "downloads.d2iq.com"
 S3_PATH ?= "dkp/$(GIT_TAG)"
 S3_ACL ?= "bucket-owner-full-control"
 

--- a/make/validate.mk
+++ b/make/validate.mk
@@ -3,7 +3,7 @@ DKP_BLOODHOUND_BIN := $(LOCAL_DIR)/bin/dkp-bloodhound_v$(DKP_BLOODHOUND_VERSION)
 
 $(DKP_BLOODHOUND_BIN):
 	mkdir -p `dirname $@`
-	curl -fsSL https://downloads.mesosphere.io/dkp-bloodhound/dkp-bloodhound_v$(DKP_BLOODHOUND_VERSION)_linux_amd64.tar.gz | tar xz -O > $@
+	curl -fsSL https://downloads.d2iq.com/dkp-bloodhound/dkp-bloodhound_v$(DKP_BLOODHOUND_VERSION)_linux_amd64.tar.gz | tar xz -O > $@
 	chmod +x $@
 
 .PHONY: validate-manifests


### PR DESCRIPTION
**What problem does this PR solve?**:
Moves from downloads.mesosphere.io -> downloads.d2iq.com

CI on main is failing due to the deprecation of the mesosphere cloudfront distribution

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
