### PR TITLE
ci: Validate PR title length instead of commit

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -6,6 +6,13 @@ on:
       - opened
       - edited
       - synchronize
+      - reopened
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
 
 jobs:
   main:
@@ -15,3 +22,8 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: deepakputhraya/action-pr-title@master
+        with:
+          max_length: 72 # Max length of PR title
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,12 +1,6 @@
 name: "Lint PR"
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
-      - reopened
   pull_request:
     types:
       - opened

--- a/.gitlint
+++ b/.gitlint
@@ -1,3 +1,3 @@
 [general]
 contrib=contrib-title-conventional-commits
-ignore=body-is-missing
+ignore=body-is-missing,title-max-length


### PR DESCRIPTION
**What problem does this PR solve?**:
Add gitlint rule to ignore commit titles that are too long; since PR titles are used in squash commits, we don't gain anything by limiting the commit messages. Instead, validate that PR titles are not too long.

example of failed run when I updated title to be too long: https://github.com/mesosphere/kommander-applications/actions/runs/5674273398/job/15377493428?pr=1433
```
Error: Pull Request title "ci: Validate PR title length instead of commit and this is going to be super long now you should fail" is greater than max length specified - 72
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
