### PR TITLE
feat: Automate kommander operator docker images versioning

### DIFF
--- a/charts/kommander-operator/values.yaml
+++ b/charts/kommander-operator/values.yaml
@@ -5,10 +5,10 @@ replicaCount: 1
 kommanderoperator:
   image:
     repository: mesosphere/kommander2-core-installer
-    tag: "${kommanderChartVersion:=v2.5.0-dev}"
+    tag:
     pullPolicy: IfNotPresent
 
 kubetools:
   image:
     repository: mesosphere/kommander2-kubetools
-    tag: "${kommanderChartVersion:=v2.5.0-dev}"
+    tag:

--- a/charts/kommander-operator/values.yaml
+++ b/charts/kommander-operator/values.yaml
@@ -5,12 +5,10 @@ replicaCount: 1
 kommanderoperator:
   image:
     repository: mesosphere/kommander2-core-installer
-    # TODO(https://d2iq.atlassian.net/browse/D2IQ-95673 ): align version with the kommander release (either by using release automation or releasing the chart with kommander)
-    tag: v2.5.0-dev
+    tag: "${kommanderChartVersion:=v2.5.0-dev}"
     pullPolicy: IfNotPresent
 
 kubetools:
   image:
     repository: mesosphere/kommander2-kubetools
-    # TODO(https://d2iq.atlassian.net/browse/D2IQ-95673 ): align version with the kommander release (either by using release automation or releasing the chart with kommander)
-    tag: v2.5.0-dev
+    tag: "${kommanderChartVersion:=v2.5.0-dev}"

--- a/common/kommander-operator/helmrelease.yaml
+++ b/common/kommander-operator/helmrelease.yaml
@@ -22,3 +22,20 @@ spec:
     crds: CreateReplace
     remediation:
       retries: 30
+  valuesFrom:
+    - kind: ConfigMap
+      name: kommander-operator-values
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kommander-operator-values
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    kommanderoperator:
+      image:
+        tag: "${kommanderChartVersion:=v2.5.0-dev}"
+    kubetools:
+      image:
+        tag: "${kommanderChartVersion:=v2.5.0-dev}"

--- a/hack/release/pkg/chartversion/chartversion.go
+++ b/hack/release/pkg/chartversion/chartversion.go
@@ -15,13 +15,18 @@ const kommanderChartVersionTemplate = "${kommanderChartVersion:=%s}"
 var (
 	kommanderHelmReleasePathPattern        = filepath.Join(constants.KommanderAppPath, "*/kommander.yaml")
 	kommanderAppMgmtHelmReleasePathPattern = filepath.Join(constants.KommanderAppMgmtPath, "*/kommander-appmanagement.yaml")
+	kommanderOperatorPath                  = "./charts/kommander-operator/values.yaml"
+	filesContainingKommanderVersion        = []string{
+		kommanderHelmReleasePathPattern,
+		kommanderAppMgmtHelmReleasePathPattern,
+		kommanderOperatorPath,
+	}
 )
 
 func UpdateChartVersions(kommanderApplicationsRepo, chartVersion string) error {
 	chartVersion = fmt.Sprintf(kommanderChartVersionTemplate, chartVersion)
 
-	kommanderHelmReleasePaths := []string{kommanderHelmReleasePathPattern, kommanderAppMgmtHelmReleasePathPattern}
-	for _, helmReleasePath := range kommanderHelmReleasePaths {
+	for _, helmReleasePath := range filesContainingKommanderVersion {
 		// Find the HelmRelease
 		matches, err := filepath.Glob(filepath.Join(kommanderApplicationsRepo, helmReleasePath))
 		if err != nil {
@@ -55,7 +60,7 @@ func UpdateChartVersions(kommanderApplicationsRepo, chartVersion string) error {
 			return fmt.Errorf("failed to update Kommander HelmRelease chart version")
 		}
 
-		err = os.WriteFile(helmReleaseFilePath, []byte(updatedFile), 0644)
+		err = os.WriteFile(helmReleaseFilePath, []byte(updatedFile), 0o644)
 		if err != nil {
 			return err
 		}

--- a/hack/release/pkg/chartversion/chartversion.go
+++ b/hack/release/pkg/chartversion/chartversion.go
@@ -15,7 +15,7 @@ const kommanderChartVersionTemplate = "${kommanderChartVersion:=%s}"
 var (
 	kommanderHelmReleasePathPattern        = filepath.Join(constants.KommanderAppPath, "*/kommander.yaml")
 	kommanderAppMgmtHelmReleasePathPattern = filepath.Join(constants.KommanderAppMgmtPath, "*/kommander-appmanagement.yaml")
-	kommanderOperatorPath                  = "./charts/kommander-operator/values.yaml"
+	kommanderOperatorPath                  = "./common/kommander-operator/helmrelease.yaml"
 	filesContainingKommanderVersion        = []string{
 		kommanderHelmReleasePathPattern,
 		kommanderAppMgmtHelmReleasePathPattern,


### PR DESCRIPTION
**What problem does this PR solve?**:
To make it easier to test kommander operator, let's make it possible to override the version with kommander-vars.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
