### PR TITLE
feat: Use newly created operator image

### DIFF
--- a/charts/kommander-operator/values.yaml
+++ b/charts/kommander-operator/values.yaml
@@ -4,8 +4,9 @@
 replicaCount: 1
 kommanderoperator:
   image:
-    repository: nginx
-    tag: 1.22
+    repository: mesosphere/kommander2-core-installer
+    # TODO(https://d2iq.atlassian.net/browse/D2IQ-95673 ): align version with the kommander release (either by using release automation or releasing the chart with kommander)
+    tag: v2.5.0-dev
     pullPolicy: IfNotPresent
 
 kubetools:


### PR DESCRIPTION
**What problem does this PR solve?**:
Use kommander operator image in a chart.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
Depends on https://github.com/mesosphere/kommander/pull/2920

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
