### PR TITLE
fix: increase the failureThreshold of the DKA liveness probe #1407

### DIFF
--- a/services/dex-k8s-authenticator/1.2.14/defaults/cm.yaml
+++ b/services/dex-k8s-authenticator/1.2.14/defaults/cm.yaml
@@ -25,6 +25,11 @@ data:
       generateHmacSecret: true
       # Clusters will be managed in the overrides CM
       clusters: {}
+      livenessProbe:
+        periodSeconds: 10   # Under high load use 'periodSeconds: 30'
+        initialDelaySeconds: 10   # Under high load use 'initialDelaySeconds: 15'
+        timeoutSeconds: 10   # Under high load use 'timeoutSeconds: 30'
+        failureThreshold: 6
     deploymentAnnotations:
       configmap.reloader.stakater.com/reload: "dex-k8s-authenticator"
     resources:


### PR DESCRIPTION
This PR increases to 6 the failureThreshold for the DKA liveness probe to prevent failures when the number of clusters to parse is >=50. The long time required to read the configuration file made the application to not respond correctly to liveness probe, resulting in CrashLoopBackoff. 

Ref. https://d2iq.atlassian.net/browse/D2IQ-94340
Ref. https://d2iq.atlassian.net/browse/D2IQ-96636

**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
