### PR TITLE
fix: Add necessary permissions to kommander-operator chart

### DIFF
--- a/charts/kommander-operator/templates/deployment.yaml
+++ b/charts/kommander-operator/templates/deployment.yaml
@@ -29,11 +29,3 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: http
-          readinessProbe:
-            httpGet:
-              path: /
-              port: http

--- a/charts/kommander-operator/templates/rback_v1_clusterrole_binding_operator_kommander-operator.yaml
+++ b/charts/kommander-operator/templates/rback_v1_clusterrole_binding_operator_kommander-operator.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Chart.Name }}-sa
-    namespace: {{ .Release.Namespace}}
+    namespace: {{ .Release.Namespace }}

--- a/charts/kommander-operator/templates/rback_v1_clusterrole_operator_kommander-operator.yaml
+++ b/charts/kommander-operator/templates/rback_v1_clusterrole_operator_kommander-operator.yaml
@@ -6,9 +6,9 @@ metadata:
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
-        rbac.authorization.k8s.io/aggregate-to-view: "true"
-        rbac.authorization.k8s.io/aggregate-to-update: "true"
-        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+        rbac.kommandercore.d2iq.com/aggregate-to-view: "true"
+        rbac.kommandercore.d2iq.com/aggregate-to-update: "true"
+        rbac.kommandercore.d2iq.com/aggregate-to-admin: "true"
 rules: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -17,14 +17,17 @@ metadata:
   name: {{ .Chart.Name }}-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.kommandercore.d2iq.com/aggregate-to-view: "true"
 rules:
   - apiGroups:
+      - dkp.d2iq.io
       - apps.kommander.d2iq.io
       - kommander.mesosphere.io
       - types.kubefed.io
       - helm.toolkit.fluxcd.io
       - kustomize.toolkit.fluxcd.io
     resources:
+      - kommandercores
       - appdeployments
       - kustomizations
       - federatednamespaces
@@ -33,6 +36,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -40,19 +44,24 @@ metadata:
   name: {{ .Chart.Name }}-update
   labels:
     rbac.authorization.k8s.io/aggregate-to-update: "true"
+    rbac.kommandercore.d2iq.com/aggregate-to-update: "true"
 rules:
   - apiGroups:
+      - dkp.d2iq.io
       - apps.kommander.d2iq.io
       - kustomize.toolkit.fluxcd.io
       - types.kubefed.io
+      - kommander.mesosphere.io
     resources:
+      - kommandercores
+      - kommandercores/status
       - appdeployments
       - kustomizations
       - federatednamespaces
+      - kommanderclusters
     verbs:
       - patch
       - update
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -60,19 +69,28 @@ metadata:
   name: {{ .Chart.Name }}-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.kommandercore.d2iq.com/aggregate-to-admin: "true"
 rules:
   - apiGroups:
+      - dkp.d2iq.io
       - apps.kommander.d2iq.io
       - batch
       - core.kubefed.io
       - helm.toolkit.fluxcd.io
       - types.kubefed.io
+      - ""
+      - kustomize.toolkit.fluxcd.io
+      - apps
     resources:
+      - kommandercores
       - appdeployments
       - kubefedclusters
       - jobs
       - federatednamespaces
       - helmreleases
+      - pods
+      - deployments
+      - kustomizations
     verbs:
       - deletecollection
       - delete


### PR DESCRIPTION
**What problem does this PR solve?**:
It was missing a few permissions

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
