### PR TITLE
fix: not skipping authz for kube dashboard

### DIFF
--- a/services/traefik-forward-auth-mgmt/0.3.9/defaults/cm.yaml
+++ b/services/traefik-forward-auth-mgmt/0.3.9/defaults/cm.yaml
@@ -34,6 +34,9 @@ data:
       whitelist: []
       enableRBAC: true
       enableImpersonation: true
+      rbacPassThroughPaths:
+        - "/dkp/kiali/"
+        - "/dkp/kiali/*"
     ingress:
       enabled: true
       annotations:

--- a/services/traefik-forward-auth-mgmt/0.3.9/defaults/cm.yaml
+++ b/services/traefik-forward-auth-mgmt/0.3.9/defaults/cm.yaml
@@ -34,11 +34,6 @@ data:
       whitelist: []
       enableRBAC: true
       enableImpersonation: true
-      rbacPassThroughPaths:
-        - "/dkp/kubernetes/"
-        - "/dkp/kubernetes/*"
-        - "/dkp/kiali/"
-        - "/dkp/kiali/*"
     ingress:
       enabled: true
       annotations:

--- a/services/traefik-forward-auth/0.3.9/defaults/cm.yaml
+++ b/services/traefik-forward-auth/0.3.9/defaults/cm.yaml
@@ -33,7 +33,6 @@ data:
       whitelist: []
       enableRBAC: true
       enableImpersonation: true
-      rbacPassThroughPaths: ["/dkp/kubernetes/", "/dkp/kubernetes/*"]
       extraConfig: |
         cookie-name =  _forward_auth_kommander
         csrf-cookie-name = _forward_auth_csrf_kommander

--- a/services/traefik-forward-auth/0.3.9/defaults/cm.yaml
+++ b/services/traefik-forward-auth/0.3.9/defaults/cm.yaml
@@ -33,6 +33,9 @@ data:
       whitelist: []
       enableRBAC: true
       enableImpersonation: true
+      rbacPassThroughPaths:
+        - "/dkp/kiali/"
+        - "/dkp/kiali/*"
       extraConfig: |
         cookie-name =  _forward_auth_kommander
         csrf-cookie-name = _forward_auth_csrf_kommander


### PR DESCRIPTION
**What problem does this PR solve?**:
TFA-full ingresses are skipping the k8s API authorization thus a user can just access the URL(just seeing the empty page) without any RBAC permission

see TFA Code about this config option:

https://github.com/mesosphere/traefik-forward-auth/blob/master/internal/handlers/server.go#L497-L504

**Which issue(s) does this PR fix?**:
https://d2iq.atlassian.net/browse/D2IQ-97861#


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
