### PR TITLE
Backport/release 2.4/pr 1107

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -194,6 +194,11 @@ resources:
       - url: https://github.com/rook/rook
         ref: ${image_tag}
         license_path: LICENSE
+  - container_image: quay.io/ceph/ceph:v17.2.5
+    sources:
+      - url: https://github.com/ceph/ceph
+        ref: ${image_tag}
+        license_path: COPYING
   - container_image: docker.io/stakater/reloader:v0.0.121
     sources:
       - url: https://github.com/stakater/Reloader

--- a/services/rook-ceph-cluster/1.10.8/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.10.8/defaults/cm.yaml
@@ -10,7 +10,9 @@ data:
     clusterName: dkp-ceph-cluster
     toolbox:
       # If needed, enable a toolbox for debugging (creates a pod with ceph CLI)
-      enabled: false
+      # The name is hardcoded, so if deploying more than one `rook-ceph-custer` then this flag needs to be set to false.
+      # This is enabled by default to workaround D2IQ-96634
+      enabled: true
 
     # PSP is Unsupported in 1.25+ k8s
     # Set this to the same value as the rook-ceph chart.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release-2.5`:
https://github.com/mesosphere/kommander-applications/pull/1107