### PR TITLE
feat: Add pre-upgrade job to delete OBC jobs

### DIFF
--- a/services/rook-ceph-cluster/1.11.4/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.11.4/defaults/cm.yaml
@@ -251,6 +251,8 @@ data:
         bucketName: dkp-velero
         storageClassName: dkp-object-store
         enableOBCHealthCheck: true
+        priorityClassName: system-cluster-critical
+        ttlSecondsAfterFinished: 100
         additionalConfig:
           maxSize: "20G"
       grafana-loki:
@@ -258,6 +260,8 @@ data:
         bucketName: dkp-loki
         storageClassName: dkp-object-store
         enableOBCHealthCheck: true
+        priorityClassName: system-cluster-critical
+        ttlSecondsAfterFinished: 100
         additionalConfig:
           # maxObjects:
           maxSize: "80G"

--- a/services/rook-ceph-cluster/1.11.4/kustomization.yaml
+++ b/services/rook-ceph-cluster/1.11.4/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 resources:
   - object-bucket-claims.yaml
   - pre-install.yaml
+  - obc-pre-upgrade.yaml
   - rook-ceph-cluster.yaml
   - grafana-dashboards

--- a/services/rook-ceph-cluster/1.11.4/obc-pre-upgrade.yaml
+++ b/services/rook-ceph-cluster/1.11.4/obc-pre-upgrade.yaml
@@ -1,21 +1,15 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
-  name: object-bucket-claims-helmrelease
+  name: rook-ceph-cluster-obc-pre-upgrade
   namespace: ${releaseNamespace}
 spec:
-  dependsOn:
-    # CephCluster needs to be active to activate ObjectBucketClaims
-    - name: rook-ceph-cluster-helmrelease
-      namespace: ${releaseNamespace}
-    - name: rook-ceph-cluster-obc-pre-upgrade
-      namespace: ${releaseNamespace}
   force: true
   prune: true
   wait: true
   interval: 6h
   retryInterval: 1m
-  path: ./services/rook-ceph-cluster/1.11.4/objectbucketclaims
+  path: ./services/rook-ceph-cluster/1.11.4/obc-pre-upgrade
   sourceRef:
     kind: GitRepository
     name: management

--- a/services/rook-ceph-cluster/1.11.4/obc-pre-upgrade/delete-obc-jobs.yaml
+++ b/services/rook-ceph-cluster/1.11.4/obc-pre-upgrade/delete-obc-jobs.yaml
@@ -43,6 +43,7 @@ metadata:
   name: delete-obc-jobs
   namespace: ${releaseNamespace}
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     metadata:
       name: delete-obc-jobs
@@ -50,7 +51,6 @@ spec:
       serviceAccountName: obc-pre-upgrade
       restartPolicy: OnFailure
       priorityClassName: system-cluster-critical
-      ttlSecondsAfterFinished: 100
       containers:
         - name: kubectl
           image: bitnami/kubectl:1.24.6

--- a/services/rook-ceph-cluster/1.11.4/obc-pre-upgrade/delete-obc-jobs.yaml
+++ b/services/rook-ceph-cluster/1.11.4/obc-pre-upgrade/delete-obc-jobs.yaml
@@ -1,0 +1,61 @@
+# For upgrades from DKP <2.6 to 2.6.x.
+# **REMOVE THIS AFTER 2.6 IS RELEASED**
+# Delete the Jobs created by the OBC chart prior to upgrading. We added priority class
+# support to Job specs, which is an immutable field and requires the Job to be
+# deleted and recreated. After this release, we can remove this pre-upgrade step because
+# TTL will be set on the Job to automatically clean it up after it runs.
+# Select all OBC jobs by using the label "helm.toolkit.fluxcd.io/name=object-bucket-claims".
+# The job will also be run pre-install but will be a noop.
+# It will also get run during upgrades within 2.6, but recreating the job will not have any effects.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: obc-pre-upgrade
+  namespace: ${releaseNamespace}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: obc-pre-upgrade
+  namespace: ${releaseNamespace}
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "watch", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: obc-pre-upgrade
+  namespace: ${releaseNamespace}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: obc-pre-upgrade
+subjects:
+  - kind: ServiceAccount
+    name: obc-pre-upgrade
+    namespace: ${releaseNamespace}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-obc-jobs
+  namespace: ${releaseNamespace}
+spec:
+  template:
+    metadata:
+      name: delete-obc-jobs
+    spec:
+      serviceAccountName: obc-pre-upgrade
+      restartPolicy: OnFailure
+      priorityClassName: system-cluster-critical
+      ttlSecondsAfterFinished: 100
+      containers:
+        - name: kubectl
+          image: bitnami/kubectl:1.24.6
+          command:
+            - sh
+            - -c
+            - |
+              kubectl delete jobs.batch -l helm.toolkit.fluxcd.io/name=object-bucket-claims --cascade=orphan -n ${releaseNamespace}

--- a/services/rook-ceph-cluster/1.11.4/objectbucketclaims/helmrelease.yaml
+++ b/services/rook-ceph-cluster/1.11.4/objectbucketclaims/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: 0.1.4
+      version: 0.1.7
   timeout: 20m
   interval: 15s
   install:


### PR DESCRIPTION
**What problem does this PR solve?**:
Add pre-upgrade job to delete OBC jobs before upgrading OBC helmreleases. This ensures that we won't run into immutable errors, which we are adding priority class to the Job spec (an immutable field). TTL is also being set on these Jobs so that we don't need this pre-upgrade script in the future.
depends on https://github.com/mesosphere/charts/pull/1431

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-97328

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
