### PR TITLE
feat: introduce `requiredDependencies`

### DIFF
--- a/services/centralized-kubecost/metadata.yaml
+++ b/services/centralized-kubecost/metadata.yaml
@@ -1,5 +1,5 @@
 type: internal
 scope:
   - workspace
-dependencies:
+requiredDependencies:
   - traefik

--- a/services/dex-k8s-authenticator/metadata.yaml
+++ b/services/dex-k8s-authenticator/metadata.yaml
@@ -1,7 +1,7 @@
 type: internal
 scope:
   - workspace
-dependencies:
+requiredDependencies:
   - dex
   - kommander
   - traefik

--- a/services/dkp-insights-management/metadata.yaml
+++ b/services/dkp-insights-management/metadata.yaml
@@ -1,6 +1,6 @@
 type: internal
 scope:
   - workspace
-dependencies:
+requiredDependencies:
   - kubefed
   - traefik

--- a/services/istio/metadata.yaml
+++ b/services/istio/metadata.yaml
@@ -2,7 +2,7 @@ displayName: Istio Service Mesh
 description: Open source service mesh that layers transparently onto existing distributed applications. Requires Prometheus.
 category:
   - service-mesh
-dependencies:
+requiredDependencies:
   - kube-prometheus-stack
 type: platform
 scope:

--- a/services/jaeger/metadata.yaml
+++ b/services/jaeger/metadata.yaml
@@ -2,7 +2,7 @@ displayName: Jaeger
 description: Distributed tracing system used for monitoring and troubleshooting microservices-based distributed systems.
 category:
   - service-mesh
-dependencies:
+requiredDependencies:
   - istio
 type: platform
 scope:

--- a/services/karma-traefik/metadata.yaml
+++ b/services/karma-traefik/metadata.yaml
@@ -1,5 +1,5 @@
 type: internal
 scope:
   - workspace
-dependencies:
+requiredDependencies:
   - kube-prometheus-stack

--- a/services/karma/metadata.yaml
+++ b/services/karma/metadata.yaml
@@ -1,5 +1,5 @@
 type: internal
 scope:
   - workspace
-dependencies:
+requiredDependencies:
   - karma-traefik

--- a/services/kiali/metadata.yaml
+++ b/services/kiali/metadata.yaml
@@ -2,7 +2,7 @@ displayName: Kiali
 description: Management console for an Istio-based service mesh. Requires Prometheus, Istio, and Jaeger.
 category:
   - service-mesh
-dependencies:
+requiredDependencies:
   - istio
 type: platform
 scope:

--- a/services/knative/metadata.yaml
+++ b/services/knative/metadata.yaml
@@ -1,6 +1,6 @@
 displayName: Knative
 description: Kubernetes-based platform to build, deploy, and manage modern serverless workloads
-dependencies:
+requiredDependencies:
   - istio
 category:
   - general

--- a/services/kommander/metadata.yaml
+++ b/services/kommander/metadata.yaml
@@ -1,5 +1,5 @@
 type: internal
 scope:
   - workspace
-dependencies:
+requiredDependencies:
   - kubefed

--- a/services/kube-prometheus-stack/metadata.yaml
+++ b/services/kube-prometheus-stack/metadata.yaml
@@ -2,7 +2,7 @@ displayName: Prometheus Monitoring
 description: Stack of applications that collect metrics and provides visualization and alerting capabilities. Includes Prometheus, Prometheus Alertmanager and Grafana.
 category:
   - monitoring
-dependencies:
+requiredDependencies:
   - traefik
 type: platform
 scope:

--- a/services/kubecost-thanos-traefik/metadata.yaml
+++ b/services/kubecost-thanos-traefik/metadata.yaml
@@ -1,5 +1,5 @@
 type: internal
 scope:
   - workspace
-dependencies:
+requiredDependencies:
   - kubecost

--- a/services/kubecost/metadata.yaml
+++ b/services/kubecost/metadata.yaml
@@ -2,7 +2,7 @@ displayName: Kubecost
 description: Provides real-time cost visibility and insights for teams using Kubernetes, helping organizations continuously reduce cloud costs.
 category:
   - monitoring
-dependencies:
+requiredDependencies:
   - traefik
 type: partner
 scope:

--- a/services/prometheus-adapter/metadata.yaml
+++ b/services/prometheus-adapter/metadata.yaml
@@ -2,7 +2,7 @@ displayName: Prometheus Adapter
 description: Provides cluster metrics from Prometheus. Requires Prometheus.
 category:
   - monitoring
-dependencies:
+requiredDependencies:
   - kube-prometheus-stack
 type: platform
 scope:

--- a/services/prometheus-thanos-traefik/metadata.yaml
+++ b/services/prometheus-thanos-traefik/metadata.yaml
@@ -1,5 +1,5 @@
 type: internal
 scope:
   - workspace
-dependencies:
+requiredDependencies:
   - kube-prometheus-stack

--- a/services/traefik-forward-auth-mgmt/metadata.yaml
+++ b/services/traefik-forward-auth-mgmt/metadata.yaml
@@ -1,7 +1,7 @@
 type: internal
 scope:
   - workspace
-dependencies:
+requiredDependencies:
   - dex
   - kommander
   - traefik

--- a/services/traefik-forward-auth/metadata.yaml
+++ b/services/traefik-forward-auth/metadata.yaml
@@ -2,7 +2,7 @@ displayName: Traefik Forward Auth
 description: Installs a forward authentication service - from D2iQ - that provides OAuth based authentication for Traefik. Requires Traefik.
 category:
   - sso
-dependencies:
+requiredDependencies:
   - traefik
 type: internal
 scope:


### PR DESCRIPTION
**What problem does this PR solve?**:

This introduces a new key in the application metadata `requiredDependencies` which is renamed
and was previously called `dependencies`. The `dependencies` key is now used for dependencies
which we do not enforce to be enabled.

This includes two additional PRs in other repositories:
https://github.com/mesosphere/kommander/pull/3177
https://github.com/mesosphere/kommander-ui/pull/4771

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://d2iq.atlassian.net/browse/D2IQ-96325

KEP: https://github.com/mesosphere/dkp-platform/blob/master/keps/sig-ksphere-ui/20230308-soft-dependencies.md

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

Do I need to bump the versions?

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
