### PR TITLE
feat: create-kommander-branch workflow supports multiple apps

### DIFF
--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -72,13 +72,17 @@ jobs:
             if  [[ ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }} == chartbump/* ]] ;
             then
               # Update kuttl tests that reference the app being bumped
-              appversion=$(echo ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }} | sed -r 's/(chartbump\/)(.*)/\2/')
-              appname=$(echo $appversion | sed -r 's/(.*)(-.*)/\1/')
+              kapps=$(echo '${{ github.event.pull_request.body }}' | grep kapps:)
+              kapps=${kapps#"kapps:"}
+              echo $kapps
               semver="(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)"
-              for file in $(find ./tests ./docs -type f -print); do
-                case $file in
-                  *".yaml" | *".yaml.tmpl" | *".md") sed -r -i "s/$appname-$semver/$appversion/g" $file;;
-                esac
+              for appversion in $kapps; do
+                appname=$(echo $appversion | sed -r 's/(.*)(-.*)/\1/')
+                for file in $(find ./tests ./docs -type f -print); do
+                  case $file in
+                    *".yaml" | *".yaml.tmpl" | *".md") sed -r -i "s/$appname-$semver/$appversion/g" $file;;
+                  esac
+                done
               done
               git add ./tests
              fi


### PR DESCRIPTION
**What problem does this PR solve?**:
https://d2iq.atlassian.net/browse/D2IQ-96950?focusedCommentId=558963

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-96950

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
Inspect the PRs created using the updated automation:
* https://github.com/mesosphere/kommander/pull/3447
* https://github.com/mesosphere/kommander/pull/3448

To get the PRs above to work, I cherry-picked the commit into their corresponding k-apps branches and manually updated the PR descriptions to include the automation's expected inputs.

Future updates will depend on https://github.com/mesosphere/dkp-infra-tools/pull/169 getting merged in, which will set the same formatted input in the chartbump PR description body.
(Depends on https://github.com/mesosphere/dkp-infra-tools/pull/169)

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
