### PR TITLE
feat: Trigger docs automation for published releases

### DIFF
--- a/.github/workflows/publish-appversions.yml
+++ b/.github/workflows/publish-appversions.yml
@@ -9,24 +9,21 @@ jobs:
   publish-test:
     name: Publish docs test
     if: ${{ github.event_name == 'workflow_dispatch' }}
-    runs-on:
-    - self-hosted
-    - small
+    runs-on: ubuntu-latest
     steps:
       - name: Repository dispatch
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: mesosphere/dkp-infra-tools
-          event-type: confluence-docs
-          client-payload: '{"docs_type":"appversions","branch":"main"}'
+        run: |
+          curl -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/mesosphere/dkp-infra-tools/dispatches \
+            -d '{"event_type":"confluence-docs","client_payload":{"docs_type":"appversions","branch":"main"}}'
 
   publish-tag:
     name: Publish docs with tag
     if: ${{ startsWith(github.ref_name, 'v') }}
-    runs-on:
-    - self-hosted
-    - small
+    runs-on: ubuntu-latest
     steps:
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/publish-appversions.yml
+++ b/.github/workflows/publish-appversions.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           curl -L -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
+            -H "Authorization: Bearer ${{ secrets.MESOSPHERECI_USER_TOKEN }}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/mesosphere/dkp-infra-tools/dispatches \
             -d '{"event_type":"confluence-docs","client_payload":{"docs_type":"appversions","branch":"main"}}'

--- a/.github/workflows/publish-appversions.yml
+++ b/.github/workflows/publish-appversions.yml
@@ -26,9 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repository dispatch
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: mesosphere/dkp-infra-tools
-          event-type: confluence-docs
-          client-payload: '{"docs_type":"appversions","tag":"${{ github.ref_name }}"}'
+        run: |
+          curl -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.MESOSPHERECI_USER_TOKEN }}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/mesosphere/dkp-infra-tools/dispatches \
+            -d '{"event_type":"confluence-docs","client_payload":{"docs_type":"appversions","branch":"${{ github.ref_name }}"}}'


### PR DESCRIPTION
**What problem does this PR solve?**:
Triggers the Confluence docs automation in dkp-infra-tools when there is a new release published. It can be tested via workflow dispatch.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-97039

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
Workflow dispatch test: https://github.com/mesosphere/kommander-applications/actions/runs/5081036474/jobs/9130932074
Dispatched job: https://github.com/mesosphere/dkp-infra-tools/actions/runs/5081913964/jobs/9130935727

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
