### PR TITLE
feat: wait for ceph operator in ceph cluster preupgrade

### DIFF
--- a/services/rook-ceph-cluster/1.10.10/pre-install.yaml
+++ b/services/rook-ceph-cluster/1.10.10/pre-install.yaml
@@ -18,3 +18,5 @@ spec:
   postBuild:
     substitute:
       releaseNamespace: ${releaseNamespace}
+      # Update the following version whenever ceph-cluster service is bumped.
+      desiredCephOperatorVersion: v1.10.10

--- a/services/rook-ceph-cluster/1.10.10/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.10.10/pre-install/ceph-crd-check.yaml
@@ -14,6 +14,9 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "watch", "list"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -42,7 +45,7 @@ spec:
       serviceAccountName: check-dkp-ceph-crd
       restartPolicy: OnFailure
       containers:
-        - name: kubectl
+        - name: pre-install
           image: bitnami/kubectl:1.24.6
           command:
             - sh
@@ -52,3 +55,39 @@ spec:
               do
                 sleep 30
               done
+        - name: pre-upgrade
+          image: bitnami/kubectl:1.24.6
+          command:
+            - sh
+            - -c
+            - |
+              # If there is a HelmRelease managed by DKP in same namespace when this job is being ran, it *might* be an
+              # upgrade scenario. If there is no such helm release, there is no way this is an upgrade scenario.
+              # Iff there is such a helmrelease, wait for it to be healthy and be of the same version.
+              #
+              # This is done here to avoid having an explicit dependency against DKP shipped ceph operator while still
+              # being able to allow us to wait for DKP shipped ceph operator if there is one.
+              timeout 30m /bin/bash <<'EOF' || true
+              kubectl get helmreleases.helm.toolkit.fluxcd.io -n ${releaseNamespace} rook-ceph
+              if [[ $? -ne 0 ]]; then
+                echo "Since rook-ceph HelmRelease does not exist, this might not be an upgrade scenario. Exiting..."
+                exit 0
+              fi
+
+              managedBy=$(kubectl get helmreleases.helm.toolkit.fluxcd.io -n ${releaseNamespace} rook-ceph -ogo-template='{{index .metadata.labels "kommander.d2iq.io/managed-by-kind"}}')
+              if [[ $managedBy != "AppDeployment" ]]; then
+                echo "HelmRelease is not managed by AppDeployment, no need to wait in this scenario. Exiting..."
+                exit 0
+              fi
+
+              echo "Waiting for ceph operator to complete its upgrade..."
+              while true; do
+                cephOperatorVersion=$(kubectl get helmreleases.helm.toolkit.fluxcd.io -n ${releaseNamespace} rook-ceph -ogo-template={{.status.lastAppliedRevision}})
+                if [[ $cephOperatorVersion == ${desiredCephOperatorVersion} ]]; then
+                  echo "Ceph operator is at same version as desired cluster version (${desiredCephOperatorVersion}). Exiting..."
+                  break
+                fi
+                echo "Ceph operator is at $cephOperatorVersion version and desired version is ${desiredCephOperatorVersion}. Continuing to wait..."
+                sleep 10
+              done
+              EOF


### PR DESCRIPTION
**What problem does this PR solve?**:

Alternative of #965 

With current ceph upgrade of 1.10.6 -> 1.10.10 which is flaking, i think the problem is : 

```
t=0 | everything was healthy, both rook-ceph and rook-ceph-cluster were running at 1.10.6
t=1 | kicked off upgrade to 1.10.10 for both rook-ceph and rook-ceph-cluster  HelmReleases
t=2 | rook-ceph was in process of deleting the webhook.
t=2 | (same time as above) rook-ceph-cluster helm upgrade tried to mutate CephCluster and other resources. The ValidatingWebhookConfiguration is still present but probably the pod/service is being terminated.

The problem is last two actions happen at t=2 . instead rook-ceph-cluster should be upgraded AFTER completing the upgrade of rook-ceph.
```

Based on how the last two actions happen, we hit the flake (or not). This PR attempts to resolve the race by adding an optional dependency check. Note that its important for this to be optional because we have to support those cases where ceph cluster is managed by a ceph operator that is not owned/managed by DKP.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://d2iq.atlassian.net/browse/D2IQ-95736

Sample logs of new container:

```
NAME        AGE   READY     STATUS
rook-ceph   30m   Unknown   Reconciliation in progress
Waiting for ceph operator to complete its upgrade...
Ceph operator is at v1.10.3 version and desired version is v1.10.10. Continuing to wait...
Ceph operator is at v1.10.3 version and desired version is v1.10.10. Continuing to wait...
Ceph operator is at same version as desired cluster version (v1.10.10). Exiting...
```

https://teamcity.mesosphere.io/repository/download/ClosedSource_Kommander2_KommanderApplications_UpgradeE2eTests/3819191:id/feature/upgrade/kind/singlecluster/support-bundle-2023-02-06T22_19_49.tar.gz!/support-bundle-2023-02-06T22_19_49/pod-logs/kommander/check-dkp-ceph-crd-qshjh-pre-upgrade.log


Or during fresh installs : 

```
NAME        AGE   READY     STATUS
rook-ceph   3s    Unknown   Reconciliation in progress
Waiting for ceph operator to complete its upgrade...
Ceph operator is at <no value> version and desired version is v1.10.10. Continuing to wait...
Ceph operator is at <no value> version and desired version is v1.10.10. Continuing to wait...
Ceph operator is at <no value> version and desired version is v1.10.10. Continuing to wait...
Ceph operator is at same version as desired cluster version (v1.10.10). Exiting...
```

Above log might look differently based on the order of how `rook-ceph` and `rook-ceph-cluster` gets installed.

https://teamcity.mesosphere.io/repository/download/ClosedSource_Kommander2_KommanderApplications_InstallE2eTests/3819193:id/feature/install/kindcluster/support-bundle-2023-02-06T22_00_07.tar.gz!/support-bundle-2023-02-06T22_00_07/pod-logs/kommander/check-dkp-ceph-crd-m76g9-pre-upgrade.log

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
