### PR TITLE
feat: Set priority class on more components

### DIFF
--- a/services/dex/2.12.1/defaults/cm.yaml
+++ b/services/dex/2.12.1/defaults/cm.yaml
@@ -66,6 +66,7 @@ data:
           fieldRef:
             fieldPath: metadata.namespace
     dex-controller:
+      priorityClassName: "dkp-critical-priority"
       controller:
         manager:
           dexConfigSecretName: dex

--- a/services/kube-oidc-proxy/0.3.2/kube-oidc-proxy.yaml
+++ b/services/kube-oidc-proxy/0.3.2/kube-oidc-proxy.yaml
@@ -21,7 +21,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-staging
         namespace: kommander-flux
-      version: 0.3.1
+      version: 0.3.2
   interval: 15s
   install:
     crds: CreateReplace

--- a/services/kube-prometheus-stack/45.21.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/45.21.0/defaults/cm.yaml
@@ -9,6 +9,7 @@ data:
     commonLabels:
       prometheus.kommander.d2iq.io/select: "true"
     prometheusOperator:
+      priorityClassName: "dkp-critical-priority"
       logLevel: warn
       tls:
         tlsMinVersion: VersionTLS12
@@ -347,6 +348,7 @@ data:
     kubeScheduler:
       enabled: false
     alertmanager:
+      enabled: true
       config:
         global:
           resolve_timeout: 5m
@@ -489,6 +491,7 @@ data:
     nodeExporter:
       enabled: true
     kube-state-metrics:
+      priorityClassName: "dkp-critical-priority"
       metricLabelsAllowlist:
         - pods=[*]
         - namespaces=[*]

--- a/services/traefik-forward-auth-mgmt/0.3.9/traefik-forward-auth-mgmt.yaml
+++ b/services/traefik-forward-auth-mgmt/0.3.9/traefik-forward-auth-mgmt.yaml
@@ -19,7 +19,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-staging
         namespace: kommander-flux
-      version: 0.3.8
+      version: 0.3.9
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:
Set priority class on some missing components (part 1, will have more PRs to deal with others as I keep auditing)
- kube-prometheus-stack: kube-state-metrics, operator
- dex-controller
- kube-oidc-proxy HR version was not bumped (bug in chart bumper?)
- traefik-forward-auth-mgmt HR version was not bumped (bug in chart bumper?)

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-97328

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
