### PR TITLE
feat: automate image bump for licenses.d2iq.yaml

### DIFF
--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -47,6 +47,7 @@ jobs:
           git_commit_gpgsign: true
           git_tag_gpgsign: true
       - name: Update licenses
+        continue-on-error: true
         if: steps.runValidation.outcome == 'failure'
         uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.9
         with:

--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -63,7 +63,7 @@ jobs:
           git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
           git add licenses.d2iq.yaml
           if output=$(git status --porcelain) && [ ! -z "$output" ]; then
-            git commit -v -m "build: Updated licenses.yaml"
+            git commit -v -m "build: Updated licenses.d2iq.yaml"
             git push --force-with-lease
           fi
         env:

--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -61,7 +61,7 @@ jobs:
           git config user.name d2iq-mergebot
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
           git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
-          git add .github/service-labeler.yaml
+          git add licenses.d2iq.yaml
           if output=$(git status --porcelain) && [ ! -z "$output" ]; then
             git commit -v -m "build: Updated licenses.yaml"
             git push --force-with-lease

--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -26,7 +26,7 @@ jobs:
           echo "printing contents of images.txt"
           cat images.txt
       - name: Run validation
-        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.8
+        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.9
         with:
           args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=github
         env:

--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -14,8 +14,12 @@ jobs:
     env:
       BLOODHOUND_VERSION: v0.8.0
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Download Bloodhound CLI
         run: |
           curl -fsSL https://downloads.d2iq.com/dkp-bloodhound/dkp-bloodhound_${BLOODHOUND_VERSION}_linux_amd64.tar.gz | tar xz -O > bloodhound
@@ -26,8 +30,40 @@ jobs:
           echo "printing contents of images.txt"
           cat images.txt
       - name: Run validation
+        id: runValidation
+        continue-on-error: true
         uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.9
         with:
           args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=github
         env:
           GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
+      - name: Import GPG key
+        if: steps.runValidation.outcome == 'failure'
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+      - name: Update licenses
+        if: steps.runValidation.outcome == 'failure'
+        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.9
+        with:
+          args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=update
+        env:
+          GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
+      - name: Commit and push changes
+        if: steps.runValidation.outcome == 'failure'
+        run: |
+          git config user.email ci-mergebot@d2iq.com
+          git config user.name d2iq-mergebot
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+          git add .github/service-labeler.yaml
+          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+            git commit -v -m "build: Updated licenses.yaml"
+            git push --force-with-lease
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -210,7 +210,7 @@ resources:
       - url: https://github.com/knative-sandbox/net-istio
         ref: knative-v1.8.0
         license_path: LICENSE
-  - container_image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook:v1.7.0
+  - container_image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook:v1.8.0
     sources:
       - url: https://github.com/knative-sandbox/net-istio
         ref: knative-v1.8.0
@@ -332,7 +332,7 @@ resources:
       - url: https://github.com/kiali/kiali-operator
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: quay.io/kiwigrid/k8s-sidecar:1.19.1
+  - container_image: quay.io/kiwigrid/k8s-sidecar:1.19.2
     sources:
       - url: https://github.com/kiwigrid/k8s-sidecar
         ref: ${image_tag}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -210,7 +210,7 @@ resources:
       - url: https://github.com/knative-sandbox/net-istio
         ref: knative-v1.8.0
         license_path: LICENSE
-  - container_image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook:v1.8.0
+  - container_image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook:v1.7.0
     sources:
       - url: https://github.com/knative-sandbox/net-istio
         ref: knative-v1.8.0
@@ -332,7 +332,7 @@ resources:
       - url: https://github.com/kiali/kiali-operator
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: quay.io/kiwigrid/k8s-sidecar:1.19.2
+  - container_image: quay.io/kiwigrid/k8s-sidecar:1.19.1
     sources:
       - url: https://github.com/kiwigrid/k8s-sidecar
         ref: ${image_tag}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -388,13 +388,13 @@ resources:
         ref: ${image_tag}
         license_path: LICENSE
         notice_path: NOTICE
-  - container_image: quay.io/prometheus/prometheus:v2.35.0
+  - container_image: quay.io/prometheus/prometheus:v2.36.0
     sources:
       - url: https://github.com/prometheus/prometheus
         ref: ${image_tag}
         license_path: LICENSE
         notice_path: NOTICE
-  - container_image: quay.io/thanos/thanos:v0.17.1
+  - container_image: quay.io/thanos/thanos:v0.18.1
     sources:
       - url: https://github.com/thanos-io/thanos
         ref: ${image_tag}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -1,27 +1,12 @@
 ignore:
   - docker.io/mesosphere/grafana-plugins:v0.0.1
-
-  # The image is set of tools that is not built from source code.
-  # See: https://github.com/mesosphere/kommander (dir: docker)
   - docker.io/mesosphere/kommander2-kubetools
-
-  # Fossa cannot scan nginx source code (C/C++)
-  # Original mapping:
-  # - container_image: docker.io/nginxinc/nginx-unprivileged:1.22.0-alpine
-  #   sources:
-  #     - url: https://github.com/nginxinc/docker-nginx-unprivileged
-  #       ref: 82a186f7a71ca66269dba0a3eef1fb16f9121946
-  #       license_path: LICENSE
   - docker.io/nginxinc/nginx-unprivileged:1.22.0-alpine
-
-  # List of bitnami containers that were mapped to build repository source code
-  # but not to the actual bundled software source code
   - docker.io/bitnami/external-dns:0.13.2-debian-11-r0
   - docker.io/bitnami/kubectl:1.24.6
   - docker.io/bitnami/kubectl:1.24.1
   - docker.io/bitnami/memcached:1.6.15-debian-11-r8
   - docker.io/bitnami/postgresql:11.16.0-debian-11-r9
-
 resources:
   - container_image: docker.io/mesosphere/kommander2-core-installer:${kommander}
     sources:
@@ -76,9 +61,6 @@ resources:
     sources:
       - url: https://github.com/mesosphere/konvoy2
         ref: ${image_tag}
-        # The `capimate` source code is in `capimate` subdirectory but it shares
-        # go.mod with main konvoy2 source code.
-        # directory: capimate
   - container_image: cr.fluentbit.io/fluent/fluent-bit:2.0.6
     sources:
       - url: https://github.com/fluent/fluent-bit
@@ -388,13 +370,13 @@ resources:
         ref: ${image_tag}
         license_path: LICENSE
         notice_path: NOTICE
-  - container_image: quay.io/prometheus/prometheus:v2.36.0
+  - container_image: quay.io/prometheus/prometheus:v2.35.0
     sources:
       - url: https://github.com/prometheus/prometheus
         ref: ${image_tag}
         license_path: LICENSE
         notice_path: NOTICE
-  - container_image: quay.io/thanos/thanos:v0.18.1
+  - container_image: quay.io/thanos/thanos:v0.17.1
     sources:
       - url: https://github.com/thanos-io/thanos
         ref: ${image_tag}


### PR DESCRIPTION
**What problem does this PR solve?**:
Automates the process of bumping images in licenses.d2iq.yaml by using the new 'update' flag for image mapping. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-95738 

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

The last commit in this PR is and example run of an automated image bump. Two images were manually changed to outdated versions. Mergebot created a pr to remedy this.

As comments are not included in new versions of licenses.d2iq.yaml, there will be a follow-up pr which updates the documentation in this repo's README.

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
