### PR TITLE
fix: remove thanos-traefik HR dependsOn

### DIFF
--- a/services/karma-traefik/0.0.1/karma-traefik.yaml
+++ b/services/karma-traefik/0.0.1/karma-traefik.yaml
@@ -5,9 +5,6 @@ metadata:
   name: karma-traefik
   namespace: ${releaseNamespace}
 spec:
-  dependsOn:
-    - namespace: ${releaseNamespace}
-      name: kube-prometheus-stack
   chart:
     spec:
       chart: thanos-traefik

--- a/services/kubecost-thanos-traefik/0.0.1/kubecost-thanos-traefik.yaml
+++ b/services/kubecost-thanos-traefik/0.0.1/kubecost-thanos-traefik.yaml
@@ -5,9 +5,6 @@ metadata:
   name: kubecost-thanos-traefik
   namespace: ${releaseNamespace}
 spec:
-  dependsOn:
-    - namespace: ${releaseNamespace}
-      name: kubecost
   chart:
     spec:
       chart: thanos-traefik

--- a/services/prometheus-thanos-traefik/0.0.1/prometheus-thanos-traefik.yaml
+++ b/services/prometheus-thanos-traefik/0.0.1/prometheus-thanos-traefik.yaml
@@ -5,9 +5,6 @@ metadata:
   name: prometheus-thanos-traefik
   namespace: ${releaseNamespace}
 spec:
-  dependsOn:
-    - namespace: ${releaseNamespace}
-      name: kube-prometheus-stack
   chart:
     spec:
       chart: thanos-traefik


### PR DESCRIPTION
**What problem does this PR solve?**:
This HelmRelease can exist without their dependencies, so lets remove them.

This will also allow us to deploy `kubecost-thanos-traefik` (and other) without requiring `kubecost` to be installed which will help with the expansion feature.

relates to https://github.com/mesosphere/kommander/pull/3128/files

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
