### PR TITLE
fix: Bump postgres/fluentbit/fluentd images

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -6,7 +6,7 @@ ignore:
   - docker.io/bitnami/kubectl:1.24.6
   - docker.io/bitnami/kubectl:1.24.1
   - docker.io/bitnami/memcached:1.6.15-debian-11-r8
-  - docker.io/bitnami/postgresql:11.16.0-debian-11-r9
+  - docker.io/bitnami/postgresql:11.18.0-debian-11-r34
   - gcr.io/kubecost1/cost-model:prod-1.100.2
   - gcr.io/kubecost1/frontend:prod-1.100.2
 resources:
@@ -63,7 +63,7 @@ resources:
     sources:
       - url: https://github.com/mesosphere/konvoy2
         ref: ${image_tag}
-  - container_image: cr.fluentbit.io/fluent/fluent-bit:2.0.6
+  - container_image: cr.fluentbit.io/fluent/fluent-bit:2.0.11
     sources:
       - url: https://github.com/fluent/fluent-bit
         ref: v${image_tag}

--- a/services/fluent-bit/0.21.6/defaults/cm.yaml
+++ b/services/fluent-bit/0.21.6/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
     ---
     # overriding the default image tag to be consistent with logging-operator
     image:
-      tag: 2.0.6
+      tag: 2.0.11
 
     resources:
       limits:

--- a/services/gitea/7.0.2/defaults/cm.yaml
+++ b/services/gitea/7.0.2/defaults/cm.yaml
@@ -66,4 +66,4 @@ data:
         tag: 1.6.15-debian-11-r8
     postgresql:
       image:
-        tag: 11.16.0-debian-11-r9
+        tag: 11.18.0-debian-11-r34

--- a/services/logging-operator/3.17.10/defaults/cm.yaml
+++ b/services/logging-operator/3.17.10/defaults/cm.yaml
@@ -99,7 +99,7 @@ data:
         # Explicitly specify the version here. This should be updated when logging-operator is upgraded.
         # Also, update the image in fluent-bit configuration if the image is upgraded here.
         repository: fluent/fluent-bit
-        tag: 2.0.6
+        tag: 2.0.11
       resources:
        limits:
          memory: 750Mi

--- a/services/logging-operator/3.17.10/defaults/cm.yaml
+++ b/services/logging-operator/3.17.10/defaults/cm.yaml
@@ -59,8 +59,8 @@ data:
     fluentd:
       image:
         # Explicitly use the default image. This should be updated when logging-operator is upgraded.
-        repository: ghcr.io/banzaicloud/fluentd
-        tag: v1.14.6-alpine-5
+        repository: ghcr.io/kube-logging/fluentd
+        tag: v1.15.3-build.57
       resources:
        limits:
          memory: 400Mi

--- a/services/logging-operator/3.17.10/defaults/cm.yaml
+++ b/services/logging-operator/3.17.10/defaults/cm.yaml
@@ -84,10 +84,7 @@ data:
               requests:
                 storage: 10Gi
             volumeMode: Filesystem
-      metrics:
-        port: 24231
-        path: /metrics
-        prometheusAnnotations: true
+      metrics: null
       bufferVolumeMetrics:
         port: 9200
         path: /metrics


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumps Postgres (in gitea), fluentd and fluent-bit images to mitigate CVEs.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
