### PR TITLE
fix: ensure license check fails check

### DIFF
--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -34,46 +34,8 @@ jobs:
           cat images.txt
       - name: Run validation
         id: runValidation
-        continue-on-error: true
         uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.9
         with:
           args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=github
         env:
           GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
-      - name: Import GPG key
-        if: |
-          steps.runValidation.outcome == 'failure'
-          && contains(github.event.pull_request.labels.*.name, 'update-licenses')
-        uses: crazy-max/ghaction-import-gpg@v4
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          git_tag_gpgsign: true
-      - name: Update licenses
-        continue-on-error: true
-        if: |
-          steps.runValidation.outcome == 'failure'
-          && contains(github.event.pull_request.labels.*.name, 'update-licenses')
-        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.9
-        with:
-          args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=update
-        env:
-          GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
-      - name: Commit and push changes
-        if: |
-          steps.runValidation.outcome == 'failure'
-          && contains(github.event.pull_request.labels.*.name, 'update-licenses')
-        run: |
-          git config user.email ci-mergebot@d2iq.com
-          git config user.name d2iq-mergebot
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
-          git add licenses.d2iq.yaml
-          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
-            git commit -v -m "build: Updated licenses.d2iq.yaml"
-            git push --force-with-lease
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}


### PR DESCRIPTION
**What problem does this PR solve?**:
This check has been silently failing because of the `continue-on-error: true`. We previously used that to know when to run the update step but that has since been disabled by default.

For now, lets remove those steps and ensure this check fails if the images aren't up to date and prioritize https://d2iq.atlassian.net/browse/D2IQ-96183 to fix the automation.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
