### PR TITLE
feat: Update jaeger allinone img to match operator version

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -137,7 +137,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/istio/proxy
-  - container_image: docker.io/jaegertracing/all-in-one:1.30.0
+  - container_image: docker.io/jaegertracing/all-in-one:1.46.0
     sources:
       - license_path: LICENSE
         notice_path: NOTICE

--- a/services/grafana-logging/6.57.4/grafana.yaml
+++ b/services/grafana-logging/6.57.4/grafana.yaml
@@ -38,8 +38,8 @@ data:
   name: "Grafana Logging"
   dashboardLink: "/dkp/logging/grafana"
   docsLink: "https://grafana.com/docs/"
-  # Check https://artifacthub.io/packages/helm/grafana/grafana/6.38.1 for app version
-  version: "8.5.14"
+  # Check https://artifacthub.io/packages/helm/grafana/grafana/6.57.4 for app version
+  version: "9.5.5"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/jaeger/2.46.2/defaults/cm.yaml
+++ b/services/jaeger/2.46.2/defaults/cm.yaml
@@ -10,7 +10,7 @@ data:
       spec:
         strategy: allInOne
         allInOne:
-          image: jaegertracing/all-in-one:1.30.0
+          image: jaegertracing/all-in-one:1.46.0
           options:
             query:
               base-path: /dkp/jaeger

--- a/services/jaeger/2.46.2/helmrelease/release.yaml
+++ b/services/jaeger/2.46.2/helmrelease/release.yaml
@@ -43,7 +43,7 @@ data:
   dashboardLink: "/dkp/jaeger"
   docsLink: "https://istio.io/docs/tasks/telemetry/distributed-tracing/jaeger/"
   # Check https://artifacthub.io/packages/helm/jaegertracing/jaeger-operator/ for app version
-  version: "1.39.0"
+  version: "1.46.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/karma/2.0.2/karma.yaml
+++ b/services/karma/2.0.2/karma.yaml
@@ -83,7 +83,7 @@ data:
   dashboardLink: "/dkp/kommander/monitoring/karma"
   docsLink: "https://github.com/prymitive/karma"
   # We override karma image:
-  # https://github.com/mesosphere/kommander-applications/blob/main/services/karma/2.0.1/defaults/cm.yaml#L14
+  # https://github.com/mesosphere/kommander-applications/blob/main/services/karma/2.0.2/defaults/cm.yaml#L14
   version: "0.88"
 ---
 apiVersion: cert-manager.io/v1

--- a/services/kiali/1.70.0/kiali.yaml
+++ b/services/kiali/1.70.0/kiali.yaml
@@ -44,7 +44,7 @@ data:
   dashboardLink: "/dkp/kiali"
   docsLink: "https://istio.io/docs/tasks/telemetry/kiali/"
   # Chart version matches app version
-  version: "1.57.1"
+  version: "1.70.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/kube-prometheus-stack/46.8.0/helmrelease/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/46.8.0/helmrelease/kube-prometheus-stack.yaml
@@ -46,7 +46,7 @@ data:
   docsLink: "https://prometheus.io/docs/"
   # Prometheus app version can be found at prometheus.prometheusSpec.image.tag:
   # https://github.com/mesosphere/charts/blob/master/staging/kube-prometheus-stack/values.yaml#L2147
-  version: "2.42.2"
+  version: "2.44.0"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/services/kubecost/0.35.1/kubecost.yaml
+++ b/services/kubecost/0.35.1/kubecost.yaml
@@ -40,7 +40,7 @@ data:
   dashboardLink: "/dkp/kubecost/frontend/overview.html"
   docsLink: "http://docs.kubecost.com/"
   # From: https://github.com/mesosphere/charts/blob/master/stable/kubecost/Chart.yaml#L2
-  version: "1.97.0"
+  version: "1.104.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/traefik/23.1.0/traefik.yaml
+++ b/services/traefik/23.1.0/traefik.yaml
@@ -37,9 +37,9 @@ metadata:
 data:
   name: "Traefik"
   dashboardLink: "/dkp/traefik/dashboard/"
-  docsLink: "https://doc.traefik.io/traefik/v2.9"
+  docsLink: "https://doc.traefik.io/traefik/v2.10"
   # Check https://artifacthub.io/packages/helm/traefik/traefik for app version
-  version: "2.9.4"
+  version: "2.10.1"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
**What problem does this PR solve?**:
noticed that the jaeger `allinone` image was using a pretty outdated version -- updating it to the same version that the operator is running.
ALSO: noticed most of our dashboard cm's had outdated versions, updated them here as well

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
