### PR TITLE
fix: Fix indentation in dex defaults cm

### DIFF
--- a/services/dex/2.11.1/defaults/cm.yaml
+++ b/services/dex/2.11.1/defaults/cm.yaml
@@ -70,10 +70,10 @@ data:
         manager:
           dexConfigSecretName: dex
           dexDeploymentName: dex
-    deployment:
-      annotations:
-        secret.reloader.stakater.com/reload: dex-dex-controller-webhook-server-cert # If a fullNameOverride has been set, change the value of "dex-dex-controller" accordingly.
-    service:
-      metrics:
-        labels:
-          servicemonitor.kommander.mesosphere.io/path: metrics
+      deployment:
+        annotations:
+          secret.reloader.stakater.com/reload: dex-dex-controller-webhook-server-cert # If a fullNameOverride has been set, change the value of "dex-dex-controller" accordingly.
+      service:
+        metrics:
+          labels:
+            servicemonitor.kommander.mesosphere.io/path: metrics


### PR DESCRIPTION
**What problem does this PR solve?**:
noticed the indentation was off here

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
partially mentioned in https://d2iq.atlassian.net/browse/D2IQ-96189

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
