### PR TITLE
fix: bump rook-ceph-cluster/loki HelmRelease timeout

### DIFF
--- a/services/grafana-loki/0.69.16/grafana-loki-helmrelease/grafana-loki.yaml
+++ b/services/grafana-loki/0.69.16/grafana-loki-helmrelease/grafana-loki.yaml
@@ -13,6 +13,7 @@ spec:
         namespace: kommander-flux
       version: 0.69.16
   interval: 15s
+  timeout: 15m
   install:
     crds: CreateReplace
     remediation:

--- a/services/project-grafana-loki/0.69.16/project-grafana-loki.yaml
+++ b/services/project-grafana-loki/0.69.16/project-grafana-loki.yaml
@@ -12,6 +12,7 @@ spec:
         name: grafana.github.io
         namespace: kommander-flux
       version: 0.69.16
+  timeout: 15m
   interval: 15s
   install:
     crds: CreateReplace

--- a/services/rook-ceph-cluster/1.11.7/helmrelease/helmrelease.yaml
+++ b/services/rook-ceph-cluster/1.11.7/helmrelease/helmrelease.yaml
@@ -12,6 +12,7 @@ spec:
         name: charts.rook.io-release
         namespace: kommander-flux
       version: v1.11.7
+  timeout: 15m
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:
in 2.5.0, we enabled deploying the rook ceph tools pod by default, which is deployed by the `rook-ceph-cluster` HelmRelease.

The rook ceph tools pod mounts secrets/configmap that are created by the rook operator. If the rook operator takes a while to create secrets, the entire CephCluster will be uninstalled and retried (the CephCluster cannot be deleted when there are object bucket claims referencing it… but i don't think we want to disable retries entirely because certain situations might benefit from retrying like if the helm-controller can't create the object at all for some reason 🤔). 

Bumping the timeout value might be a good middle ground to help resolve potential install issues. Relates to https://d2iq.atlassian.net/browse/D2IQ-97063

Also, while doing pre-prov testing i noticed the loki HR timing out so we can bump that as well

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
