### PR TITLE
fix: bump kubectl image used by cluster-observer

### DIFF
--- a/services/kommander/0.6.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
+++ b/services/kommander/0.6.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
@@ -27,7 +27,7 @@ spec:
   releaseName: ${releaseName}
   valuesFrom:
     - kind: ConfigMap
-      name: cluster-observer-1.1.1-d2iq-defaults
+      name: ${name}-d2iq-defaults
     - kind: ConfigMap
       name: ${valuesFrom}
   targetNamespace: ${targetNamespace}

--- a/services/kommander/0.6.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
+++ b/services/kommander/0.6.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
@@ -27,5 +27,7 @@ spec:
   releaseName: ${releaseName}
   valuesFrom:
     - kind: ConfigMap
+      name: cluster-observer-1.1.1-d2iq-defaults
+    - kind: ConfigMap
       name: ${valuesFrom}
   targetNamespace: ${targetNamespace}

--- a/services/kommander/0.6.0/dynamic-helmreleases/cluster-observer/defaults/cm.yaml
+++ b/services/kommander/0.6.0/dynamic-helmreleases/cluster-observer/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-observer-1.1.1-d2iq-defaults
+  name: ${name}-d2iq-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kommander/0.6.0/dynamic-helmreleases/cluster-observer/defaults/cm.yaml
+++ b/services/kommander/0.6.0/dynamic-helmreleases/cluster-observer/defaults/cm.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-observer-1.1.1-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    hooks:
+      kubectlImage: bitnami/kubectl:1.26.4

--- a/services/kommander/0.6.0/dynamic-helmreleases/cluster-observer/kustomization.yaml
+++ b/services/kommander/0.6.0/dynamic-helmreleases/cluster-observer/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - defaults/cm.yaml
   - cluster-observer.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumps the cluster observer kubectl image to match the rest of the services

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-98236

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
