### PR TITLE
feat: Set priority on kustomization jobs

### DIFF
--- a/services/centralized-kubecost/0.34.0/post-install-jobs/post-install-jobs.yaml
+++ b/services/centralized-kubecost/0.34.0/post-install-jobs/post-install-jobs.yaml
@@ -39,6 +39,7 @@ spec:
     spec:
       serviceAccountName: kubecost-configmap-edit
       restartPolicy: OnFailure
+      priorityClassName: dkp-high-priority
       containers:
         - name: kubectl
           image: bitnami/kubectl:1.24.6

--- a/services/centralized-kubecost/0.34.0/release/release.yaml
+++ b/services/centralized-kubecost/0.34.0/release/release.yaml
@@ -70,6 +70,7 @@ spec:
     spec:
       serviceAccountName: kubecost-thanos-configmap-edit
       restartPolicy: OnFailure
+      priorityClassName: dkp-high-priority
       containers:
         - name: kubectl
           image: bitnami/kubectl:1.24.6

--- a/services/grafana-loki/0.69.14/grafana-loki-pre-install-jobs/pre-install.yaml
+++ b/services/grafana-loki/0.69.14/grafana-loki-pre-install-jobs/pre-install.yaml
@@ -43,6 +43,7 @@ spec:
     spec:
       serviceAccountName: grafana-loki-pre-install
       restartPolicy: OnFailure
+      priorityClassName: dkp-critical-priority
       containers:
         - name: pre-install
           image: bitnami/kubectl:1.24.6
@@ -95,4 +96,6 @@ spec:
                 echo "The CephCluster '.status.ceph.capacity.lastUpdated' field is not populated yet, retrying after 10s..."
                 sleep 10
               done
+
+              echo "CephCluster capacity updated at: $ceph_cluster_capacity"
               EOF

--- a/services/grafana-loki/0.69.14/grafana-loki-pre-install.yaml
+++ b/services/grafana-loki/0.69.14/grafana-loki-pre-install.yaml
@@ -4,7 +4,7 @@ metadata:
   name: grafana-loki-pre-install
   namespace: ${releaseNamespace}
 spec:
-  force: false
+  force: true
   prune: true
   wait: true
   interval: 6h

--- a/services/rook-ceph-cluster/1.11.4/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.11.4/pre-install/ceph-crd-check.yaml
@@ -43,6 +43,7 @@ spec:
       name: dkp-ceph-prereq-job
     spec:
       serviceAccountName: check-dkp-ceph-crd
+      priorityClassName: system-cluster-critical
       restartPolicy: OnFailure
       containers:
         - name: pre-install

--- a/services/thanos/12.4.3/jobs/jobs.yaml
+++ b/services/thanos/12.4.3/jobs/jobs.yaml
@@ -41,6 +41,7 @@ spec:
     spec:
       serviceAccountName: kommander-thanos-configmap-edit
       restartPolicy: OnFailure
+      priorityClassName: dkp-critical-priority
       containers:
         - name: kubectl
           image: bitnami/kubectl:1.24.6

--- a/services/velero/4.0.1/pre-install/pre-install-job.yaml
+++ b/services/velero/4.0.1/pre-install/pre-install-job.yaml
@@ -43,6 +43,7 @@ spec:
     spec:
       serviceAccountName: velero-pre-install
       restartPolicy: OnFailure
+      priorityClassName: dkp-critical-priority
       containers:
         - name: pre-install
           image: bitnami/kubectl:1.24.6

--- a/services/velero/4.0.1/velero-pre-install.yaml
+++ b/services/velero/4.0.1/velero-pre-install.yaml
@@ -4,7 +4,7 @@ metadata:
   name: velero-pre-install
   namespace: ${releaseNamespace}
 spec:
-  force: false
+  force: true
   prune: true
   wait: true
   interval: 6h


### PR DESCRIPTION
**What problem does this PR solve?**:
Set priority class on pre/post-install jobs backed by kustomizations. These are one-off jobs that run at installation to properly set up the application, so I think that prioritizing them would be safe. Users won't be able to configure this, but as they run then exit, I don't think we would see that use case.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-97328

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
