### PR TITLE
fix: disable PSPs explictly to avoid upgrade failures (2.6)

### DIFF
--- a/services/gatekeeper/3.12.0/defaults/cm.yaml
+++ b/services/gatekeeper/3.12.0/defaults/cm.yaml
@@ -24,3 +24,5 @@ data:
     controllerManager:
       tlsMinVersion: 1.2
     resourceQuota: false
+    psp:
+      enabled: false

--- a/services/logging-operator/4.2.3/defaults/cm.yaml
+++ b/services/logging-operator/4.2.3/defaults/cm.yaml
@@ -6,6 +6,9 @@ metadata:
 data:
   values.yaml: |-
     ---
+    rbac:
+      psp:
+        enabled: false
     priorityClassName: "dkp-critical-priority"
     resources:
      limits:


### PR DESCRIPTION
* fix: disable PSPs

* fix(gatekeeper): Disable psps by default

PSP was removed in k8s 1.25, we should explicitly disable PSPs in our default values.

---------

**What problem does this PR solve?**:
backports https://github.com/mesosphere/kommander-applications/pull/1437

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-98509

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
