### PR TITLE
feat: Set default priority class on koperator

### DIFF
--- a/charts/kommander-operator/Chart.yaml
+++ b/charts/kommander-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kommander-operator
-appVersion: "0.1.0"
-version: 0.1.0
+appVersion: "0.2.0"
+version: 0.2.0
 description: kommander-operator helm chart.
 maintainers:
   - name: azhovan

--- a/charts/kommander-operator/templates/deployment.yaml
+++ b/charts/kommander-operator/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ .Chart.Name }}-sa
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.kommanderoperator.image.repository }}:{{ .Values.kommanderoperator.image.tag }}"

--- a/charts/kommander-operator/templates/post_install_kommandercore_hook.yaml
+++ b/charts/kommander-operator/templates/post_install_kommandercore_hook.yaml
@@ -62,6 +62,9 @@ spec:
   template:
     spec:
       serviceAccountName: {{ .Chart.Name }}-installation
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-installation
           image: "{{ .Values.kubetools.image.repository | default "mesosphere/kommander2-kubetools" }}:{{ .Values.kubetools.image.tag }}"

--- a/charts/kommander-operator/values.yaml
+++ b/charts/kommander-operator/values.yaml
@@ -12,3 +12,5 @@ kubetools:
   image:
     repository: mesosphere/kommander2-kubetools
     tag:
+
+priorityClassName: "dkp-critical-priority"

--- a/common/kommander-operator/helmrelease.yaml
+++ b/common/kommander-operator/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
         kind: GitRepository
         name: management
         namespace: kommander-flux
-      version: 0.1.0
+      version: 0.2.0
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:
Set default priority class on koperator. I bumped the versions here, not sure it matters... it seems like koperator will just be upgraded immediately/automatically when the kapps repo is updated? I guess that's fine for now because there's not much happening with this bump, but something to think about later if ordering matters and we can't upgrade koperator first before everything else (e.g. kommander/kommander-appmanagement)

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-97328

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
