### PR TITLE
fix: update automatic license bump to run with label

### DIFF
--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -32,7 +32,6 @@ jobs:
           cat images.txt
       - name: Update licenses
         id: updateLicenses
-        continue-on-error: true
         if: |
           contains(github.event.pull_request.labels.*.name, 'update-licenses')
         uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.10

--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -7,7 +7,39 @@ on:
   workflow_dispatch: {}
   push:
     tags:
+    tags:
+      - v*
+    branches:
+      - main
+jobs:
+  check-license-yaml:
+    runs-on: ubuntu-latest
+    name: Check licenses.d2iq.yaml
+    env:
+      BLOODHOUND_VERSION: v0.8.0
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download Bloodhound CLI
+        run: |
+          curl -fsSL https://downloads.d2iq.com/dkp-bloodhound/dkp-bloodhound_${BLOODHOUND_VERSION}_linux_amd64.tar.gz | tar xz -O > bloodhound
+          chmod +x bloodhound
+      - name: Generate image list
+        run: |
+          ./bloodhound --no-validation --list-images > images.txt
+          echo "printing contents of images.txt"
+          cat images.txt
+      - name: Run validation
+        id: runValidation
+        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.9
+        with:
+          args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=github
         env:
+          GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
           GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
       - name: Import GPG key
         if: |

--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -7,35 +7,39 @@ on:
   workflow_dispatch: {}
   push:
     tags:
-      - v*
-    branches:
-      - main
-jobs:
-  check-license-yaml:
-    runs-on: ubuntu-latest
-    name: Check licenses.d2iq.yaml
-    env:
-      BLOODHOUND_VERSION: v0.8.0
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Download Bloodhound CLI
-        run: |
-          curl -fsSL https://downloads.d2iq.com/dkp-bloodhound/dkp-bloodhound_${BLOODHOUND_VERSION}_linux_amd64.tar.gz | tar xz -O > bloodhound
-          chmod +x bloodhound
-      - name: Generate image list
-        run: |
-          ./bloodhound --no-validation --list-images > images.txt
-          echo "printing contents of images.txt"
-          cat images.txt
-      - name: Run validation
-        id: runValidation
-        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.9
-        with:
-          args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=github
         env:
           GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
+      - name: Import GPG key
+        if: |
+          steps.runValidation.outcome == 'failure'
+          && contains(github.event.pull_request.labels.*.name, 'update-licenses')
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_tag_gpgsign: true
+      - name: Update licenses
+        continue-on-error: true
+        if: |
+          steps.runValidation.outcome == 'failure'
+          && contains(github.event.pull_request.labels.*.name, 'update-licenses')
+        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.10
+        with:
+          args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=update
+        env:
+          GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
+      - name: Commit and push changes
+        if: |
+          steps.runValidation.outcome == 'failure'
+          && contains(github.event.pull_request.labels.*.name, 'update-licenses')
+        run: |
+          git config user.email ci-mergebot@d2iq.com
+          git config user.name d2iq-mergebot
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+          git add licenses.d2iq.yaml
+          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+            git commit -v -m "build: Updated licenses.d2iq.yaml"
+            git push --force-with-lease
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}

--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -1,9 +1,7 @@
 name: Check licenses.d2iq.yaml
 on:
   pull_request:
-    types:
-      - labeled
-      - unlabeled
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   workflow_dispatch: {}
   push:
     tags:

--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -73,4 +73,3 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
-          

--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch: {}
   push:
     tags:
-    tags:
       - v*
     branches:
       - main
@@ -39,7 +38,6 @@ jobs:
         with:
           args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=github
         env:
-          GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
           GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
       - name: Import GPG key
         if: |

--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -32,34 +32,27 @@ jobs:
           ./bloodhound --no-validation --list-images > images.txt
           echo "printing contents of images.txt"
           cat images.txt
-      - name: Run validation
-        id: runValidation
-        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.9
-        with:
-          args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=github
-        env:
-          GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
-      - name: Import GPG key
-        if: |
-          steps.runValidation.outcome == 'failure'
-          && contains(github.event.pull_request.labels.*.name, 'update-licenses')
-        uses: crazy-max/ghaction-import-gpg@v4
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          git_tag_gpgsign: true
       - name: Update licenses
+        id: updateLicenses
         continue-on-error: true
         if: |
-          steps.runValidation.outcome == 'failure'
-          && contains(github.event.pull_request.labels.*.name, 'update-licenses')
+          contains(github.event.pull_request.labels.*.name, 'update-licenses')
         uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.10
         with:
           args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=update
         env:
           GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
+      - name: Import GPG key
+        if: |
+          steps.updateLicenses.outcome == 'success'
+          && contains(github.event.pull_request.labels.*.name, 'update-licenses')
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_tag_gpgsign: true
       - name: Commit and push changes
         if: |
-          steps.runValidation.outcome == 'failure'
+          steps.updateLicenses.outcome == 'success'
           && contains(github.event.pull_request.labels.*.name, 'update-licenses')
         run: |
           git config user.email ci-mergebot@d2iq.com
@@ -73,3 +66,9 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
+      - name: Run validation
+        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.10
+        with:
+          args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=github
+        env:
+          GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"

--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -75,3 +75,4 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
+          


### PR DESCRIPTION
**What problem does this PR solve?**:
Integrates fix in dkp-infra-tools to remove automated license removal for unused licenses. Check licenses automation continues to be 'opt-in' via the 'update-licenses' label

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
For: https://d2iq.atlassian.net/jira/software/c/projects/D2IQ/boards/61?modal=detail&selectedIssue=D2IQ-96183&sprint=1959&assignee=63289bb1748d1bfcb855df3a

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
