### PR TITLE
feat: Add dkp priority class manifests to common/base

### DIFF
--- a/common/priority-classes/dkp-priority-classes.yaml
+++ b/common/priority-classes/dkp-priority-classes.yaml
@@ -1,0 +1,23 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: dkp-critical-priority
+value: 100002000
+globalDefault: false
+description: "This is the highest priority class that is used for critical priority DKP workloads."
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: dkp-high-priority
+value: 100001000
+globalDefault: false
+description: "This is the priority class that is used for high priority DKP workloads."
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: dkp-default-priority
+value: 100000000
+globalDefault: true
+description: "This is the global default priority class that is automatically applied to pods without a priority class."

--- a/common/priority-classes/dkp-priority-classes.yaml
+++ b/common/priority-classes/dkp-priority-classes.yaml
@@ -13,11 +13,3 @@ metadata:
 value: 100001000
 globalDefault: false
 description: "This is the priority class that is used for high priority DKP workloads."
----
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: dkp-default-priority
-value: 100000000
-globalDefault: true
-description: "This is the global default priority class that is automatically applied to pods without a priority class."

--- a/common/priority-classes/kustomization.yaml
+++ b/common/priority-classes/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../helm-repositories/
-  - ../priority-classes/
-  - ../values/
+  - dkp-priority-classes.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:
Add new DKP priority class manifests directly to the gitrepo under `/common/base` since these manifests should always be deployed to both the mgmt cluster and the attached clusters. These will automatically get applied during upgrade first (with gitrepo update), before other apps are upgraded, which is required since these upgraded apps will be updated to use the priority classes.

This works for attached cluster upgrades as well, because the kommander flux controller will be upgraded already with kommander upgrade, and once the upgraded flux controller is running, it will automatically apply the new "federated global manifests" (which include the kustomization pointing to `./common/priority-claasses/` -- added in https://github.com/mesosphere/kommander/pull/3281) before workspace upgrade is performed.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-96266

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
