### PR TITLE
fix: duplicate key in fluentbit config defaults

### DIFF
--- a/services/fluent-bit/0.30.3/defaults/cm.yaml
+++ b/services/fluent-bit/0.30.3/defaults/cm.yaml
@@ -18,8 +18,6 @@ data:
         cpu: 350m
         memory: 250Mi
 
-    priorityClassName: system-node-critical
-
     securityContext:
       privileged: true
 


### PR DESCRIPTION
**What problem does this PR solve?**:

The key for priority class is duplicated at https://github.com/mesosphere/kommander-applications/blob/04fd26194dee601b01a3bd482618daa2b393dd68/services/fluent-bit/0.30.3/defaults/cm.yaml#L13 and https://github.com/mesosphere/kommander-applications/blob/04fd26194dee601b01a3bd482618daa2b393dd68/services/fluent-bit/0.30.3/defaults/cm.yaml#L21

Found this when testing out the new config service endpoint.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
