### PR TITLE
feat: readinessProbe for fluentd

### DIFF
--- a/services/logging-operator/3.17.8/defaults/cm.yaml
+++ b/services/logging-operator/3.17.8/defaults/cm.yaml
@@ -74,6 +74,14 @@ data:
       scaling:
         replicas: 1
       port: 24240
+      readinessProbe:
+        failureThreshold: 3
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        successThreshold: 1
+        tcpSocket:
+          port: 24240
+        timeoutSeconds: 3
       logLevel: warn
       fluentLogDestination: stdout
       bufferStorageVolume:


### PR DESCRIPTION
otherwise there is no readinessProbe for fluentd STS

**What problem does this PR solve?**:
add readinessProbe for fluentd statefulset

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**If the PR adds a version bump, does it add a breaking change in License**:
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] No License Change (or NA).
