### PR TITLE
fix: disable rook-ceph admission controller (2.4)

### DIFF
--- a/services/rook-ceph-cluster/1.10.8/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.10.8/pre-install/ceph-crd-check.yaml
@@ -89,4 +89,6 @@ spec:
                 echo "Ceph operator is at $cephOperatorVersion version and desired version is ${desiredCephOperatorVersion}. Continuing to wait..."
                 sleep 10
               done
+
+              kubectl wait helmreleases.helm.toolkit.fluxcd.io -n ${releaseNamespace} rook-ceph --for=condition=Ready --timeout 30m
               EOF

--- a/services/rook-ceph/1.10.8/defaults/cm.yaml
+++ b/services/rook-ceph/1.10.8/defaults/cm.yaml
@@ -43,3 +43,7 @@ data:
 
     # This allows DKP installations with static local static provisioner with loopback block devices (E.g.: preprovisioned with LVMs) work out of the box.
     allowLoopDevices: true
+
+    # The admission controller was disabled by default in https://github.com/rook/rook/releases/tag/v1.10.9 to fix https://github.com/rook/rook/issues/10719.
+    # This also solves upgrade issues related to the admission webhook that can occur due to a race between the `rook-ceph` and `rook-ceph-cluster` app
+    disableAdmissionController: true


### PR DESCRIPTION
**What problem does this PR solve?**:
This PR solves potential upgrade issues that can occur when the `rook-ceph` HelmRelease is upgraded, then the `rook-ceph-cluster` HelmRelease is upgraded but the admission controller isn't ready yet. 

The admission controller was disabled by default upstream in `v1.10.9` to fix an issue with cert expiration - https://github.com/rook/rook/issues/10719

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-97225

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
