### PR TITLE
ci: Update e2e upgrade from version to v2.5.0-dev

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -16,7 +16,7 @@ E2E_KINDEST_IMAGE ?= "mesosphere/kind-node-ci:v1.24.6"
 # and therefore the whole install process so we need to run the upgrade tests against an older version
 # of Kubernetes. This can be removed once the `UPGRADE_FROM_VERSION` below is Kommander >=v2.4.
 E2E_KINDEST_IMAGE_FOR_UPGRADE_TEST ?= "mesosphere/kind-node-ci:v1.23.9"
-UPGRADE_FROM_VERSION ?= "v2.4.0-dev"
+UPGRADE_FROM_VERSION ?= "v2.5.0-dev"
 
 # (aweris): This should be a temporary workaround for v2.3.0 development. If you're still see clone test in v2.4.0
 # it means "a temporary workaround" actually means "permanent solution".


### PR DESCRIPTION
**What problem does this PR solve?**:
we missed some bumps after release

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
