### PR TITLE
ci: update capimate to 2.3.3

### DIFF
--- a/hack/release/pkg/constants/constants.go
+++ b/hack/release/pkg/constants/constants.go
@@ -3,7 +3,7 @@ package constants
 const (
 	KommanderAppPath       = "./services/kommander/"
 	KommanderAppMgmtPath   = "./services/kommander-appmanagement/"
-	CAPIMateDefaultVersion = "v2.3.1"
+	CAPIMateDefaultVersion = "v2.3.3"
 	// SemverRegexp validates any semver (taken verbatim from semver specs).
 	SemverRegexp = `v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?` //nolint:lll // it's not readable anyway
 )

--- a/services/kommander/0.3.4/defaults/cm.yaml
+++ b/services/kommander/0.3.4/defaults/cm.yaml
@@ -88,7 +88,7 @@ data:
         graphqlPath: /dkp/kommander/dashboard/graphql
     capimate:
       image:
-        tag: v2.3.1
+        tag: v2.3.3
     attached:
       prerequisites:
         defaultApps:


### PR DESCRIPTION
Although we have a script to do this on release, this updates the default CAPIMate versions for 2.3.
https://d2iq.slack.com/archives/C01LNF6KML5/p1681920802932859

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
