### PR TITLE
fix: explicitly declare this quota

### DIFF
--- a/services/kommander-flux/0.41.2/templates/kustomization.yaml
+++ b/services/kommander-flux/0.41.2/templates/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- v1_resource-quota.yaml
 - apiextensions.k8s.io_v1_customresourcedefinition_alerts.notification.toolkit.fluxcd.io.yaml
 - apiextensions.k8s.io_v1_customresourcedefinition_buckets.source.toolkit.fluxcd.io.yaml
 - apiextensions.k8s.io_v1_customresourcedefinition_gitrepositories.source.toolkit.fluxcd.io.yaml

--- a/services/kommander-flux/0.41.2/templates/v1_resource-quota.yaml
+++ b/services/kommander-flux/0.41.2/templates/v1_resource-quota.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: flux-critical-pods
+  namespace: kommander-flux
+spec:
+  hard:
+    pods: 1G
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+      - system-node-critical
+      - system-cluster-critical


### PR DESCRIPTION
so that it works on GKE 1.26+

workaround is from: https://github.com/openservicemesh/osm/issues/4408#issuecomment-1302008888

**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
