### PR TITLE
fix: licenses for kommander single module (2.5)

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -14,47 +14,38 @@ resources:
     sources:
       - url: https://github.com/mesosphere/kommander
         ref: ${image_tag}
-        directory: installer
   - container_image: docker.io/mesosphere/kommander2-appmanagement-webhook:${kommander}
     sources:
       - url: https://github.com/mesosphere/kommander
         ref: ${image_tag}
-        directory: federation
   - container_image: docker.io/mesosphere/kommander2-appmanagement:${kommander}
     sources:
       - url: https://github.com/mesosphere/kommander
         ref: ${image_tag}
-        directory: federation
   - container_image: docker.io/mesosphere/kommander2-federation-authorizedlister:${kommander}
     sources:
       - url: https://github.com/mesosphere/kommander
         ref: ${image_tag}
-        directory: federation
   - container_image: docker.io/mesosphere/kommander2-federation-controller-manager:${kommander}
     sources:
       - url: https://github.com/mesosphere/kommander
         ref: ${image_tag}
-        directory: federation
   - container_image: docker.io/mesosphere/kommander2-federation-webhook:${kommander}
     sources:
       - url: https://github.com/mesosphere/kommander
         ref: ${image_tag}
-        directory: federation
   - container_image: docker.io/mesosphere/kommander2-flux-operator:${kommander}
     sources:
       - url: https://github.com/mesosphere/kommander
         ref: ${image_tag}
-        directory: federation
   - container_image: docker.io/mesosphere/kommander2-licensing-controller-manager:${kommander}
     sources:
       - url: https://github.com/mesosphere/kommander
         ref: ${image_tag}
-        directory: licensing
   - container_image: docker.io/mesosphere/kommander2-licensing-webhook:${kommander}
     sources:
       - url: https://github.com/mesosphere/kommander
         ref: ${image_tag}
-        directory: licensing
   - container_image: docker.io/mesosphere/kubeaddons-addon-initializer:v0.7.0
     sources:
       - url: https://github.com/mesosphere/kubeaddons-extrasteps


### PR DESCRIPTION
Backport https://github.com/mesosphere/kommander-applications/pull/1084

**What problem does this PR solve?**:
Kommander is a single module.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
