### PR TITLE
fix(kps): Remove duplicate apiserver and unused keepalived scrapeconfig

### DIFF
--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -271,38 +271,6 @@ data:
             - source_labels: [__meta_kubernetes_namespace]
               target_label: namespace
               action: replace
-          - job_name: 'kubernetes-keepalived'
-            metrics_path: /snmp
-            params:
-              target: ["127.0.0.1:6161"]
-              module: ["keepalived"]
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            kubernetes_sd_configs:
-              - role: pod
-                namespaces:
-                  names:
-                  - kube-system
-            relabel_configs:
-            - source_labels: [__meta_kubernetes_pod_container_port_protocol]
-              regex: TCP
-              action: keep
-            - source_labels: [__meta_kubernetes_pod_container_port_number]
-              regex: "6161"
-              action: keep
-            - source_labels: [__meta_kubernetes_pod_container_port_name]
-              target_label: endpoint
-              action: replace
-            - source_labels: [__meta_kubernetes_pod_node_name]
-              target_label: node
-              action: replace
-            - source_labels: [__meta_kubernetes_pod_name]
-              target_label: pod
-              action: replace
-            - source_labels: [__meta_kubernetes_namespace]
-              target_label: namespace
-              action: replace
         enableAdminAPI: true
         walCompression: true
         # secrets:

--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -181,22 +181,6 @@ data:
             - configMapRef:
                 name: cluster-info-configmap
         additionalScrapeConfigs:
-          # Kubernetes API
-          - job_name: 'kubernetes-apiserver'
-            kubernetes_sd_configs:
-            - role: endpoints
-              namespaces:
-                names:
-                - default
-            scheme: https
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
-            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            relabel_configs:
-            - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
-              action: keep
-              regex: kubernetes;https
           # Kubernetes pods
           - job_name: 'kubernetes-pods'
             kubernetes_sd_configs:


### PR DESCRIPTION
It looks like the KPS chart already defines a servicemonitor which scrapes the apiserver metrics. Our additional scrapeconfig definition is resulting in scraping the same apiserver targets and generating duplicate metrics. We can remove our scrape config and rely on the chart created servicemonitor.

Also, we no longer deploy keepalived in dkp 2.x so removing that unused scrape target.

**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-98647

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
