### PR TITLE
refactor: Use system-cluster-critical priority for rook-ceph

### DIFF
--- a/services/rook-ceph/1.11.4/defaults/cm.yaml
+++ b/services/rook-ceph/1.11.4/defaults/cm.yaml
@@ -12,7 +12,7 @@ data:
       # https://rook.io/docs/rook/latest/Troubleshooting/disaster-recovery/#restoring-crds-after-deletion
       enabled: true
 
-    priorityClassName: "dkp-critical-priority"
+    priorityClassName: "system-cluster-critical"
     resources:
       limits:
         cpu: 750m


### PR DESCRIPTION
**What problem does this PR solve?**:
We decided in https://d2iq.slack.com/archives/C04SS4T0EN9/p1684189296640239 to set rook-ceph operator priority to `system-cluster-critical` to match the priority class of rook-ceph-cluster, which depends on the operator.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
