### PR TITLE
fix: use registry.k8s.io image

### DIFF
--- a/services/kubecost/0.33.1/defaults/cm.yaml
+++ b/services/kubecost/0.33.1/defaults/cm.yaml
@@ -7,6 +7,11 @@ data:
   values.yaml: |
     ---
     cost-analyzer:
+      prometheus:
+        kube-state-metrics:
+          image:
+            # Remove this override after https://github.com/kubecost/cost-analyzer-helm-chart/pull/2018 is released in v1.101.0
+            repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
       global:
         prometheus:
           enabled: true


### PR DESCRIPTION
**What problem does this PR solve?**:

In light of https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/ we can anticipate a future cops issue when a customer tries to pull the image from the old registry. Until we can bump kubecost (its right around the corner - https://github.com/kubecost/cost-analyzer-helm-chart/releases/tag/v1.101.0-rc.3 ) we can override configmap values to not use the `k8s.gcr.io` registry.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
