### PR TITLE
feat: run ceph toolbox deployment by default

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -168,6 +168,11 @@ resources:
       - url: https://github.com/rook/rook
         ref: ${image_tag}
         license_path: LICENSE
+  - container_image: quay.io/ceph/ceph:v17.2.5
+    sources:
+      - url: https://github.com/ceph/ceph
+        ref: ${image_tag}
+        license_path: COPYING
   - container_image: docker.io/stakater/reloader:v1.0.5
     sources:
       - url: https://github.com/stakater/Reloader

--- a/services/rook-ceph-cluster/1.10.11/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.10.11/defaults/cm.yaml
@@ -10,7 +10,9 @@ data:
     clusterName: dkp-ceph-cluster
     toolbox:
       # If needed, enable a toolbox for debugging (creates a pod with ceph CLI)
-      enabled: false
+      # The name is hardcoded, so if deploying more than one `rook-ceph-custer` then this flag needs to be set to false.
+      # This is enabled by default to workaround D2IQ-96634
+      enabled: true
 
     # PSP is Unsupported in 1.25+ k8s
     # Set this to the same value as the rook-ceph chart.


### PR DESCRIPTION
**What problem does this PR solve?**:

In certain vsphere environments @jonathanbeber has found that `CephObjectStore` does not get healthy ootb. Upon further investigation done by @cbuto the error seems to be 

```
k describe cephobjectstore -nkommander dkp-object-store     
....
Events:
  Type     Reason           Age                   From                         Message
  ----     ------           ----                  ----                         -------
  Warning  ReconcileFailed  8m42s (x20 over 71m)  rook-ceph-object-controller  failed to reconcile CephObjectStore "kommander/dkp-object-store". failed to create object store deployments: failed to configure multisite for object store: failed create ceph multisite for object-store ["dkp-object-store"]: failed to commit config changes after creating multisite config for CephObjectStore "kommander/dkp-object-store": failed to commit RGW configuration period changes%!(EXTRA []string=[]): signal: interrupt
```

which we found that is caused by a master zonegroup not marked as the default zonegroup. Ideally, this should be done by rook operator but cuz of a <yet to be determined reason> this is not being done consistently. In order to workaround those cases where rook operator fails to do this, we can use the toolbox pod to exec into a cluster and run the following commands to reconcile the `CephObjectStore` created by us for DKP needs. Commands we plan to execute are:

```bash
radosgw-admin zonegroup default --rgw-zonegroup=dkp-object-store
radosgw-admin period update --commit
```

after which a user can `kubectl rollout restart deployment/rook-ceph-operator -n kommander` to reconile the object store. This will be backported to 2.5 and 2.4 branches.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-96634

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

More context 
https://d2iq.slack.com/archives/C01LNF6KML5/p1680101685442639
https://d2iq.slack.com/archives/C01LNF6KML5/p1680286806718219
https://d2iq.slack.com/archives/C01LNF6KML5/p1680279102504449

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
