### PR TITLE
feat: Set priority class for KPS (grafana) and kommander-ui

### DIFF
--- a/services/centralized-grafana/45.21.0/defaults/cm.yaml
+++ b/services/centralized-grafana/45.21.0/defaults/cm.yaml
@@ -14,6 +14,7 @@ data:
     grafana:
       enabled: true
       defaultDashboardsEnabled: true
+      priorityClassName: "dkp-critical-priority"
       serviceMonitor:
         labels:
           prometheus.kommander.d2iq.io/select: "true"

--- a/services/kommander-ui/9.28.3/defaults/cm.yaml
+++ b/services/kommander-ui/9.28.3/defaults/cm.yaml
@@ -19,3 +19,4 @@ data:
     showCost: true
     showCD: true
     fedNamespace: kube-federation-system
+    priorityClassName: "dkp-critical-priority"

--- a/services/kube-prometheus-stack/45.21.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/45.21.0/defaults/cm.yaml
@@ -387,6 +387,7 @@ data:
     grafana:
       enabled: true
       defaultDashboardsEnabled: true
+      priorityClassName: "dkp-critical-priority"
       serviceMonitor:
         labels:
           prometheus.kommander.d2iq.io/select: "true"


### PR DESCRIPTION
**What problem does this PR solve?**:
- KPS charts missed setting priority class for the grafana subchart 
- kommander-ui chart was newly pulled into new app, setting to dkp-critical-priority

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-97255

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
