### PR TITLE
fix: Run informer in deployment for velero post-install (2.4)

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -63,7 +63,7 @@ resources:
       - url: https://github.com/mesosphere/kommander
         ref: ${image_tag}
         directory: licensing
-  - container_image: docker.io/mesosphere/kubeaddons-addon-initializer:v0.6.1
+  - container_image: docker.io/mesosphere/kubeaddons-addon-initializer:v0.7.0
     sources:
       - url: https://github.com/mesosphere/kubeaddons-extrasteps
         ref: ${image_tag}

--- a/services/velero/3.3.1/post-install/deployment_update-backupstoragelocation.yaml
+++ b/services/velero/3.3.1/post-install/deployment_update-backupstoragelocation.yaml
@@ -35,24 +35,24 @@ subjects:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: velero-backup-storage-location-informer
+  name: velero-backup-storage-location-updater
   namespace: ${releaseNamespace}
   labels:
     app: velero
-    name: velero-backup-storage-location-informer
+    name: velero-backup-storage-location-updater
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: velero
-      name: velero-backup-storage-location-informer
+      name: velero-backup-storage-location-updater
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
         app: velero
-        name: velero-backup-storage-location-informer
+        name: velero-backup-storage-location-updater
     spec:
       serviceAccountName: velero-post-install
       containers:

--- a/services/velero/3.3.1/post-install/deployment_update-backupstoragelocation.yaml
+++ b/services/velero/3.3.1/post-install/deployment_update-backupstoragelocation.yaml
@@ -32,21 +32,32 @@ subjects:
     name: velero-post-install
     namespace: ${releaseNamespace}
 ---
-apiVersion: batch/v1
-kind: Job
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: velero-post-install
+  name: velero-backup-storage-location-informer
   namespace: ${releaseNamespace}
+  labels:
+    app: velero
+    name: velero-backup-storage-location-informer
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: velero
+      name: velero-backup-storage-location-informer
+  strategy:
+    type: Recreate
   template:
     metadata:
-      name: velero-post-install
+      labels:
+        app: velero
+        name: velero-backup-storage-location-informer
     spec:
       serviceAccountName: velero-post-install
-      restartPolicy: OnFailure
       containers:
         - name: velero-update-s3url
-          image: mesosphere/kubeaddons-addon-initializer:v0.6.1
+          image: mesosphere/kubeaddons-addon-initializer:v0.7.0
           args:
             - velero
           env:
@@ -60,6 +71,8 @@ spec:
               value: "dkp-object-store"
             - name: "VELERO_BUCKET"
               value: "dkp-velero"
+            - name: "VELERO_BACKUP_STORAGE_LOCATION"
+              value: "default"
             - name: "TRAEFIK_INGRESS_SERVICE_NAME"
               value: kommander-traefik
             - name: "TRAEFIK_INGRESS_NAMESPACE"


### PR DESCRIPTION
**What problem does this PR solve?**:
backports #1048 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
