### PR TITLE
feat: Introduce kommander-ui service

### DIFF
--- a/.github/service-labeler.yaml
+++ b/.github/service-labeler.yaml
@@ -42,6 +42,8 @@ services/kommander-appmanagement:
   - services/kommander-appmanagement/**
 services/kommander-flux:
   - services/kommander-flux/**
+services/kommander-ui:
+  - services/kommander-ui/**
 services/kube-oidc-proxy:
   - services/kube-oidc-proxy/**
 services/kube-prometheus-stack:

--- a/services/kommander-ui/9.11.11/defaults/cm.yaml
+++ b/services/kommander-ui/9.11.11/defaults/cm.yaml
@@ -14,3 +14,8 @@ data:
         traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth@kubernetescrd"
       path: /dkp/kommander/dashboard
       graphqlPath: /dkp/kommander/dashboard/graphql
+    impersonateUser: true
+    mountUtilityServiceCert: false
+    showCost: true
+    showCD: true
+    fedNamespace: kube-federation-system

--- a/services/kommander-ui/9.11.11/defaults/cm.yaml
+++ b/services/kommander-ui/9.11.11/defaults/cm.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kommander-ui-9.11.11-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    ---
+    ingress:
+      enabled: true
+      extraAnnotations:
+        kubernetes.io/ingress.class: kommander-traefik
+        traefik.ingress.kubernetes.io/router.tls: "true"
+        traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth@kubernetescrd"
+      path: /dkp/kommander/dashboard
+      graphqlPath: /dkp/kommander/dashboard/graphql

--- a/services/kommander-ui/9.11.11/defaults/kustomization.yaml
+++ b/services/kommander-ui/9.11.11/defaults/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml

--- a/services/kommander-ui/9.11.11/kommander-ui.yaml
+++ b/services/kommander-ui/9.11.11/kommander-ui.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kommander-ui
+  namespace: ${releaseNamespace}
+spec:
+  dependsOn:
+    - namespace: ${releaseNamespace}
+      name: kommander
+  chart:
+    spec:
+      chart: kommander-ui
+      sourceRef:
+        kind: HelmRepository
+        name: kommander-ui
+        namespace: kommander-flux
+      version: 9.11.11
+  interval: 15s
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+  valuesFrom:
+    - kind: ConfigMap
+      name: kommander-ui-9.11.11-d2iq-defaults
+  targetNamespace: ${releaseNamespace}

--- a/services/kommander-ui/9.11.11/kustomization.yaml
+++ b/services/kommander-ui/9.11.11/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kommander-ui.yaml

--- a/services/kommander-ui/metadata.yaml
+++ b/services/kommander-ui/metadata.yaml
@@ -1,0 +1,5 @@
+type: internal
+scope:
+  - workspace
+dependencies:
+  - kommander

--- a/services/kommander-ui/metadata.yaml
+++ b/services/kommander-ui/metadata.yaml
@@ -1,5 +1,5 @@
 type: internal
 scope:
   - workspace
-dependencies:
+requiredDependencies:
   - kommander

--- a/services/kommander/0.6.0/defaults/cm.yaml
+++ b/services/kommander/0.6.0/defaults/cm.yaml
@@ -76,14 +76,7 @@ data:
         prometheus-thanos-traefik: "0.0.1"
         thanos: "12.4.3"
     kommander-ui:
-      ingress:
-        enabled: true
-        extraAnnotations:
-          kubernetes.io/ingress.class: kommander-traefik
-          traefik.ingress.kubernetes.io/router.tls: "true"
-          traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth@kubernetescrd"
-        path: /dkp/kommander/dashboard
-        graphqlPath: /dkp/kommander/dashboard/graphql
+      enabled: false
     capimate:
       image:
         tag: v0.0.0-dev.0


### PR DESCRIPTION
**What problem does this PR solve?**:
This change creates a separate service for kommander-ui.

**Which issue(s) does this PR fix?**:
https://d2iq.atlassian.net/browse/D2IQ-92244


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
```release-note
Kommander-ui is a separate service now and it is deployed thourhg appdeployment like other services.
```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
