### PR TITLE
feat: wait for ceph operator in ceph cluster preupgrade (2.4)

### DIFF
--- a/services/rook-ceph-cluster/1.10.8/pre-install.yaml
+++ b/services/rook-ceph-cluster/1.10.8/pre-install.yaml
@@ -18,3 +18,5 @@ spec:
   postBuild:
     substitute:
       releaseNamespace: ${releaseNamespace}
+      # Update the following version whenever ceph-cluster service is bumped.
+      desiredCephOperatorVersion: v1.10.8

--- a/services/rook-ceph-cluster/1.10.8/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.10.8/pre-install/ceph-crd-check.yaml
@@ -15,6 +15,9 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "watch", "list"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -43,7 +46,7 @@ spec:
       serviceAccountName: check-dkp-ceph-crd
       restartPolicy: OnFailure
       containers:
-        - name: kubectl
+        - name: pre-install
           image: bitnami/kubectl:1.24.6
           command:
             - sh
@@ -53,3 +56,37 @@ spec:
               do
                 sleep 30
               done
+        - name: pre-upgrade
+          image: bitnami/kubectl:1.24.6
+          command:
+            - sh
+            - -c
+            - |
+              # If there is a HelmRelease managed by DKP in same namespace when this job is being ran, it *might* be an
+              # upgrade scenario. If there is no such helm release, there is no way this is an upgrade scenario.
+              # Iff there is such a helmrelease, wait for it to be healthy and be of the same version.
+              #
+              # This is done here to avoid having an explicit dependency against DKP shipped ceph operator while still
+              # being able to allow us to wait for DKP shipped ceph operator if there is one.
+              timeout 30m /bin/bash <<'EOF' || true
+              kubectl get helmreleases.helm.toolkit.fluxcd.io -n ${releaseNamespace} rook-ceph
+              if [[ $? -ne 0 ]]; then
+                echo "Since rook-ceph HelmRelease does not exist, this might not be an upgrade scenario. Exiting..."
+                exit 0
+              fi
+              managedBy=$(kubectl get helmreleases.helm.toolkit.fluxcd.io -n ${releaseNamespace} rook-ceph -ogo-template='{{index .metadata.labels "kommander.d2iq.io/managed-by-kind"}}')
+              if [[ $managedBy != "AppDeployment" ]]; then
+                echo "HelmRelease is not managed by AppDeployment, no need to wait in this scenario. Exiting..."
+                exit 0
+              fi
+              echo "Waiting for ceph operator to complete its upgrade..."
+              while true; do
+                cephOperatorVersion=$(kubectl get helmreleases.helm.toolkit.fluxcd.io -n ${releaseNamespace} rook-ceph -ogo-template={{.status.lastAppliedRevision}})
+                if [[ $cephOperatorVersion == ${desiredCephOperatorVersion} ]]; then
+                  echo "Ceph operator is at same version as desired cluster version (${desiredCephOperatorVersion}). Exiting..."
+                  break
+                fi
+                echo "Ceph operator is at $cephOperatorVersion version and desired version is ${desiredCephOperatorVersion}. Continuing to wait..."
+                sleep 10
+              done
+              EOF


### PR DESCRIPTION
**What problem does this PR solve?**:

Backport of #968 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://d2iq.atlassian.net/browse/D2IQ-95736

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

See #968 for details

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
