### PR TITLE
fix: use a more generic contains for nvidia kommander automation

### DIFF
--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -95,20 +95,20 @@ jobs:
           }
 
       - name: checkout local directory for script
-        if: contains(needs.get-kapps-branch-name.outputs.branch_name, 'chartbump/nvidia-gpu-operator')
+        if: contains(needs.get-kapps-branch-name.outputs.branch_name, 'gpu-operator')
         uses: actions/checkout@v3
         with:
           path: 'main'
 
       - name: get go
-        if: contains(needs.get-kapps-branch-name.outputs.branch_name, 'chartbump/nvidia-gpu-operator')
+        if: contains(needs.get-kapps-branch-name.outputs.branch_name, 'gpu-operator')
         uses: actions/setup-go@v4
         with:
           go-version-file: 'kommander/go.mod'
           cache: true
 
       - name: run nvidia script
-        if: contains(needs.get-kapps-branch-name.outputs.branch_name, 'chartbump/nvidia-gpu-operator')
+        if: contains(needs.get-kapps-branch-name.outputs.branch_name, 'gpu-operator')
         run: |
           go install github.com/itchyny/gojq/cmd/gojq@latest
           cd main

--- a/hack/update-nvidia.sh
+++ b/hack/update-nvidia.sh
@@ -28,8 +28,8 @@ for image in "${images[@]}"; do
         new_version=$(tail --lines=+8 "${2}"| gojq --yaml-input '.validator.version'| xargs)
         new_image="${new_image//"${version}"/"${new_version}"}"
       ;;
-      devicePlugin)
-        new_version=$(tail --lines=+8 "${2}"| gojq --yaml-input '.devicePlugin.config.version'| xargs)
+      k8s-device-plugin)
+        new_version=$(tail --lines=+8 "${2}"| gojq --yaml-input '.devicePlugin.version'| xargs)
         new_image="${new_image//"${version}"/"${new_version}"}"
       ;;
       *)


### PR DESCRIPTION
**What problem does this PR solve?**:
fixes the automation condition for automated nvidia chart bumps to update the missing images

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
