### PR TITLE
feat: Add post-install job to overwrite velero s3Url

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -68,6 +68,10 @@ resources:
       - url: https://github.com/mesosphere/kommander
         ref: ${image_tag}
         directory: licensing
+  - container_image: docker.io/mesosphere/kubeaddons-addon-initializer:v0.6.1
+    sources:
+      - url: https://github.com/mesosphere/kubeaddons-extrasteps
+        ref: ${image_tag}
   - container_image: docker.io/mesosphere/capimate:${kommander}
     sources:
       - url: https://github.com/mesosphere/konvoy2

--- a/services/traefik/20.8.0/defaults/cm.yaml
+++ b/services/traefik/20.8.0/defaults/cm.yaml
@@ -198,3 +198,10 @@ data:
     # 2. A breaking change was made in traefik 17.0.1 https://github.com/traefik/traefik-helm-chart/blob/v17.0.1/traefik/templates/deployment.yaml#L38 which caused it to be renamed to `kommander-treafik-${releaseNamespace}`
     # 3. Another change was made in 20.3.0 for backwards compatibility thats lets a user override the label value - https://github.com/traefik/traefik-helm-chart/blob/v20.3.0/traefik/templates/_helpers.tpl#L42-L47
     instanceLabelOverride: "kommander-traefik"
+
+    ports:
+      velero-ceph:
+        port: 8080
+        expose: true
+        exposedPort: 8085 # Velero is configured to use this value
+        protocol: TCP

--- a/services/velero/3.4.0/defaults/cm.yaml
+++ b/services/velero/3.4.0/defaults/cm.yaml
@@ -13,6 +13,7 @@ data:
         bucket: dkp-velero
         config:
           region: dkp-object-store
+          # this s3Url default value is overwritten by kubeaddons-addon-initializer unless set to something different
           s3Url: http://rook-ceph-rgw-dkp-object-store.${releaseNamespace}.svc:80/
           s3ForcePathStyle: true
           insecureSkipTLSVerify: "true"
@@ -35,6 +36,24 @@ data:
         labels:
           servicemonitor.kommander.mesosphere.io/path: "metrics"
     initContainers:
+      - name: initialize-velero
+        image: "${initializerImage:=mesosphere/kubeaddons-addon-initializer:v0.6.1}"
+        args: ["velero"]
+        env:
+          - name: "CEPH_NAMESPACE"
+            value: ${releaseNamespace}
+          - name: "CEPH_OBJECT_STORE_PORT"
+            value: "8085"
+          - name: "VELERO_NAMESPACE"
+            value: ${releaseNamespace}
+          - name: "VELERO_CEPH_OBJECT_STORE_REGION"
+            value: "dkp-object-store"
+          - name: "VELERO_BUCKET"
+            value: "dkp-velero"
+          - name: "TRAEFIK_INGRESS_SERVICE_NAME"
+            value: kommander-traefik
+          - name: "TRAEFIK_INGRESS_NAMESPACE"
+            value: ${releaseNamespace}
       - name: velero-plugin-for-aws
         image: velero/velero-plugin-for-aws:v1.5.2
         imagePullPolicy: IfNotPresent

--- a/services/velero/3.4.0/defaults/cm.yaml
+++ b/services/velero/3.4.0/defaults/cm.yaml
@@ -36,24 +36,6 @@ data:
         labels:
           servicemonitor.kommander.mesosphere.io/path: "metrics"
     initContainers:
-      - name: initialize-velero
-        image: "${initializerImage:=mesosphere/kubeaddons-addon-initializer:v0.6.1}"
-        args: ["velero"]
-        env:
-          - name: "CEPH_NAMESPACE"
-            value: ${releaseNamespace}
-          - name: "CEPH_OBJECT_STORE_PORT"
-            value: "8085"
-          - name: "VELERO_NAMESPACE"
-            value: ${releaseNamespace}
-          - name: "VELERO_CEPH_OBJECT_STORE_REGION"
-            value: "dkp-object-store"
-          - name: "VELERO_BUCKET"
-            value: "dkp-velero"
-          - name: "TRAEFIK_INGRESS_SERVICE_NAME"
-            value: kommander-traefik
-          - name: "TRAEFIK_INGRESS_NAMESPACE"
-            value: ${releaseNamespace}
       - name: velero-plugin-for-aws
         image: velero/velero-plugin-for-aws:v1.5.2
         imagePullPolicy: IfNotPresent

--- a/services/velero/3.4.0/helmrelease/helmrelease.yaml
+++ b/services/velero/3.4.0/helmrelease/helmrelease.yaml
@@ -27,3 +27,26 @@ spec:
     - kind: ConfigMap
       name: velero-3.4.0-d2iq-defaults
   targetNamespace: ${releaseNamespace}
+---
+# This ingress is needed to make Traefik configure an additional route
+# for handling HTTPS requests to Ceph Object Store on the same port.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: velero-ceph
+  namespace: ${releaseNamespace}
+  annotations:
+    kubernetes.io/ingress.class: kommander-traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: velero-ceph
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: rook-ceph-rgw-dkp-object-store
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific

--- a/services/velero/3.4.0/kustomization.yaml
+++ b/services/velero/3.4.0/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - velero-pre-install.yaml
+  - velero-post-install.yaml
   - velero.yaml
   - grafana-dashboards

--- a/services/velero/3.4.0/post-install/post-install-job.yaml
+++ b/services/velero/3.4.0/post-install/post-install-job.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: velero-post-install
+  namespace: ${releaseNamespace}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: velero-post-install
+  namespace: ${releaseNamespace}
+rules:
+  - apiGroups: [""]
+    resources: ["services", "configmaps"]
+    verbs: ["get", "list"]
+  - apiGroups: ["velero.io"]
+    resources: ["backupstoragelocations"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: velero-post-install
+  namespace: ${releaseNamespace}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: velero-post-install
+subjects:
+  - kind: ServiceAccount
+    name: velero-post-install
+    namespace: ${releaseNamespace}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: velero-post-install
+  namespace: ${releaseNamespace}
+spec:
+  template:
+    metadata:
+      name: velero-post-install
+    spec:
+      serviceAccountName: velero-post-install
+      restartPolicy: OnFailure
+      containers:
+        - name: velero-update-s3url
+          image: mesosphere/kubeaddons-addon-initializer:v0.6.1
+          args:
+            - velero
+          env:
+            - name: "CEPH_NAMESPACE"
+              value: ${releaseNamespace}
+            - name: "CEPH_OBJECT_STORE_PORT"
+              value: "8085"
+            - name: "VELERO_NAMESPACE"
+              value: ${releaseNamespace}
+            - name: "VELERO_CEPH_OBJECT_STORE_REGION"
+              value: "dkp-object-store"
+            - name: "VELERO_BUCKET"
+              value: "dkp-velero"
+            - name: "TRAEFIK_INGRESS_SERVICE_NAME"
+              value: kommander-traefik
+            - name: "TRAEFIK_INGRESS_NAMESPACE"
+              value: ${releaseNamespace}

--- a/services/velero/3.4.0/velero-post-install.yaml
+++ b/services/velero/3.4.0/velero-post-install.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: velero-post-install
+  namespace: ${releaseNamespace}
+spec:
+  dependsOn:
+    - name: velero-helmrelease
+      namespace: ${releaseNamespace}
+  force: false
+  prune: true
+  wait: true
+  interval: 6h
+  retryInterval: 1m
+  path: ./services/velero/3.4.0/post-install
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 1m
+  postBuild:
+    substitute:
+      releaseNamespace: ${releaseNamespace}


### PR DESCRIPTION
**What problem does this PR solve?**:
Prior to migrating to ceph from minio, we had an initContainer defined in velero that updated the s3Url config in velero to point to the public endpoint for the minio bucket. ~This brings back that initContainer~ to update the config to point to the ceph `dkp-velero` bucket public endpoint. This enables users to be able to use the velero cli to view logs.

Doing this in an initContainer no longer worked, because the backupstoragelocation is created in a post-install hook so the object doesn't exist when the initcontainer runs, which tries to update that object. In our velero forked helm chart, we disabled helm hooks, so the object existed and was able to be updated in the initcontainer. Instead, I have added a post-install kustomization that runs a job to run the update instead.

Watching kustomizations:
```
velero-helmrelease                         66s   Unknown   Reconciliation in progress
velero-helmrelease                         66s   True      Applied revision: main/8180290fbdde74a600b2118391bc1fc825bf8977
velero-helmrelease                         66s   True      Applied revision: main/8180290fbdde74a600b2118391bc1fc825bf8977
velero-post-install                        90s   Unknown   Reconciliation in progress
velero-post-install                        91s   Unknown   Reconciliation in progress
velero-post-install                        91s   Unknown   Reconciliation in progress
velero-post-install                        91s   Unknown   Reconciliation in progress
velero-post-install                        91s   Unknown   Reconciliation in progress
velero-post-install                        91s   Unknown   Reconciliation in progress
velero-post-install                        101s   Unknown   Reconciliation in progress
velero-post-install                        101s   True      Applied revision: main/8180290fbdde74a600b2118391bc1fc825bf8977
velero-post-install                        101s   True      Applied revision: main/8180290fbdde74a600b2118391bc1fc825bf8977
```

Watching the backupstoragelocation:
```
---
apiVersion: velero.io/v1
kind: BackupStorageLocation
metadata:
  annotations:
    helm.sh/hook: post-install,post-upgrade,post-rollback
    helm.sh/hook-delete-policy: before-hook-creation
  creationTimestamp: "2023-02-10T01:42:20Z"
  generation: 3
  labels:
    app.kubernetes.io/instance: velero
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: velero
    helm.sh/chart: velero-3.1.2
  name: default
  namespace: kommander
  resourceVersion: "1552820"
  uid: 16a9c712-b472-4889-83a6-5f034bd44a03
spec:
  accessMode: ReadWrite
  config:
    insecureSkipTLSVerify: "true"
    region: dkp-object-store
    s3ForcePathStyle: "true"
    s3Url: http://rook-ceph-rgw-dkp-object-store.kommander.svc:80/
  default: true
  objectStorage:
    bucket: dkp-velero
  provider: aws
status:
  lastSyncedTime: "2023-02-10T01:42:37Z"
  lastValidationTime: "2023-02-10T01:42:37Z"
  phase: Available
---
apiVersion: velero.io/v1
kind: BackupStorageLocation
metadata:
  annotations:
    helm.sh/hook: post-install,post-upgrade,post-rollback
    helm.sh/hook-delete-policy: before-hook-creation
  creationTimestamp: "2023-02-10T01:42:20Z"
  generation: 4
  labels:
    app.kubernetes.io/instance: velero
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: velero
    helm.sh/chart: velero-3.1.2
  name: default
  namespace: kommander
  resourceVersion: "1553227"
  uid: 16a9c712-b472-4889-83a6-5f034bd44a03
spec:
  accessMode: ReadWrite
  config:
    insecureSkipTLSVerify: "true"
    region: dkp-object-store
    s3ForcePathStyle: "true"
    s3Url: https://a64c241af108b4000b2a6820ddee527d-1376773859.us-west-2.elb.amazonaws.com:8085
  objectStorage:
    bucket: dkp-velero
  provider: aws
status:
  lastSyncedTime: "2023-02-10T01:42:37Z"
  lastValidationTime: "2023-02-10T01:42:37Z"
  phase: Available
```

post-install job logs
```
2023/02/10 01:42:51 WARNING: Velero's default BackupStorageLocation config.region = 'dkp-object-store'
2023/02/10 01:42:56 updating s3Url in BackupStorageLocation
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-95509
https://d2iq.atlassian.net/browse/D2IQ-95330

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
