### PR TITLE
feat: Set priority class on remaining ceph components

### DIFF
--- a/services/rook-ceph-cluster/1.11.4/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.11.4/defaults/cm.yaml
@@ -13,7 +13,7 @@ data:
       # The name is hardcoded, so if deploying more than one `rook-ceph-custer` then this flag needs to be set to false.
       # This is enabled by default to workaround D2IQ-96634
       enabled: true
-      priorityClassName: system-cluster-critical
+      priorityClassName: dkp-high-priority
 
     # All values below are taken from the CephCluster CRD
     cephClusterSpec:

--- a/services/rook-ceph-cluster/1.11.4/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.11.4/defaults/cm.yaml
@@ -13,6 +13,7 @@ data:
       # The name is hardcoded, so if deploying more than one `rook-ceph-custer` then this flag needs to be set to false.
       # This is enabled by default to workaround D2IQ-96634
       enabled: true
+      priorityClassName: system-cluster-critical
 
     # All values below are taken from the CephCluster CRD
     cephClusterSpec:
@@ -52,6 +53,10 @@ data:
         urlPrefix: ""
         port: 8443
         ssl: false
+
+      # priority classes to apply to ceph resources
+      priorityClassNames:
+        crashcollector: system-cluster-critical
 
       storage:
         storageClassDeviceSets:


### PR DESCRIPTION
**What problem does this PR solve?**:
Noticed these ceph components missing priority class:
- `rook-ceph-crashcollector-*` deployments
- `rook-ceph-tools` deployment

After applying this config:
```
k get deployments -A -o=jsonpath='{range .items[*]}{@.metadata.name}{"\t\t"}{@.spec.template.spec.priorityClassName}{" \n"}' | grep rook
rook-ceph-crashcollector-0afc3f63c87e8fbd2d737160a815af58		system-cluster-critical
rook-ceph-crashcollector-4e28b5dfc7ab3fb1ef0ccfa75ebb4e5e		system-cluster-critical
rook-ceph-crashcollector-a99c97a5e98b0753453efc74e029fcde		system-cluster-critical
rook-ceph-crashcollector-b65a830587be13131bf9a54364f22029		system-cluster-critical
rook-ceph-crashcollector-d883e3ac3e29c07c7b06d99c6bdd4c54		system-cluster-critical
rook-ceph-mgr-a		system-cluster-critical
rook-ceph-mgr-b		system-cluster-critical
rook-ceph-mon-a		system-node-critical
rook-ceph-mon-b		system-node-critical
rook-ceph-mon-c		system-node-critical
rook-ceph-operator		system-cluster-critical
rook-ceph-osd-0		system-node-critical
rook-ceph-osd-1		system-node-critical
rook-ceph-osd-2		system-node-critical
rook-ceph-osd-3		system-node-critical
rook-ceph-rgw-dkp-object-store-a		system-cluster-critical
rook-ceph-tools		system-cluster-critical
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-97328

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
