### PR TITLE
feat: Bump up alertmanager resource requests

### DIFF
--- a/services/kube-prometheus-stack/44.2.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/44.2.1/defaults/cm.yaml
@@ -361,8 +361,8 @@ data:
             cpu: 200m
             memory: 250Mi
           requests:
-            cpu: 10m
-            memory: 50Mi
+            cpu: 100m
+            memory: 200Mi
     grafana:
       enabled: true
       defaultDashboardsEnabled: true


### PR DESCRIPTION
This bumps it up to match what we were originally setting in the KPS overrides (for mgmt cluster). The diff in resources here is small and doesn't hurt to bump here to be the default. This allows us to also remove this override from the KPS overrides.

**What problem does this PR solve?**:
goes with https://github.com/mesosphere/kommander-cli/pull/986

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-96187

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
