### PR TITLE
feat: dkp critical for gitea&chartmuseum

### DIFF
--- a/services/chartmuseum/3.9.0/defaults/cm.yaml
+++ b/services/chartmuseum/3.9.0/defaults/cm.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: ${releaseNamespace}
 data:
   values.yaml: |
+    priorityClassName: "dkp-critical-priority"
     env:
       existingSecret: ${chartmuseumAdminCredentialsSecret}
       existingSecretMappings:

--- a/services/gitea/8.2.0/defaults/cm.yaml
+++ b/services/gitea/8.2.0/defaults/cm.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   values.yaml: |-
     ---
+    priorityClassName: "dkp-critical-priority"
     image:
       rootless: true
     ingress:

--- a/services/gitea/8.2.0/defaults/cm.yaml
+++ b/services/gitea/8.2.0/defaults/cm.yaml
@@ -63,8 +63,11 @@ data:
       mountPath: "/git-tls"
     clusterDomain: cluster.local.
     memcached:
+      priorityClassName: "dkp-critical-priority"
       image:
         tag: 1.6.15-debian-11-r8
     postgresql:
+      primary:
+        priorityClassName: "dkp-critical-priority"
       image:
         tag: 11.16.0-debian-11-r9


### PR DESCRIPTION
**What problem does this PR solve?**:
apply dkp critical priority class for gitea and chart museum

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-96267

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
