### PR TITLE
fix: Disable grafana links in kiali dashboard

### DIFF
--- a/services/kiali/1.63.2/defaults/cm.yaml
+++ b/services/kiali/1.63.2/defaults/cm.yaml
@@ -25,7 +25,7 @@ data:
                 is_core: true
                 is_proxy: true
           grafana:
-            in_cluster_url: http://kube-prometheus-stack-grafana.${workspaceNamespace}.svc.cluster.local:3000
+            enabled: false
           prometheus:
             health_check_url: http://kube-prometheus-stack-prometheus.${workspaceNamespace}.svc.cluster.local:9090/-/healthy
             url: http://kube-prometheus-stack-prometheus.${workspaceNamespace}.svc.cluster.local:9090


### PR DESCRIPTION
**What problem does this PR solve?**:
![image](https://user-images.githubusercontent.com/5897740/222811361-7496e45e-7941-47fd-9fb0-70cbedb7f569.png)

I haven't been able to figure out how to fix the `grafana URL is not set in Kiali configuration` error, but since this just enables links to grafana directly from the kiali dashboard, I think we can just disable the integration and avoid the error in the UI. This is technically a "feature" so if we feel like we must provide this feature in the future, then we can come back to this bug.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-96214

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
