### PR TITLE
fix: ensure pre-upgrade runs prior to upgrade

### DIFF
--- a/services/rook-ceph-cluster/1.11.4/pre-install.yaml
+++ b/services/rook-ceph-cluster/1.11.4/pre-install.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
-  name: rook-ceph-cluster-pre-install-v1.11.4
+  name: rook-ceph-cluster-prereq-jobs-v1.11.4
   namespace: ${releaseNamespace}
 spec:
   force: true

--- a/services/rook-ceph-cluster/1.11.4/pre-install.yaml
+++ b/services/rook-ceph-cluster/1.11.4/pre-install.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
-  name: rook-ceph-cluster-pre-install
+  name: rook-ceph-cluster-pre-install-v1.11.4
   namespace: ${releaseNamespace}
 spec:
   force: true

--- a/services/rook-ceph-cluster/1.11.4/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.11.4/pre-install/ceph-crd-check.yaml
@@ -35,12 +35,12 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: dkp-ceph-pre-install
+  name: dkp-ceph-prereq-job
   namespace: ${releaseNamespace}
 spec:
   template:
     metadata:
-      name: dkp-ceph-pre-install
+      name: dkp-ceph-prereq-job
     spec:
       serviceAccountName: check-dkp-ceph-crd
       restartPolicy: OnFailure

--- a/services/rook-ceph-cluster/1.11.4/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.11.4/pre-install/ceph-crd-check.yaml
@@ -35,12 +35,12 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: check-dkp-ceph-crd
+  name: dkp-ceph-pre-install
   namespace: ${releaseNamespace}
 spec:
   template:
     metadata:
-      name: check-dkp-ceph-crd
+      name: dkp-ceph-pre-install
     spec:
       serviceAccountName: check-dkp-ceph-crd
       restartPolicy: OnFailure

--- a/services/rook-ceph-cluster/1.11.4/rook-ceph-cluster.yaml
+++ b/services/rook-ceph-cluster/1.11.4/rook-ceph-cluster.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   dependsOn:
     # There can only be one operator per cluster, just ensure CRDs are present, no need to wait for actual operator Deployment.
-    - name: rook-ceph-cluster-pre-install-v1.11.4
+    - name: rook-ceph-cluster-prereq-jobs-v1.11.4
       namespace: ${workspaceNamespace}
   force: false
   prune: true

--- a/services/rook-ceph-cluster/1.11.4/rook-ceph-cluster.yaml
+++ b/services/rook-ceph-cluster/1.11.4/rook-ceph-cluster.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   dependsOn:
     # There can only be one operator per cluster, just ensure CRDs are present, no need to wait for actual operator Deployment.
-    - name: rook-ceph-cluster-pre-install
+    - name: rook-ceph-cluster-pre-install-v1.11.4
       namespace: ${workspaceNamespace}
   force: false
   prune: true


### PR DESCRIPTION
**What problem does this PR solve?**:
backports https://github.com/mesosphere/kommander-applications/pull/1246 minus the waiting for the webook since it will already be disabled in 2.5

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-97225

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
