### PR TITLE
fix: Fix errors in kiali config

### DIFF
--- a/services/kiali/1.63.2/defaults/cm.yaml
+++ b/services/kiali/1.63.2/defaults/cm.yaml
@@ -27,7 +27,7 @@ data:
           grafana:
             in_cluster_url: http://kube-prometheus-stack-grafana.${workspaceNamespace}.svc.cluster.local:3000
           prometheus:
-            health_check_url: http://kube-prometheus-stack-prometheus.kommander.svc.cluster.local:9090/-/healthy
+            health_check_url: http://kube-prometheus-stack-prometheus.${workspaceNamespace}.svc.cluster.local:9090/-/healthy
             url: http://kube-prometheus-stack-prometheus.${workspaceNamespace}.svc.cluster.local:9090
           tracing:
             in_cluster_url: http://jaeger-jaeger-operator-jaeger-query.istio-system.svc.cluster.local:16685

--- a/services/kiali/1.63.2/defaults/cm.yaml
+++ b/services/kiali/1.63.2/defaults/cm.yaml
@@ -20,7 +20,8 @@ data:
           prometheus:
             url: http://kube-prometheus-stack-prometheus.${workspaceNamespace}.svc.cluster.local:9090
           tracing:
-            in_cluster_url: http://jaeger-jaeger-operator-jaeger-query.istio-system.svc.cluster.local:16686
+            in_cluster_url: http://jaeger-jaeger-operator-jaeger-query.istio-system.svc.cluster.local:16685
+            use_grpc: true
         deployment:
           accessible_namespaces:
           - '**'

--- a/services/kiali/1.63.2/defaults/cm.yaml
+++ b/services/kiali/1.63.2/defaults/cm.yaml
@@ -18,6 +18,7 @@ data:
           grafana:
             in_cluster_url: http://kube-prometheus-stack-grafana.${workspaceNamespace}.svc.cluster.local:3000
           prometheus:
+            health_check_url: http://kube-prometheus-stack-prometheus.kommander.svc.cluster.local:9090/-/healthy
             url: http://kube-prometheus-stack-prometheus.${workspaceNamespace}.svc.cluster.local:9090
           tracing:
             in_cluster_url: http://jaeger-jaeger-operator-jaeger-query.istio-system.svc.cluster.local:16685

--- a/services/kiali/1.63.2/defaults/cm.yaml
+++ b/services/kiali/1.63.2/defaults/cm.yaml
@@ -15,6 +15,15 @@ data:
         server:
           web_root: /dkp/kiali
         external_services:
+          istio:
+            component_status:
+              components:
+              - app_label: "istiod"
+                is_core: true
+                is_proxy: false
+              - app_label: "istio-ingressgateway"
+                is_core: true
+                is_proxy: true
           grafana:
             in_cluster_url: http://kube-prometheus-stack-grafana.${workspaceNamespace}.svc.cluster.local:3000
           prometheus:


### PR DESCRIPTION
**What problem does this PR solve?**:
- use correct grpc port for jaeger in kiali config (`use_grpc` defaults to `true`, so just explicitly setting it here to prevent future confusion)
- add prometheus health check endpoint explicitly, which fixes the "Unreachable" errors
- overwrite the istio components to not include "istio-egressgateway" component since it is not deployed in our istio app by default

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-96214

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
