### PR TITLE
feat: Add optional mgmt overrides cm to KPS HR

### DIFF
--- a/services/kube-prometheus-stack/44.2.1/helmrelease/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/44.2.1/helmrelease/kube-prometheus-stack.yaml
@@ -31,6 +31,9 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: kube-prometheus-stack-44.2.1-d2iq-defaults
+    - kind: ConfigMap
+      name: kube-prometheus-stack-mgmt-overrides
+      optional: true
   targetNamespace: ${releaseNamespace}
 ---
 apiVersion: v1


### PR DESCRIPTION
**What problem does this PR solve?**:
Always add optional CM for KPS HR for mgmt specific overrides that will be created in the kcli. This is so that we can allow users to use the workspace configOverrides for their own custom configuration. Right now, users would edit and existing `kube-prometheus-stack-overrides` CM with our mgmt override values, and because of that, we have not been able to automatically update that CM for existing versions if we had any updates, and also results in a bug during expansion, since the mgmt overrides are not compatible with an attached cluster setup.

This work is done in tandem with changes in the CLI to create a new `kube-prometheus-stack-mgmt-overrides` CM that also gets updated during upgrades. To assist with upgrades from previous versions, we will also implement an upgrader step to read in the existing `kube-prometheus-stack-overrides` CM and remove our mgmt override values from that CM so that the result is user custom config (or if no custom config was added, we can remove the config override altogether from the appdeployment).

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-96172

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
