### PR TITLE
fix: update validate license to be opt-in

### DIFF
--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -1,7 +1,9 @@
 name: Check licenses.d2iq.yaml
 on:
-  pull_request: 
-    types: [ labeled ]
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
   workflow_dispatch: {}
   push:
     tags:
@@ -40,7 +42,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
       - name: Import GPG key
         if: |
-          steps.runValidation.outcome == 'failure' 
+          steps.runValidation.outcome == 'failure'
           && contains(github.event.pull_request.labels.*.name, 'update-licenses')
         uses: crazy-max/ghaction-import-gpg@v4
         with:
@@ -52,7 +54,7 @@ jobs:
       - name: Update licenses
         continue-on-error: true
         if: |
-          steps.runValidation.outcome == 'failure' 
+          steps.runValidation.outcome == 'failure'
           && contains(github.event.pull_request.labels.*.name, 'update-licenses')
         uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.9
         with:
@@ -61,7 +63,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
       - name: Commit and push changes
         if: |
-          steps.runValidation.outcome == 'failure' 
+          steps.runValidation.outcome == 'failure'
           && contains(github.event.pull_request.labels.*.name, 'update-licenses')
         run: |
           git config user.email ci-mergebot@d2iq.com

--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -39,7 +39,9 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
       - name: Import GPG key
-        if: steps.runValidation.outcome == 'failure' && ${{ github.event.label.name == 'update-licenses' }}
+        if: |
+          steps.runValidation.outcome == 'failure' 
+          && contains(github.event.pull_request.labels.*.name, 'update-licenses')
         uses: crazy-max/ghaction-import-gpg@v4
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -49,14 +51,18 @@ jobs:
           git_tag_gpgsign: true
       - name: Update licenses
         continue-on-error: true
-        if: steps.runValidation.outcome == 'failure' && ${{ github.event.label.name == 'update-licenses' }}
+        if: |
+          steps.runValidation.outcome == 'failure' 
+          && contains(github.event.pull_request.labels.*.name, 'update-licenses')
         uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.9
         with:
           args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=update
         env:
           GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
       - name: Commit and push changes
-        if: steps.runValidation.outcome == 'failure' && ${{ github.event.label.name == 'update-licenses' }}
+        if: |
+          steps.runValidation.outcome == 'failure' 
+          && contains(github.event.pull_request.labels.*.name, 'update-licenses')
         run: |
           git config user.email ci-mergebot@d2iq.com
           git config user.name d2iq-mergebot

--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -1,6 +1,7 @@
 name: Check licenses.d2iq.yaml
 on:
-  pull_request: {}
+  pull_request: 
+    types: [ labeled ]
   workflow_dispatch: {}
   push:
     tags:
@@ -38,7 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
       - name: Import GPG key
-        if: steps.runValidation.outcome == 'failure'
+        if: steps.runValidation.outcome == 'failure' && ${{ github.event.label.name == 'update-licenses' }}
         uses: crazy-max/ghaction-import-gpg@v4
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -48,14 +49,14 @@ jobs:
           git_tag_gpgsign: true
       - name: Update licenses
         continue-on-error: true
-        if: steps.runValidation.outcome == 'failure'
+        if: steps.runValidation.outcome == 'failure' && ${{ github.event.label.name == 'update-licenses' }}
         uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.9
         with:
           args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=update
         env:
           GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
       - name: Commit and push changes
-        if: steps.runValidation.outcome == 'failure'
+        if: steps.runValidation.outcome == 'failure' && ${{ github.event.label.name == 'update-licenses' }}
         run: |
           git config user.email ci-mergebot@d2iq.com
           git config user.name d2iq-mergebot

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -103,7 +103,7 @@ resources:
       - url: https://github.com/jimmidyson/configmap-reload
         ref: ${image_tag}
         license_path: LICENSE.txt
-  - container_image: docker.io/kiwigrid/k8s-sidecar:1.15.9
+  - container_image: docker.io/kiwigrid/k8s-sidecar:1.16.9
     sources:
       - url: https://github.com/kiwigrid/k8s-sidecar
         ref: ${image_tag}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -103,7 +103,7 @@ resources:
       - url: https://github.com/jimmidyson/configmap-reload
         ref: ${image_tag}
         license_path: LICENSE.txt
-  - container_image: docker.io/kiwigrid/k8s-sidecar:1.16.9
+  - container_image: docker.io/kiwigrid/k8s-sidecar:1.15.9
     sources:
       - url: https://github.com/kiwigrid/k8s-sidecar
         ref: ${image_tag}


### PR DESCRIPTION
**What problem does this PR solve?**:
makes GHA to update license.d2iq.yaml optional based on the use of the 'update-licenses' label until check licenses is debugged
Ex. of incorrect bug in check-licenses: https://github.com/mesosphere/kommander-applications/pull/1008/commits/f4b46edb84153fbdfa29c0a71c0acf8542f2a194 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
