### PR TITLE
chore: bump kubectl image tags

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -3,7 +3,7 @@ ignore:
   - docker.io/mesosphere/kommander2-kubetools
   - docker.io/nginxinc/nginx-unprivileged:1.22.0-alpine
   - docker.io/bitnami/external-dns:0.13.4-debian-11-r19
-  - docker.io/bitnami/kubectl:1.24.6
+  - docker.io/bitnami/kubectl:1.26.4
   - docker.io/bitnami/kubectl:1.24.1
   - docker.io/bitnami/memcached:1.6.15-debian-11-r8
   - docker.io/bitnami/postgresql:11.16.0-debian-11-r9

--- a/make/test.mk
+++ b/make/test.mk
@@ -9,7 +9,7 @@ E2E_TIMEOUT       ?= 120m
 # flexible with our testing as well as testing against the same patch version as we deliver
 # by default with DKP.
 # See https://github.com/mesosphere/kind-docker-image-automation/ for the build repo.
-E2E_KINDEST_IMAGE ?= "mesosphere/kind-node-ci:v1.24.6"
+E2E_KINDEST_IMAGE ?= "mesosphere/kind-node-ci:v1.26.3"
 
 # Kommander <=v2.3 does not install on Kubernetes >=v1.24 due to the introduction of
 # `LegacyServiceAccountTokenNoAutoGeneration` feature (enabled by default). This breaks self-attachment

--- a/services/centralized-kubecost/0.34.0/post-install-jobs/post-install-jobs.yaml
+++ b/services/centralized-kubecost/0.34.0/post-install-jobs/post-install-jobs.yaml
@@ -42,7 +42,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.24.6
+          image: bitnami/kubectl:1.26.4
           command:
             - sh
             - -c

--- a/services/centralized-kubecost/0.34.0/release/release.yaml
+++ b/services/centralized-kubecost/0.34.0/release/release.yaml
@@ -73,7 +73,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.24.6
+          image: bitnami/kubectl:1.26.4
           command:
             - sh
             - "-c"

--- a/services/grafana-loki/0.69.14/grafana-loki-pre-install-jobs/pre-install.yaml
+++ b/services/grafana-loki/0.69.14/grafana-loki-pre-install-jobs/pre-install.yaml
@@ -46,7 +46,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: pre-install
-          image: bitnami/kubectl:1.24.6
+          image: bitnami/kubectl:1.26.4
           command:
             - sh
             - -c

--- a/services/istio/1.17.2/defaults/cm.yaml
+++ b/services/istio/1.17.2/defaults/cm.yaml
@@ -30,5 +30,5 @@ data:
           prometheus.kommander.d2iq.io/select: "true"
     global:
       image: bitnami/kubectl
-      tag: 1.24.6
+      tag: 1.26.4
       priorityClassName: "dkp-critical-priority"

--- a/services/kubefed/0.10.2/defaults/cm.yaml
+++ b/services/kubefed/0.10.2/defaults/cm.yaml
@@ -35,7 +35,7 @@ data:
       postInstallJob:
         repository: bitnami
         image: kubectl
-        tag: 1.24.6
+        tag: 1.26.4
     webhook:
       annotations:
         secret.reloader.stakater.com/reload: "kubefed-root-ca"

--- a/services/kubetunnel/0.0.21/defaults/cm.yaml
+++ b/services/kubetunnel/0.0.21/defaults/cm.yaml
@@ -17,4 +17,4 @@ data:
     hooks:
       kubectlImage:
         repository: bitnami/kubectl
-        tag: 1.24.6
+        tag: 1.26.4

--- a/services/rook-ceph-cluster/1.11.4/obc-pre-upgrade/delete-obc-jobs.yaml
+++ b/services/rook-ceph-cluster/1.11.4/obc-pre-upgrade/delete-obc-jobs.yaml
@@ -53,7 +53,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.24.6
+          image: bitnami/kubectl:1.26.4
           command:
             - sh
             - -c

--- a/services/rook-ceph-cluster/1.11.4/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.11.4/pre-install/ceph-crd-check.yaml
@@ -47,7 +47,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: pre-install
-          image: bitnami/kubectl:1.24.6
+          image: bitnami/kubectl:1.26.4
           command:
             - sh
             - -c
@@ -57,7 +57,7 @@ spec:
                 sleep 30
               done
         - name: pre-upgrade
-          image: bitnami/kubectl:1.24.6
+          image: bitnami/kubectl:1.26.4
           command:
             - sh
             - -c

--- a/services/thanos/12.6.2/jobs/jobs.yaml
+++ b/services/thanos/12.6.2/jobs/jobs.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.24.6
+          image: bitnami/kubectl:1.26.4
           command:
             - sh
             - "-c"

--- a/services/traefik/23.0.1/defaults/cm.yaml
+++ b/services/traefik/23.0.1/defaults/cm.yaml
@@ -39,7 +39,7 @@ data:
         app: traefik
       initContainers:
       - name: initialize-middleware
-        image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.24.6}"
+        image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.26.4}"
         command:
           - bash
         args:

--- a/services/velero/4.0.1/defaults/cm.yaml
+++ b/services/velero/4.0.1/defaults/cm.yaml
@@ -47,4 +47,4 @@ data:
       image:
         # If we don't override the version here, upstream chart will pull an image dynamically based on k8s cluster version.
         # which makes it harder to build airgapped tar bundles. So to make bundle collection predictable, we override the tag here.
-        tag: 1.24.6
+        tag: 1.26.4

--- a/services/velero/4.0.1/pre-install/pre-install-job.yaml
+++ b/services/velero/4.0.1/pre-install/pre-install-job.yaml
@@ -46,7 +46,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: pre-install
-          image: bitnami/kubectl:1.24.6
+          image: bitnami/kubectl:1.26.4
           command:
             - sh
             - -c


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumps kubectl images to avoid having multiple versions of the image in the bundles

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
