### PR TITLE
fix: Add kubetunnel to list of management apps

### DIFF
--- a/services/kommander/0.5.0/defaults/cm.yaml
+++ b/services/kommander/0.5.0/defaults/cm.yaml
@@ -94,7 +94,6 @@ data:
     - "dkp-insights-management"
     - "gitea"
     - "karma"
-    - "karma-traefik"
     - "kommander"
     - "kommander-appmanagement"
     - "kubefed"

--- a/services/kommander/0.5.0/defaults/cm.yaml
+++ b/services/kommander/0.5.0/defaults/cm.yaml
@@ -100,6 +100,7 @@ data:
     - "kubefed"
     - "thanos"
     - "traefik-forward-auth-mgmt"
+    - "kubetunnel"
     attached:
       prerequisites:
         defaultApps:


### PR DESCRIPTION
**What problem does this PR solve?**:
Kubetunnel is a mgmt only application, we can ignore it while copying over appdeployments during expansion.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
