### PR TITLE
fix: Handle upgrade to logging-operator v4.2.0

### DIFF
--- a/services/logging-operator/4.2.3/defaults/cm.yaml
+++ b/services/logging-operator/4.2.3/defaults/cm.yaml
@@ -32,6 +32,7 @@ metadata:
 data:
   values.yaml: |
     ---
+    enableRecreateWorkloadOnImmutableFieldChange: true
     clusterFlows:
       - name: cluster-containers
         spec:

--- a/services/logging-operator/4.2.3/pre-upgrade/pre-upgrade.yaml
+++ b/services/logging-operator/4.2.3/pre-upgrade/pre-upgrade.yaml
@@ -13,6 +13,9 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "watch", "list", "update", "patch", "create"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    verbs: ["delete", "list"]
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: ["helmreleases"]
     verbs: ["get", "watch", "list"]
@@ -63,4 +66,7 @@ spec:
               fi
 
               helm mapkubeapis logging-operator --namespace ${releaseNamespace}
+
+              # handle spec.selector update in logging-operator 4.2.0
+              kubectl delete daemonset -n${releaseNamespace} -l app.kubernetes.io/managed-by=logging-operator-logging,app.kubernetes.io/name=fluentbit --ignore-not-found
               EOF

--- a/services/logging-operator/4.2.3/pre-upgrade/pre-upgrade.yaml
+++ b/services/logging-operator/4.2.3/pre-upgrade/pre-upgrade.yaml
@@ -13,9 +13,6 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "watch", "list", "update", "patch", "create"]
-  - apiGroups: ["apps"]
-    resources: ["daemonsets"]
-    verbs: ["delete", "list"]
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: ["helmreleases"]
     verbs: ["get", "watch", "list"]
@@ -66,7 +63,4 @@ spec:
               fi
 
               helm mapkubeapis logging-operator --namespace ${releaseNamespace}
-
-              # handle spec.selector update in logging-operator 4.2.0
-              kubectl delete daemonset -n${releaseNamespace} -l app.kubernetes.io/managed-by=logging-operator-logging,app.kubernetes.io/name=fluentbit --ignore-not-found
               EOF


### PR DESCRIPTION
**What problem does this PR solve?**:
In the logging-operator `4.2.0`, the fluent-bit daemonset `spec.selector` field was [updated](https://github.com/kube-logging/logging-operator/blob/5a8e76e6e81c7440e70bf37bd8b1d6ff5d11a376/pkg/resources/fluentbit/fluentbit.go#L60) which is an immutable field. 

On upgrade to 2.6, the fluent-bit daemonset is never upgraded because the logging-operator cannot update the DS with the new selectors. The only way to continue is to delete the DS. Unfortunately, since our logging-operator HR is not behind a Kustomization, we don't have a good way of running a job after the operator finishes upgrading so we can't just simply run a `kubectl delete` on the DS. 

By setting `enableRecreateWorkloadOnImmutableFieldChange`, we allow the operator to recreate resources if required. If this is set, it's recommended to set `logging.spec.fluentbit.spec.positiondb` and a PVC for the fluentd buffer, both of which we have set.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-98592

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
