### PR TITLE
feat: recategorize istio, kiali, jaeger as platform app, add supported and certified bages

### DIFF
--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -66,7 +66,7 @@ jobs:
           git show-ref --quiet --verify -- refs/remotes/origin/kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }} || {
             git checkout -b kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }}
             # Point the kommander-applications ref to the k-apps branch
-            sed -i 's/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}/' Makefile
+            sed -i 's|KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.base_branch_name }}|KOMMANDER_APPLICATIONS_REF ?= ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }}|' Makefile
             git add Makefile
             # Update kuttl tests that reference the app being bumped
             appversion=$(echo ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }} | sed -r 's/(chartbump\/)(.*)/\2/')

--- a/services/istio/metadata.yaml
+++ b/services/istio/metadata.yaml
@@ -4,9 +4,12 @@ category:
   - service-mesh
 dependencies:
   - kube-prometheus-stack
-type: catalog
+type: platform
 scope:
   - workspace
+certifications:
+  - certified
+  - supported
 overview: |-
   # Overview
   Istio is an open platform for providing a uniform way to integrate microservices, manage traffic flow across microservices, enforce policies and aggregate telemetry data. Istio's control plane provides an abstraction layer over the underlying cluster management platform, such as Kubernetes, Mesos, etc. A large ecosystem of contributors, partners, integrations, and distributors extend and leverage Istio for a wide variety of scenarios. To use Istio, Prometheus needs to be deployed.

--- a/services/jaeger/metadata.yaml
+++ b/services/jaeger/metadata.yaml
@@ -4,9 +4,12 @@ category:
   - service-mesh
 dependencies:
   - istio
-type: catalog
+type: platform
 scope:
   - workspace
+certifications:
+  - certified
+  - supported
 overview: |-
   # Overview
   Jaeger is open source software for tracing transactions between distributed services. It is used for monitoring and troubleshooting complex microservices environments. Jaeger uses distributed tracing to follow the path of a request through different microservices.

--- a/services/kiali/metadata.yaml
+++ b/services/kiali/metadata.yaml
@@ -4,9 +4,12 @@ category:
   - service-mesh
 dependencies:
   - istio
-type: catalog
+type: platform
 scope:
   - workspace
+certifications:
+  - certified
+  - supported
 overview: |-
   # Overview
   Kiali is a management console for an Istio-based service mesh. It provides dashboards, observability, and lets you operate your mesh with robust configuration and validation capabilities. It shows the structure of your service mesh by inferring traffic topology and displays the health of your mesh. To use Kiali, Prometheus, Istio, and Jaeger need to be deployed.


### PR DESCRIPTION
**What problem does this PR solve?**:

This PR categorizes istio as an platform application.

**Which issue(s) does this PR fix?**:

<!-- Add a link to the JIRA issue below-->

https://d2iq.atlassian.net/browse/D2IQ-95625

**Special notes for your reviewer**:

<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

**Does this PR introduce a user-facing change?**:

<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->

```release-note
* Istio, kiali and jaeger are now a platform applications
```

**Checklist**

<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
