### PR TITLE
ci: adds missing-images automation

### DIFF
--- a/.github/services-pr-labeler.yaml
+++ b/.github/services-pr-labeler.yaml
@@ -6,6 +6,7 @@ open-kommander-pr:
   - services/istio/**
   - services/jaeger/**
   - services/kiali/**
+  - services/nvidia-gpu-operator/**
   - services/kube-oidc-proxy/**
   - services/logging-operator/**
   - services/project-grafana-logging/**

--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -87,7 +87,36 @@ jobs:
               git push --force-with-lease --set-upstream origin kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }}
               echo "created_new_branch=true" >> $GITHUB_OUTPUT
             fi
+            cd -
           }
+
+      - name: checkout local directory for script
+        if: contains(needs.get-kapps-branch-name.outputs.branch_name, 'chartbump/nvidia-gpu-operator')
+        uses: actions/checkout@v3
+        with:
+          path: 'main'
+
+      - name: get go
+        if: contains(needs.get-kapps-branch-name.outputs.branch_name, 'chartbump/nvidia-gpu-operator')
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'kommander/go.mod'
+          cache: true
+
+      - name: run nvidia script
+        if: contains(needs.get-kapps-branch-name.outputs.branch_name, 'chartbump/nvidia-gpu-operator')
+        run: |
+          go install github.com/itchyny/gojq/cmd/gojq@latest
+          cd main
+          version=$(echo ${{ needs.get-kapps-branch-name.outputs.branch_name }} | rev | cut -d'-' -f 1 | rev)
+          ./hack/update-nvidia.sh ../kommander/hack/airgapped/missing-images.json services/nvidia-gpu-operator/${version}/defaults/cm.yaml
+          cd -
+          cd kommander
+          git add hack/airgapped/missing-images.json
+          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+            git commit -v -m "build: Update nvidia airgapped images"
+            git push --force-with-lease --set-upstream origin kapps/${{ needs.get-kapps-branch-name.outputs.base_branch_name }}/${{ needs.get-kapps-branch-name.outputs.branch_name }}
+          fi
 
       - name: Create comment
         if: steps.make-test-branch.outputs.created_new_branch == 'true'

--- a/hack/update-nvidia.sh
+++ b/hack/update-nvidia.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+readarray -t images < <(gojq -c '.[]' "${1}") #convert to bash arrays and remove trailing newline for each line (if any)
+new_images=() # we need to create new array to strip the new line when converting back to json file
+
+IFS=$'\n' #read til newline
+for image in "${images[@]}"; do
+  new_image=$(echo "${image}" | xargs)
+  if [[ ${new_image} == *"nvidia"* ]]; then
+    # dcgm-exporter:3.1.3-3.1.2-ubuntu20.04
+    full_component=$(echo "${new_image}" | rev | cut -d'/' -f 1 | rev)
+    component=$(echo "${full_component}" | cut -d':' -f1)
+    version=$(echo "${full_component}" | cut -d':' -f2)
+    case $component in
+      gpu-feature-discovery)
+        new_version=$(tail --lines=+8 "${2}"| gojq --yaml-input '.gfd.version' | xargs)
+        new_image="${new_image//"${version}"/"${new_version}"}"
+      ;;
+      dcgm)
+        new_version=$(tail --lines=+8 "${2}"| gojq --yaml-input '.dcgm.version'| xargs)
+        new_image="${new_image//"${version}"/"${new_version}"}"
+      ;;
+      dcgmExporter)
+        new_version=$(tail --lines=+8 "${2}"| gojq --yaml-input '.dcgmExporter.version'| xargs)
+        new_image="${new_image//"${version}"/"${new_version}"}"
+      ;;
+      gpu-operator-validator)
+        new_version=$(tail --lines=+8 "${2}"| gojq --yaml-input '.validator.version'| xargs)
+        new_image="${new_image//"${version}"/"${new_version}"}"
+      ;;
+      devicePlugin)
+        new_version=$(tail --lines=+8 "${2}"| gojq --yaml-input '.devicePlugin.config.version'| xargs)
+        new_image="${new_image//"${version}"/"${new_version}"}"
+      ;;
+      *)
+        echo "skipping component ${component}"
+      ;;
+    esac
+  fi
+  echo "adding ${new_image}"
+  new_images+=("${new_image}")
+done
+unset IFS
+truncate -s 0 "${1}"
+printf '%s\n' "${new_images[@]}" | gojq -R . | gojq -s .  >> "${1}"


### PR DESCRIPTION
**What problem does this PR solve?**:
updates `hack/airgapped/missing-images.json` in kommander repo from local values here for the nvidia operator 


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
