### PR TITLE
fix: wait for webhook to be deleted

### DIFF
--- a/services/rook-ceph-cluster/1.10.8/pre-install.yaml
+++ b/services/rook-ceph-cluster/1.10.8/pre-install.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
-  name: rook-ceph-cluster-pre-install
+  name: rook-ceph-cluster-pre-install-v1.10.8
   namespace: ${releaseNamespace}
 spec:
   force: true

--- a/services/rook-ceph-cluster/1.10.8/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.10.8/pre-install/ceph-crd-check.yaml
@@ -20,7 +20,7 @@ rules:
     verbs: ["get", "watch", "list"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
-    verbs: ["get", "watch", "list", "delete"]
+    verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -39,12 +39,12 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: check-dkp-ceph-crd
+  name: dkp-ceph-pre-install
   namespace: ${releaseNamespace}
 spec:
   template:
     metadata:
-      name: check-dkp-ceph-crd
+      name: dkp-ceph-pre-install
     spec:
       serviceAccountName: check-dkp-ceph-crd
       restartPolicy: OnFailure
@@ -92,10 +92,6 @@ spec:
                 echo "Ceph operator is at $cephOperatorVersion version and desired version is ${desiredCephOperatorVersion}. Continuing to wait..."
                 sleep 10
               done
-
-              kubectl wait helmreleases.helm.toolkit.fluxcd.io -n ${releaseNamespace} rook-ceph --for=condition=Ready --timeout 30m
-
-              kubectl delete validatingwebhookconfiguration.admissionregistration.k8s.io rook-ceph-webhook --ignore-not-found
 
               echo "verifying webhook was deleted"
               kubectl wait validatingwebhookconfiguration.admissionregistration.k8s.io rook-ceph-webhook --for=delete --timeout 30m -v6

--- a/services/rook-ceph-cluster/1.10.8/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.10.8/pre-install/ceph-crd-check.yaml
@@ -20,7 +20,7 @@ rules:
     verbs: ["get", "watch", "list"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
-    verbs: ["get", "watch", "list"]
+    verbs: ["get", "watch", "list", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -95,6 +95,8 @@ spec:
 
               kubectl wait helmreleases.helm.toolkit.fluxcd.io -n ${releaseNamespace} rook-ceph --for=condition=Ready --timeout 30m
 
-              echo "waiting for webhook to be deleted "
-              kubectl wait validatingwebhookconfiguration.admissionregistration.k8s.io -n ${releaseNamespace} rook-ceph-webhook --for=delete --timeout 30m -v6
+              kubectl delete validatingwebhookconfiguration.admissionregistration.k8s.io rook-ceph-webhook --ignore-not-found
+
+              echo "verifying webhook was deleted"
+              kubectl wait validatingwebhookconfiguration.admissionregistration.k8s.io rook-ceph-webhook --for=delete --timeout 30m -v6
               EOF

--- a/services/rook-ceph-cluster/1.10.8/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.10.8/pre-install/ceph-crd-check.yaml
@@ -18,6 +18,9 @@ rules:
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: ["helmreleases"]
     verbs: ["get", "watch", "list"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -91,4 +94,5 @@ spec:
               done
 
               kubectl wait helmreleases.helm.toolkit.fluxcd.io -n ${releaseNamespace} rook-ceph --for=condition=Ready --timeout 30m
+              kubectl wait validatingwebhookconfiguration.admissionregistration.k8s.io -n ${releaseNamespace} rook-ceph-webhook --for=delete --timeout 30m
               EOF

--- a/services/rook-ceph-cluster/1.10.8/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.10.8/pre-install/ceph-crd-check.yaml
@@ -94,5 +94,7 @@ spec:
               done
 
               kubectl wait helmreleases.helm.toolkit.fluxcd.io -n ${releaseNamespace} rook-ceph --for=condition=Ready --timeout 30m
-              kubectl wait validatingwebhookconfiguration.admissionregistration.k8s.io -n ${releaseNamespace} rook-ceph-webhook --for=delete --timeout 30m
+
+              echo "waiting for webhook to be deleted "
+              kubectl wait validatingwebhookconfiguration.admissionregistration.k8s.io -n ${releaseNamespace} rook-ceph-webhook --for=delete --timeout 30m -v6
               EOF

--- a/services/rook-ceph-cluster/1.10.8/rook-ceph-cluster.yaml
+++ b/services/rook-ceph-cluster/1.10.8/rook-ceph-cluster.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   dependsOn:
     # There can only be one operator per cluster, just ensure CRDs are present, no need to wait for actual operator Deployment.
-    - name: rook-ceph-cluster-pre-install
+    - name: rook-ceph-cluster-pre-install-v1.10.8
       namespace: ${workspaceNamespace}
   force: false
   prune: true


### PR DESCRIPTION
**What problem does this PR solve?**:
Let's explicitly wait for the webhook config to be deleted. It turns out the operator manages the webhook config and not the helm chart.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
