### PR TITLE
fix: wait for webhook to be deleted (2.5)

### DIFF
--- a/services/rook-ceph-cluster/1.10.11/pre-install.yaml
+++ b/services/rook-ceph-cluster/1.10.11/pre-install.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
-  name: rook-ceph-cluster-pre-install-v1.10.8
+  name: rook-ceph-cluster-pre-install-v1.10.11
   namespace: ${releaseNamespace}
 spec:
   force: true

--- a/services/rook-ceph-cluster/1.10.11/pre-install.yaml
+++ b/services/rook-ceph-cluster/1.10.11/pre-install.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
-  name: rook-ceph-cluster-pre-install
+  name: rook-ceph-cluster-pre-install-v1.10.8
   namespace: ${releaseNamespace}
 spec:
   force: true

--- a/services/rook-ceph-cluster/1.10.11/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.10.11/pre-install/ceph-crd-check.yaml
@@ -17,6 +17,9 @@ rules:
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: ["helmreleases"]
     verbs: ["get", "watch", "list"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -35,12 +38,12 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: check-dkp-ceph-crd
+  name: dkp-ceph-pre-install
   namespace: ${releaseNamespace}
 spec:
   template:
     metadata:
-      name: check-dkp-ceph-crd
+      name: dkp-ceph-pre-install
     spec:
       serviceAccountName: check-dkp-ceph-crd
       restartPolicy: OnFailure
@@ -90,4 +93,7 @@ spec:
                 echo "Ceph operator is at $cephOperatorVersion version and desired version is ${desiredCephOperatorVersion}. Continuing to wait..."
                 sleep 10
               done
+
+              echo "verifying webhook was deleted"
+              kubectl wait validatingwebhookconfiguration.admissionregistration.k8s.io rook-ceph-webhook --for=delete --timeout 30m -v6
               EOF

--- a/services/rook-ceph-cluster/1.10.11/rook-ceph-cluster.yaml
+++ b/services/rook-ceph-cluster/1.10.11/rook-ceph-cluster.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   dependsOn:
     # There can only be one operator per cluster, just ensure CRDs are present, no need to wait for actual operator Deployment.
-    - name: rook-ceph-cluster-pre-install-v1.10.8
+    - name: rook-ceph-cluster-pre-install-v1.10.11
       namespace: ${workspaceNamespace}
   force: false
   prune: true

--- a/services/rook-ceph-cluster/1.10.11/rook-ceph-cluster.yaml
+++ b/services/rook-ceph-cluster/1.10.11/rook-ceph-cluster.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   dependsOn:
     # There can only be one operator per cluster, just ensure CRDs are present, no need to wait for actual operator Deployment.
-    - name: rook-ceph-cluster-pre-install
+    - name: rook-ceph-cluster-pre-install-v1.10.8
       namespace: ${workspaceNamespace}
   force: false
   prune: true


### PR DESCRIPTION
**What problem does this PR solve?**:
"backports" https://github.com/mesosphere/kommander-applications/pull/1246 to resolve potential issues while upgrading from 2.4.0 to 2.5.1.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-97225

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
