### PR TITLE
fix: Remove unnecessary traefik dependency from apps

### DIFF
--- a/services/centralized-kubecost/0.33.1/release/release.yaml
+++ b/services/centralized-kubecost/0.33.1/release/release.yaml
@@ -4,9 +4,6 @@ metadata:
   name: centralized-kubecost
   namespace: ${releaseNamespace}
 spec:
-  dependsOn:
-    - namespace: ${releaseNamespace}
-      name: traefik
   chart:
     spec:
       chart: kubecost

--- a/services/centralized-kubecost/metadata.yaml
+++ b/services/centralized-kubecost/metadata.yaml
@@ -1,5 +1,3 @@
 type: internal
 scope:
   - workspace
-requiredDependencies:
-  - traefik

--- a/services/dkp-insights-management/0.4.1/helmrelease/helmrelease.yaml
+++ b/services/dkp-insights-management/0.4.1/helmrelease/helmrelease.yaml
@@ -15,8 +15,6 @@ spec:
   dependsOn:
     - name: kubefed
       namespace: ${releaseNamespace}
-    - name: traefik
-      namespace: ${releaseNamespace}
   install:
     crds: CreateReplace
     remediation:

--- a/services/dkp-insights-management/metadata.yaml
+++ b/services/dkp-insights-management/metadata.yaml
@@ -3,4 +3,3 @@ scope:
   - workspace
 requiredDependencies:
   - kubefed
-  - traefik

--- a/services/kube-prometheus-stack/44.2.1/helmrelease/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/44.2.1/helmrelease/kube-prometheus-stack.yaml
@@ -4,9 +4,6 @@ metadata:
   name: kube-prometheus-stack
   namespace: ${releaseNamespace}
 spec:
-  dependsOn:
-    - namespace: ${releaseNamespace}
-      name: traefik
   chart:
     spec:
       chart: kube-prometheus-stack

--- a/services/kube-prometheus-stack/metadata.yaml
+++ b/services/kube-prometheus-stack/metadata.yaml
@@ -2,8 +2,6 @@ displayName: Prometheus Monitoring
 description: Stack of applications that collect metrics and provides visualization and alerting capabilities. Includes Prometheus, Prometheus Alertmanager and Grafana.
 category:
   - monitoring
-requiredDependencies:
-  - traefik
 type: platform
 scope:
   - workspace

--- a/services/kubecost/0.33.1/kubecost.yaml
+++ b/services/kubecost/0.33.1/kubecost.yaml
@@ -4,9 +4,6 @@ metadata:
   name: kubecost
   namespace: ${releaseNamespace}
 spec:
-  dependsOn:
-    - namespace: ${releaseNamespace}
-      name: traefik
   chart:
     spec:
       chart: kubecost

--- a/services/kubecost/metadata.yaml
+++ b/services/kubecost/metadata.yaml
@@ -2,8 +2,6 @@ displayName: Kubecost
 description: Provides real-time cost visibility and insights for teams using Kubernetes, helping organizations continuously reduce cloud costs.
 category:
   - monitoring
-requiredDependencies:
-  - traefik
 type: partner
 scope:
   - workspace


### PR DESCRIPTION
**What problem does this PR solve?**:
There were a few apps that had traefik set as a HR dependency, when they are technically not dependent on it (they successfully deploy if traefik is not deployed).

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
