### PR TITLE
fix: Disable kubecost-grafana PSP by default

### DIFF
--- a/services/kubecost/0.33.1/defaults/cm.yaml
+++ b/services/kubecost/0.33.1/defaults/cm.yaml
@@ -35,6 +35,8 @@ data:
         enabled: false
 
       grafana:
+        rbac:
+          pspEnabled: false
         ingress:
           enabled: true
           annotations:


### PR DESCRIPTION
**What problem does this PR solve?**:
PSPs were removed in k8s 1.25 (dkp 2.5) but it is still enabled by default here so we need to explicitly disable it to avoid upgrade failures from 2.4. We only need to do this for 2.5 because the version in 2.6 changed the default to false.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-98509

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
