### PR TITLE
chore: disable config-api by default

### DIFF
--- a/services/kommander-appmanagement/0.6.0/defaults/cm.yaml
+++ b/services/kommander-appmanagement/0.6.0/defaults/cm.yaml
@@ -30,6 +30,8 @@ data:
         repository: "${kommanderAppManagementWebhookImageRepository}"
         tag: "${kommanderAppManagementImageTag}"
     defaultConfig:
+      # TODO(takirala): enable config-api by default from DKP 2.7+
+      enabled: false
       image:
         repository: "${kommanderAppManagementConfigAPIImageRepository}"
         tag: "${kommanderAppManagementImageTag}"


### PR DESCRIPTION
**What problem does this PR solve?**:

Address https://d2iq.atlassian.net/browse/D2IQ-97950

We will drop this in 2.7

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
