### PR TITLE
fix: set config reloader image repo explicitly (2.4)

### DIFF
--- a/services/logging-operator/3.17.9/defaults/cm.yaml
+++ b/services/logging-operator/3.17.9/defaults/cm.yaml
@@ -58,6 +58,7 @@ data:
       enabled: true
     fluentd:
       configReloaderImage:
+        repository: jimmidyson/configmap-reload
         tag: v0.7.1
       image:
         # Explicitly use the default image. This should be updated when logging-operator is upgraded.


### PR DESCRIPTION
**What problem does this PR solve?**:
This PR sets the default image repo for the config reloader image used in the logging-operator-logging chart. 

This should fix an upgrade issue from 2.4 to 2.5 where the logging-operator fluentd pod fails to pull an image post-upgrade.

This happens because we upgrade the `logging-operator` first, then the `logging-operator-logging` HR. The `logging-operator` upgrades and applies the new default image repo for the config-reload image (`ghcr.io/banzaicloud/config-reloader`). But the `logging-operator-logging` HR hasn't been upgraded yet (it depends on the logging-operator), so the `Logging` CR still references the `v0.7.1` tag but is using the new default image repo. This results in the fluentd pod trying to pull `ghcr.io/banzaicloud/config-reloader:v0.7.1` which doesn't exist. 

This would eventually reconcile but we can avoid this issue by setting the image repo explicitly. Once the operator upgrades, it wouldn't override the config reload image repo because we explicitly set it now. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-96588

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
