### PR TITLE
fix: Remove koperator from base kustomization

### DIFF
--- a/common/base/kustomization.yaml
+++ b/common/base/kustomization.yaml
@@ -3,4 +3,3 @@ kind: Kustomization
 resources:
   - ../helm-repositories/
   - ../values/
-  - ../kommander-operator/


### PR DESCRIPTION
This change was applying automatically to ALL attached clusters during mgmt cluster upgrade (upgrade of k-apps repo) which had their kustomization still pointing to the ./common/base. In order to avoid this, we need to move koperator path out of ./common/base resources and only install it on the mgmt cluster during install and upgrade (being done in https://github.com/mesosphere/kommander-cli/pull/990).

**What problem does this PR solve?**:

To test, I tagged `v2.5.0-dev` off my kcli branch (https://github.com/mesosphere/kommander-cli/pull/990) and am running kommander CI pointing to this kapps branch https://github.com/mesosphere/kommander/pull/3146

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-96232

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
