### PR TITLE
chore: bump jaeger-operator

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -98,7 +98,7 @@ resources:
       - url: https://github.com/istio/istio
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: docker.io/jaegertracing/jaeger-operator:1.45.0
+  - container_image: docker.io/jaegertracing/jaeger-operator:1.46.0
     sources:
       - url: https://github.com/jaegertracing/jaeger-operator
         ref: v${image_tag}

--- a/services/jaeger/2.45.0/helmrelease/release.yaml
+++ b/services/jaeger/2.45.0/helmrelease/release.yaml
@@ -43,7 +43,7 @@ data:
   dashboardLink: "/dkp/jaeger"
   docsLink: "https://istio.io/docs/tasks/telemetry/distributed-tracing/jaeger/"
   # Check https://artifacthub.io/packages/helm/jaegertracing/jaeger-operator/ for app version
-  version: "1.39.0"
+  version: "1.46.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumps jaeger-operator to latest version: https://github.com/jaegertracing/jaeger-operator/blob/main/CHANGELOG.md#v1460-2025-06-16
as preparation to add priorityclass

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/jira/software/c/projects/D2IQ/boards/61?modal=detail&selectedIssue=D2IQ-97354

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
