### PR TITLE
fix: Kommander bump PRs overwriting suffixes

### DIFF
--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -74,7 +74,7 @@ jobs:
               # Update kuttl tests that reference the app being bumped
               appversion=$(echo ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }} | sed -r 's/(chartbump\/)(.*)/\2/')
               appname=$(echo $appversion | sed -r 's/(.*)(-.*)/\1/')
-              semver="(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?"
+              semver="(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)"
               for file in $(find ./tests ./docs -type f -print); do
                 case $file in
                   *".yaml" | *".yaml.tmpl" | *".md") sed -r -i "s/$appname-$semver/$appversion/g" $file;;


### PR DESCRIPTION
**What problem does this PR solve?**:
Automated chart bump removes parts of image refs, ex: https://github.com/mesosphere/kommander/pull/2852/files#diff-43b0f650494b2bde2938c28871eab2581680248ffa7014c60a2d798629cd9b2dR9

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/jira/software/c/projects/D2IQ/boards/61?modal=detail&selectedIssue=D2IQ-95823&sprint=1950

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

Example kommander branch created without this fix: https://github.com/mesosphere/kommander/pull/3143/files#diff-43b0f650494b2bde2938c28871eab2581680248ffa7014c60a2d798629cd9b2dR9

Example of kommander branch created with this fix: https://github.com/mesosphere/kommander/pull/3148/files#diff-43b0f650494b2bde2938c28871eab2581680248ffa7014c60a2d798629cd9b2dR9

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
