### PR TITLE
chore: bump ghostunnel image for airgapped bundle

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -204,7 +204,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/mesosphere/dex
-  - container_image: docker.io/mesosphere/ghostunnel:v1.5.3-server-backend-proxy
+  - container_image: docker.io/mesosphere/ghostunnel:v1.7.1-server-backend-proxy
     sources:
       - license_path: LICENSE
         ref: ${image_tag%-server-backend-proxy}

--- a/services/kommander/0.6.0/dynamic-helmreleases/mtls-proxy/list-images-values.yaml
+++ b/services/kommander/0.6.0/dynamic-helmreleases/mtls-proxy/list-images-values.yaml
@@ -2,4 +2,4 @@ target: unused
 certSecretName: unused
 image:
   repository: mesosphere/ghostunnel
-  tag: v1.5.3-server-backend-proxy
+  tag: v1.7.1-server-backend-proxy


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumps the ghostunnel image used in the airgapped bundle

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-98180

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
