### PR TITLE
fix: Don't change original permissions of etcd certificates

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -380,7 +380,7 @@ resources:
       - url: https://github.com/kubernetes/kube-state-metrics
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: quay.io/brancz/kube-rbac-proxy:v0.14.1
+  - container_image: quay.io/brancz/kube-rbac-proxy:v0.14.2
     sources:
       - url: https://github.com/brancz/kube-rbac-proxy
         ref: ${image_tag}

--- a/services/kube-prometheus-stack/46.8.0/etcd-metrics-proxy/kube-rbac-proxy.yaml
+++ b/services/kube-prometheus-stack/46.8.0/etcd-metrics-proxy/kube-rbac-proxy.yaml
@@ -91,7 +91,7 @@ spec:
               mountPath: /etc/kube-rbac-proxy/etcd
       containers:
         - name: kube-rbac-proxy
-          image: quay.io/brancz/kube-rbac-proxy:v0.14.1
+          image: quay.io/brancz/kube-rbac-proxy:v0.14.2
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--tls-cert-file=/etc/kube-rbac-proxy/tls/tls.crt"

--- a/services/kube-prometheus-stack/46.8.0/etcd-metrics-proxy/kube-rbac-proxy.yaml
+++ b/services/kube-prometheus-stack/46.8.0/etcd-metrics-proxy/kube-rbac-proxy.yaml
@@ -75,25 +75,32 @@ spec:
       initContainers:
         - name: init
           image: docker.io/library/busybox:1
-          command: ["/bin/chown", "-R", "65532:65532", "/etc/certs/etcd"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - >
+              cp /etc/certs/etcd/ca.crt /etc/certs/etcd/healthcheck* /etc/kube-rbac-proxy/etcd/ &&
+              chown -R 65532:65532 /etc/kube-rbac-proxy/etcd
           securityContext:
             runAsUser: 0
             privileged: true
           volumeMounts:
             - name: etcd-certs
               mountPath: /etc/certs/etcd
+              readOnly: true
+            - name: etcd-certs-copy
+              mountPath: /etc/kube-rbac-proxy/etcd
       containers:
         - name: kube-rbac-proxy
           image: quay.io/brancz/kube-rbac-proxy:v0.14.1
           args:
             - "--secure-listen-address=0.0.0.0:8443"
-            - "--tls-cert-file=/etc/certs/tls.crt"
-            - "--tls-private-key-file=/etc/certs/tls.key"
+            - "--tls-cert-file=/etc/kube-rbac-proxy/tls/tls.crt"
+            - "--tls-private-key-file=/etc/kube-rbac-proxy/tls/tls.key"
             - "--upstream=https://$(NODE_IP):$(ETCD_PORT)"
             - "--allow-paths=/metrics"
-            - "--upstream-ca-file=/etc/certs/etcd/ca.crt"
-            - "--upstream-client-cert-file=/etc/certs/etcd/healthcheck-client.crt"
-            - "--upstream-client-key-file=/etc/certs/etcd/healthcheck-client.key"
+            - "--upstream-ca-file=/etc/kube-rbac-proxy/etcd/ca.crt"
+            - "--upstream-client-cert-file=/etc/kube-rbac-proxy/etcd/healthcheck-client.crt"
+            - "--upstream-client-key-file=/etc/kube-rbac-proxy/etcd/healthcheck-client.key"
             - "--v=7"
           ports:
             - containerPort: 8443
@@ -106,17 +113,25 @@ spec:
             - name: ETCD_PORT
               value: "2379"
           volumeMounts:
-            - name: etcd-certs
-              mountPath: /etc/certs/etcd
             - name: tls-certs
-              mountPath: /etc/certs
+              mountPath: /etc/kube-rbac-proxy/tls
+              readOnly: true
+            - name: etcd-certs-copy
+              mountPath: /etc/kube-rbac-proxy/etcd
+              readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
       volumes:
         - name: etcd-certs
           hostPath:
             path: /etc/kubernetes/pki/etcd
+        - name: etcd-certs-copy
+          emptyDir: {}
         - name: tls-certs
           secret:
             secretName: etcd-metrics-proxy-tls


### PR DESCRIPTION
**What problem does this PR solve?**:
This PR changes how etcd certificates are handled in `etcd-metrics-proxy` by copying original certs and modifying the copy. The existing approach modifies the original files, which causes the CIS benchmark to fail: 
```
Failed a CIS Benchmark test 1.1.19: Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)
```
Also, the PR bumps the `kube-rbac-proxy` image to the latest version.

**Which issue(s) does this PR fix?**:
https://d2iq.atlassian.net/browse/D2IQ-97242


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
