### PR TITLE
fix: new default resources for grafana

### DIFF
--- a/services/kube-prometheus-stack/44.2.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/44.2.1/defaults/cm.yaml
@@ -407,6 +407,13 @@ data:
           skipReload: true
           initDatasources: true
           searchNamespace: ALL
+        resources:
+          limits:
+            cpu: 150m
+            memory: 100Mi
+          requests:
+            cpu: 150m
+            memory: 100Mi
       grafana.ini:
         log:
           level: warn
@@ -434,10 +441,10 @@ data:
         # keep request = limit to keep this container in guaranteed class
         limits:
           cpu: 300m
-          memory: 100Mi
+          memory: 250Mi
         requests:
-          cpu: 200m
-          memory: 100Mi
+          cpu: 300m
+          memory: 250Mi
       readinessProbe:
         httpGet:
           path: /api/health


### PR DESCRIPTION
**What problem does this PR solve?**:
Fixes [D2IQ-96783].

This commit sets new default values for grafana installation. It also restores the commented but not followed practice of using the same request and limits to use a guaranteed class.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
Based on the usage in the soak cluster where the pods were in constant crashloopback (OOMKilled).

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: `CLI: Some bug fix. (COPS-xxxx)`
-->
```release-note

```

[D2IQ-96783]: https://d2iq.atlassian.net/browse/D2IQ-96783
