### PR TITLE
chore: updates mergebot config to DKP

### DIFF
--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -9,12 +9,12 @@
     "enabled": true,
     "interactive": false,
     "fix_version_map": {
-      "main": "Kommander 2.6.0",
+      "main": "DKP 2.6.0",
       "release-2.1": "Kommander 2.1.6",
       "release-2.2": "Kommander 2.2.4",
-      "release-2.3": "Kommander 2.3.4",
-      "release-2.4": "Kommander 2.4.2",
-      "release-2.5": "Kommander 2.5.2"
+      "release-2.3": "DKP 2.3.4",
+      "release-2.4": "DKP 2.4.2",
+      "release-2.5": "DKP 2.5.2"
     },
     "jira_regex": "((?:COPS|D2IQ)-\\d+)"
   },


### PR DESCRIPTION
**What problem does this PR solve?**:
Adjusts mergebot configuration to use DKP product versions instead of Kommander.
We are currently working around this by mapping in JIRA - that mapping needs manual updates whenever we release -> a work creation machine. With this PR we shouldn't need to fix after releasing anymore as the release-automation takes care of the mergebot config.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
