### PR TITLE
fix: restore admission controller enabled status in ceph

### DIFF
--- a/services/rook-ceph/1.10.10/defaults/cm.yaml
+++ b/services/rook-ceph/1.10.10/defaults/cm.yaml
@@ -43,6 +43,6 @@ data:
 
     # This allows DKP installations with static local static provisioner with loopback block devices (E.g.: preprovisioned with LVMs) work out of the box.
     allowLoopDevices: true
-    
+
     # Do not disable admission controller.
     disableAdmissionController: false

--- a/services/rook-ceph/1.10.10/defaults/cm.yaml
+++ b/services/rook-ceph/1.10.10/defaults/cm.yaml
@@ -43,3 +43,6 @@ data:
 
     # This allows DKP installations with static local static provisioner with loopback block devices (E.g.: preprovisioned with LVMs) work out of the box.
     allowLoopDevices: true
+    
+    # Do not disable admission controller.
+    disableAdmissionController: false

--- a/services/rook-ceph/1.10.10/helmrelease/helmrelease.yaml
+++ b/services/rook-ceph/1.10.10/helmrelease/helmrelease.yaml
@@ -27,3 +27,16 @@ spec:
     - kind: ConfigMap
       name: rook-ceph-1.10.10-d2iq-defaults
   targetNamespace: ${releaseNamespace}
+  # upstream chart doesn't allow to configure annotations
+  # TODO(takirala): remove this after the change that has been reintroduced https://github.com/rook/rook/pull/11532 in a future release.
+  postRenderers:
+    - kustomize:
+        patchesStrategicMerge:
+          - apiVersion: apps/v1
+            kind: Deployment
+            metadata:
+              # This name is hardcoded in upstream chart https://github.com/rook/rook/blob/v1.10.10/deploy/charts/rook-ceph/templates/deployment.yaml#L4.
+              name: rook-ceph-operator
+              annotations:
+                # This name is hardcoded in upstream chart https://github.com/rook/rook/blob/v1.10.10/pkg/operator/ceph/webhook-config.go#L36.
+                secret.reloader.stakater.com/reload: rook-admission-controller-cert


### PR DESCRIPTION
**What problem does this PR solve?**:



**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://d2iq.atlassian.net/browse/D2IQ-95736

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
