### PR TITLE
revert: "feat: Set priority class on Flux manifests (#1227)"

### DIFF
--- a/hack/flux/flux-update-kustomization.yaml
+++ b/hack/flux/flux-update-kustomization.yaml
@@ -60,11 +60,3 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
         value: 2000m
-  - target:
-      group: apps
-      version: v1
-      kind: Deployment
-    patch: |-
-      - op: add
-        path: /spec/template/spec/priorityClassName
-        value: dkp-critical-priority

--- a/services/kommander-flux/0.41.2/templates/apps_v1_deployment_helm-controller.yaml
+++ b/services/kommander-flux/0.41.2/templates/apps_v1_deployment_helm-controller.yaml
@@ -74,7 +74,6 @@ spec:
           name: temp
       nodeSelector:
         kubernetes.io/os: linux
-      priorityClassName: dkp-critical-priority
       securityContext:
         fsGroup: 1337
       serviceAccountName: helm-controller

--- a/services/kommander-flux/0.41.2/templates/apps_v1_deployment_kustomize-controller.yaml
+++ b/services/kommander-flux/0.41.2/templates/apps_v1_deployment_kustomize-controller.yaml
@@ -75,7 +75,6 @@ spec:
           name: temp
       nodeSelector:
         kubernetes.io/os: linux
-      priorityClassName: dkp-critical-priority
       securityContext:
         fsGroup: 1337
       serviceAccountName: kustomize-controller

--- a/services/kommander-flux/0.41.2/templates/apps_v1_deployment_notification-controller.yaml
+++ b/services/kommander-flux/0.41.2/templates/apps_v1_deployment_notification-controller.yaml
@@ -78,7 +78,6 @@ spec:
           name: temp
       nodeSelector:
         kubernetes.io/os: linux
-      priorityClassName: dkp-critical-priority
       securityContext:
         fsGroup: 1337
       serviceAccountName: notification-controller

--- a/services/kommander-flux/0.41.2/templates/apps_v1_deployment_source-controller.yaml
+++ b/services/kommander-flux/0.41.2/templates/apps_v1_deployment_source-controller.yaml
@@ -84,7 +84,6 @@ spec:
           name: tmp
       nodeSelector:
         kubernetes.io/os: linux
-      priorityClassName: dkp-critical-priority
       securityContext:
         fsGroup: 1337
       serviceAccountName: source-controller


### PR DESCRIPTION
This reverts commit ddb996ea5568e2250df4374b1914c3ba64d650ae.

**What problem does this PR solve?**:

https://github.com/mesosphere/kommander-applications/pull/1227 needed more work and will break CI as is. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
