### PR TITLE
feat: Add managementApps to kommander default values

### DIFF
--- a/services/kommander/0.5.0/defaults/cm.yaml
+++ b/services/kommander/0.5.0/defaults/cm.yaml
@@ -85,6 +85,21 @@ data:
     capimate:
       image:
         tag: v0.0.0-dev.0
+    managementApps:
+    - "centralized-grafana"
+    - "centralized-kubecost"
+    - "chartmuseum"
+    - "dex"
+    - "dex-k8s-authenticator"
+    - "dkp-insights-management"
+    - "gitea"
+    - "karma"
+    - "karma-traefik"
+    - "kommander"
+    - "kommander-appmanagement"
+    - "kubefed"
+    - "thanos"
+    - "traefik-forward-auth-mgmt"
     attached:
       prerequisites:
         defaultApps:


### PR DESCRIPTION
**What problem does this PR solve?**:
Add `managementApps` to kommander default values to go along with https://github.com/mesosphere/kommander/pull/3088

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-96050

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
