### PR TITLE
feat: Add post-install job to overwrite velero s3Url

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -63,6 +63,10 @@ resources:
       - url: https://github.com/mesosphere/kommander
         ref: ${image_tag}
         directory: licensing
+  - container_image: docker.io/mesosphere/kubeaddons-addon-initializer:v0.6.1
+    sources:
+      - url: https://github.com/mesosphere/kubeaddons-extrasteps
+        ref: ${image_tag}
   - container_image: docker.io/mesosphere/capimate:${kommander}
     sources:
       - url: https://github.com/mesosphere/konvoy2

--- a/services/traefik/10.30.1/defaults/cm.yaml
+++ b/services/traefik/10.30.1/defaults/cm.yaml
@@ -197,12 +197,10 @@ data:
           # pathOverride: "${releaseNamespace}/kommander-traefik"
     pilot:
       dashboard: false
+
     ports:
-      # Minio must be hosted on a separate port and not on a subpath,
-      # see explaination in https://github.com/minio/minio/issues/10162
-      velero-minio:
-        # port: 9000 is occupied by the "traefik" endpoint which is not exposed
-        port: 9090
+      velero-ceph:
+        port: 8080
         expose: true
-        exposedPort: 9000 # Velero is configured to use this value
+        exposedPort: 8085 # Velero is configured to use this value
         protocol: TCP

--- a/services/velero/3.3.1/defaults/cm.yaml
+++ b/services/velero/3.3.1/defaults/cm.yaml
@@ -13,6 +13,7 @@ data:
         bucket: dkp-velero
         config:
           region: dkp-object-store
+          # this s3Url default value is overwritten by kubeaddons-addon-initializer unless set to something different
           s3Url: http://rook-ceph-rgw-dkp-object-store.${releaseNamespace}.svc:80/
           s3ForcePathStyle: true
           insecureSkipTLSVerify: "true"
@@ -35,6 +36,24 @@ data:
         labels:
           servicemonitor.kommander.mesosphere.io/path: "metrics"
     initContainers:
+      - name: initialize-velero
+        image: "${initializerImage:=mesosphere/kubeaddons-addon-initializer:v0.6.1}"
+        args: ["velero"]
+        env:
+          - name: "CEPH_NAMESPACE"
+            value: ${releaseNamespace}
+          - name: "CEPH_OBJECT_STORE_PORT"
+            value: "8085"
+          - name: "VELERO_NAMESPACE"
+            value: ${releaseNamespace}
+          - name: "VELERO_CEPH_OBJECT_STORE_REGION"
+            value: "dkp-object-store"
+          - name: "VELERO_BUCKET"
+            value: "dkp-velero"
+          - name: "TRAEFIK_INGRESS_SERVICE_NAME"
+            value: kommander-traefik
+          - name: "TRAEFIK_INGRESS_NAMESPACE"
+            value: ${releaseNamespace}
       - name: velero-plugin-for-aws
         image: velero/velero-plugin-for-aws:v1.5.2
         imagePullPolicy: IfNotPresent

--- a/services/velero/3.3.1/defaults/cm.yaml
+++ b/services/velero/3.3.1/defaults/cm.yaml
@@ -36,24 +36,6 @@ data:
         labels:
           servicemonitor.kommander.mesosphere.io/path: "metrics"
     initContainers:
-      - name: initialize-velero
-        image: "${initializerImage:=mesosphere/kubeaddons-addon-initializer:v0.6.1}"
-        args: ["velero"]
-        env:
-          - name: "CEPH_NAMESPACE"
-            value: ${releaseNamespace}
-          - name: "CEPH_OBJECT_STORE_PORT"
-            value: "8085"
-          - name: "VELERO_NAMESPACE"
-            value: ${releaseNamespace}
-          - name: "VELERO_CEPH_OBJECT_STORE_REGION"
-            value: "dkp-object-store"
-          - name: "VELERO_BUCKET"
-            value: "dkp-velero"
-          - name: "TRAEFIK_INGRESS_SERVICE_NAME"
-            value: kommander-traefik
-          - name: "TRAEFIK_INGRESS_NAMESPACE"
-            value: ${releaseNamespace}
       - name: velero-plugin-for-aws
         image: velero/velero-plugin-for-aws:v1.5.2
         imagePullPolicy: IfNotPresent

--- a/services/velero/3.3.1/helmrelease/helmrelease.yaml
+++ b/services/velero/3.3.1/helmrelease/helmrelease.yaml
@@ -27,3 +27,26 @@ spec:
     - kind: ConfigMap
       name: velero-3.3.1-d2iq-defaults
   targetNamespace: ${releaseNamespace}
+---
+# This ingress is needed to make Traefik configure an additional route
+# for handling HTTPS requests to Ceph Object Store on the same port.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: velero-ceph
+  namespace: ${releaseNamespace}
+  annotations:
+    kubernetes.io/ingress.class: kommander-traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: velero-ceph
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: rook-ceph-rgw-dkp-object-store
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific

--- a/services/velero/3.3.1/kustomization.yaml
+++ b/services/velero/3.3.1/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - velero-pre-install.yaml
+  - velero-post-install.yaml
   - velero.yaml
   - grafana-dashboards

--- a/services/velero/3.3.1/post-install/post-install-job.yaml
+++ b/services/velero/3.3.1/post-install/post-install-job.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: velero-post-install
+  namespace: ${releaseNamespace}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: velero-post-install
+  namespace: ${releaseNamespace}
+rules:
+  - apiGroups: [""]
+    resources: ["services", "configmaps"]
+    verbs: ["get", "list"]
+  - apiGroups: ["velero.io"]
+    resources: ["backupstoragelocations"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: velero-post-install
+  namespace: ${releaseNamespace}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: velero-post-install
+subjects:
+  - kind: ServiceAccount
+    name: velero-post-install
+    namespace: ${releaseNamespace}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: velero-post-install
+  namespace: ${releaseNamespace}
+spec:
+  template:
+    metadata:
+      name: velero-post-install
+    spec:
+      serviceAccountName: velero-post-install
+      restartPolicy: OnFailure
+      containers:
+        - name: velero-update-s3url
+          image: mesosphere/kubeaddons-addon-initializer:v0.6.1
+          args:
+            - velero
+          env:
+            - name: "CEPH_NAMESPACE"
+              value: ${releaseNamespace}
+            - name: "CEPH_OBJECT_STORE_PORT"
+              value: "8085"
+            - name: "VELERO_NAMESPACE"
+              value: ${releaseNamespace}
+            - name: "VELERO_CEPH_OBJECT_STORE_REGION"
+              value: "dkp-object-store"
+            - name: "VELERO_BUCKET"
+              value: "dkp-velero"
+            - name: "TRAEFIK_INGRESS_SERVICE_NAME"
+              value: kommander-traefik
+            - name: "TRAEFIK_INGRESS_NAMESPACE"
+              value: ${releaseNamespace}

--- a/services/velero/3.3.1/velero-post-install.yaml
+++ b/services/velero/3.3.1/velero-post-install.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: velero-post-install
+  namespace: ${releaseNamespace}
+spec:
+  dependsOn:
+    - name: velero-helmrelease
+      namespace: ${releaseNamespace}
+  force: false
+  prune: true
+  wait: true
+  interval: 6h
+  retryInterval: 1m
+  path: ./services/velero/3.3.1/post-install
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 1m
+  postBuild:
+    substitute:
+      releaseNamespace: ${releaseNamespace}


### PR DESCRIPTION
**What problem does this PR solve?**:
backports https://github.com/mesosphere/kommander-applications/pull/975

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-95509
https://d2iq.atlassian.net/browse/D2IQ-95330

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
