### PR TITLE
fix(istio): expose metrics to allow prometheus scraping

### DIFF
--- a/services/istio/1.17.2/defaults/cm.yaml
+++ b/services/istio/1.17.2/defaults/cm.yaml
@@ -32,3 +32,8 @@ data:
       image: bitnami/kubectl
       tag: 1.26.4
       priorityClassName: "dkp-critical-priority"
+    operator:
+      # expose metrics for prometheus scraping
+      monitoring:
+        host: 0.0.0.0
+        port: 15014


### PR DESCRIPTION
**What problem does this PR solve?**:
Fixes the metrics scraping issue found via the daily cluster alerts.

The istio metrics host defaults to `127.0.0.1`, which doesn't allow prometheus to scrape the istio operator metrics. 

I'm not sure if this fix should go into the [chart defaults](url) or here, open to suggestions!

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-97182

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
