### PR TITLE
ci: fix update missing images script for nvidia

### DIFF
--- a/.github/services-pr-labeler.yaml
+++ b/.github/services-pr-labeler.yaml
@@ -27,6 +27,7 @@ do-not-merge/testing:
   - services/istio/**
   - services/jaeger/**
   - services/kiali/**
+  - services/nvidia-gpu-operator/**
   - services/kube-oidc-proxy/**
   - services/logging-operator/**
   - services/project-grafana-logging/**

--- a/.github/services-pr-labeler.yaml
+++ b/.github/services-pr-labeler.yaml
@@ -27,7 +27,6 @@ do-not-merge/testing:
   - services/istio/**
   - services/jaeger/**
   - services/kiali/**
-  - services/nvidia-gpu-operator/**
   - services/kube-oidc-proxy/**
   - services/logging-operator/**
   - services/project-grafana-logging/**

--- a/hack/update-nvidia.sh
+++ b/hack/update-nvidia.sh
@@ -20,7 +20,7 @@ for image in "${images[@]}"; do
         new_version=$(tail --lines=+8 "${2}"| gojq --yaml-input '.dcgm.version'| xargs)
         new_image="${new_image//"${version}"/"${new_version}"}"
       ;;
-      dcgmExporter)
+      dcgm-exporter)
         new_version=$(tail --lines=+8 "${2}"| gojq --yaml-input '.dcgmExporter.version'| xargs)
         new_image="${new_image//"${version}"/"${new_version}"}"
       ;;


### PR DESCRIPTION
**What problem does this PR solve?**:
Previously the missing image script was not updating the dcgm exporter image in the kommander repo, despite changes.

I ran the automation locally and updated the kommander PR with https://github.com/mesosphere/kommander/pull/3407/commits/df4476dc7a1683391b3c7fb405f763b688eb3621

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
