### PR TITLE
fix: patch mutating/validating gatekeeper webhooks

### DIFF
--- a/services/gatekeeper/3.11.0/release/release.yaml
+++ b/services/gatekeeper/3.11.0/release/release.yaml
@@ -29,6 +29,30 @@ spec:
     - kind: ConfigMap
       name: gatekeeper-overrides
       optional: true
+  postRenderers:
+    - kustomize:
+        patchesJson6902:
+          - target:
+              version: v1
+              kind: MutatingWebhookConfiguration
+              name: gatekeeper-mutating-webhook-configuration
+            patch:
+              - op: remove
+                path: /webhooks/0/namespaceSelector/matchExpressions/1
+          - target:
+              version: v1
+              kind: ValidatingWebhookConfiguration
+              name: gatekeeper-validating-webhook-configuration
+            patch:
+              - op: remove
+                path: /webhooks/0/namespaceSelector/matchExpressions/1
+          - target:
+              version: v1
+              kind: ValidatingWebhookConfiguration
+              name: gatekeeper-validating-webhook-configuration
+            patch:
+              - op: remove
+                path: /webhooks/1/namespaceSelector/matchExpressions/0
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease

--- a/services/gatekeeper/3.11.0/release/release.yaml
+++ b/services/gatekeeper/3.11.0/release/release.yaml
@@ -31,6 +31,10 @@ spec:
       optional: true
   postRenderers:
     - kustomize:
+        # Remove the hardcoded namespaceSelectors until https://d2iq.atlassian.net/browse/D2IQ-92439 is resolved.
+        # https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml#L29-L32
+        # https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml#L29-L32
+        # https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml#L93-L96
         patchesJson6902:
           - target:
               version: v1


### PR DESCRIPTION
**What problem does this PR solve?**:
This PR works around a recent change to the gatekeeper mutating and validation webhooks in `v3.11.0`. 

The release namespace is now being ignored in https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml#L29-L32. 

To work around this, we can patch the hardcoded matchExpressions that ignores the release namespace until we can move it to a different namespace (hopefully next release).

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-95922

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
