### PR TITLE
feat: Set priority for KPS node exporter

### DIFF
--- a/services/kube-prometheus-stack/45.21.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/45.21.0/defaults/cm.yaml
@@ -500,6 +500,7 @@ data:
           additionalLabels:
             prometheus.kommander.d2iq.io/select: "true"
     prometheus-node-exporter:
+      priorityClassName: "dkp-critical-priority"
       prometheus:
         monitor:
           additionalLabels:


### PR DESCRIPTION
**What problem does this PR solve?**:
missed this daemonset `kube-prometheus-stack-prometheus-node-exporter`

Looks good after pushing this change to the daily
```
kube-prometheus-stack-prometheus-node-exporter		dkp-critical-priority
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-97328

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
