### PR TITLE
fix: bump rook-ceph-cluster/loki HelmRelease timeout (backport) (2.5)

### DIFF
--- a/services/grafana-loki/0.69.4/grafana-loki-helmrelease/grafana-loki.yaml
+++ b/services/grafana-loki/0.69.4/grafana-loki-helmrelease/grafana-loki.yaml
@@ -14,6 +14,7 @@ spec:
         namespace: kommander-flux
       version: "0.69.4"
   interval: 15s
+  timeout: 15m
   install:
     crds: CreateReplace
     remediation:

--- a/services/project-grafana-loki/0.69.4/project-grafana-loki.yaml
+++ b/services/project-grafana-loki/0.69.4/project-grafana-loki.yaml
@@ -13,6 +13,7 @@ spec:
         name: grafana.github.io
         namespace: kommander-flux
       version: "0.69.4"
+  timeout: 15m
   interval: 15s
   install:
     crds: CreateReplace

--- a/services/rook-ceph-cluster/1.10.11/helmrelease/helmrelease.yaml
+++ b/services/rook-ceph-cluster/1.10.11/helmrelease/helmrelease.yaml
@@ -13,6 +13,7 @@ spec:
         namespace: kommander-flux
       version: v1.10.11
   interval: 15s
+  timeout: 15m
   install:
     crds: CreateReplace
     remediation:


### PR DESCRIPTION
**What problem does this PR solve?**:
backports https://github.com/mesosphere/kommander-applications/pull/1261

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
