### PR TITLE
chore: kommander chart retry

### DIFF
--- a/services/kommander/0.6.0/kommander.yaml
+++ b/services/kommander/0.6.0/kommander.yaml
@@ -26,17 +26,11 @@ spec:
   install:
     crds: CreateReplace
     remediation:
-      # The Kommander chart cannot be uninstalled in its current form. That's
-      # a known issue and trying to remediate an installation failure by
-      # deleting and retrying won't work so we can just as well not retry to
-      # begin with.
-      retries: 0
+      retries: 30
   upgrade:
     crds: CreateReplace
     remediation:
-      # Rolling back an upgrade will very like not work and is untested so
-      # let's disable any remediation.
-      retries: 0
+      retries: 30
   releaseName: kommander
   valuesFrom:
     - kind: ConfigMap


### PR DESCRIPTION
**What problem does this PR solve?**:
add retry to kommander chart. In the case where kommander chart never got installed this will be better than no retry.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-97081

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
