### PR TITLE
feat(grafana): Use grafana 9.5.7

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -94,12 +94,6 @@ resources:
       - license_path: LICENSE
         ref: v${image_tag%-rootless}
         url: https://github.com/go-gitea/gitea
-  - container_image: docker.io/grafana/grafana:8.5.14
-    sources:
-      - license_path: LICENSE
-        notice_path: NOTICE.md
-        ref: v${image_tag}
-        url: https://github.com/grafana/grafana
   - container_image: docker.io/grafana/grafana:9.4.7
     sources:
       - license_path: LICENSE
@@ -112,7 +106,7 @@ resources:
         notice_path: NOTICE.md
         ref: v${image_tag}
         url: https://github.com/grafana/grafana
-  - container_image: docker.io/grafana/grafana:10.0.3
+  - container_image: docker.io/grafana/grafana:9.5.7
     sources:
       - license_path: LICENSE
         notice_path: NOTICE.md

--- a/services/grafana-logging/6.58.6/defaults/cm.yaml
+++ b/services/grafana-logging/6.58.6/defaults/cm.yaml
@@ -7,6 +7,10 @@ data:
   values.yaml: |
     ---
     priorityClassName: "dkp-critical-priority"
+    # pinning grafana to 9.5 since it appears that upgrading to v10 is causing issues with prometheus scraping
+    # grafana metrics
+    image:
+      tag: 9.5.7
     datasources:
       datasources.yaml:
         apiVersion: 1

--- a/services/grafana-logging/6.58.6/defaults/cm.yaml
+++ b/services/grafana-logging/6.58.6/defaults/cm.yaml
@@ -7,12 +7,6 @@ data:
   values.yaml: |
     ---
     priorityClassName: "dkp-critical-priority"
-    # overriding the default image due to this issue
-    # https://d2iq.atlassian.net/browse/D2IQ-94038
-    # cause by upstream bug
-    # https://github.com/grafana/grafana/issues/56087
-    image:
-      tag: 8.5.14
     datasources:
       datasources.yaml:
         apiVersion: 1

--- a/services/grafana-logging/6.58.6/defaults/cm.yaml
+++ b/services/grafana-logging/6.58.6/defaults/cm.yaml
@@ -56,6 +56,11 @@ data:
       type: ClusterIP
       port: 3000
 
+    serviceMonitor:
+      enabled: true
+      labels:
+        prometheus.kommander.d2iq.io/select: "true"
+
     resources:
       # keep request = limit to keep this container in guaranteed class
       limits:

--- a/services/grafana-logging/6.58.6/grafana.yaml
+++ b/services/grafana-logging/6.58.6/grafana.yaml
@@ -38,8 +38,8 @@ data:
   name: "Grafana Logging"
   dashboardLink: "/dkp/logging/grafana"
   docsLink: "https://grafana.com/docs/"
-  # Check https://artifacthub.io/packages/helm/grafana/grafana/6.57.4 for app version
-  version: "9.5.5"
+  # Check https://artifacthub.io/packages/helm/grafana/grafana/6.58.6 for app version
+  version: "10.0.2"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/grafana-logging/6.58.6/grafana.yaml
+++ b/services/grafana-logging/6.58.6/grafana.yaml
@@ -39,7 +39,7 @@ data:
   dashboardLink: "/dkp/logging/grafana"
   docsLink: "https://grafana.com/docs/"
   # Check https://artifacthub.io/packages/helm/grafana/grafana/6.58.6 for app version
-  version: "10.0.2"
+  version: "9.5.7"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -340,6 +340,10 @@ data:
             memory: 200Mi
     grafana:
       enabled: true
+      # pinning grafana to 9.5 since it appears that upgrading to v10 is causing issues with prometheus scraping
+      # grafana metrics
+      image:
+        tag: 9.5.7
       defaultDashboardsEnabled: true
       priorityClassName: "dkp-critical-priority"
       serviceMonitor:

--- a/services/kube-prometheus-stack/48.3.1/helmrelease/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/48.3.1/helmrelease/kube-prometheus-stack.yaml
@@ -77,4 +77,4 @@ data:
   # Since Grafana is a subchart of kube-prometheus-stack, get the version of the Grafana chart dependency at:
   # https://github.com/mesosphere/charts/tree/master/staging/kube-prometheus-stack/charts
   # Then, check https://artifacthub.io/packages/helm/grafana/grafana/ for app version
-  version: "10.0.3"
+  version: "9.5.7"

--- a/services/kube-prometheus-stack/metadata.yaml
+++ b/services/kube-prometheus-stack/metadata.yaml
@@ -27,7 +27,7 @@ overview: |-
 
   - [Prometheus Alertmanager Documentation - Overview](https://prometheus.io/docs/alerting/latest/alertmanager/)
 
-  ### Grafana (v10.0.3)
+  ### Grafana (v9.5.7)
   A monitoring dashboard from Grafana that can be used to visualize metrics collected by Prometheus.
 
   - [Grafana Documentation](https://grafana.com/docs/)

--- a/services/project-grafana-logging/6.58.6/defaults/cm.yaml
+++ b/services/project-grafana-logging/6.58.6/defaults/cm.yaml
@@ -7,6 +7,10 @@ data:
   values.yaml: |
     ---
     priorityClassName: "dkp-critical-priority"
+    # pinning grafana to 9.5 since it appears that upgrading to v10 is causing issues with prometheus scraping
+    # grafana metrics
+    image:
+      tag: 9.5.7
     datasources:
       datasources.yaml:
         apiVersion: 1

--- a/services/project-grafana-logging/6.58.6/defaults/cm.yaml
+++ b/services/project-grafana-logging/6.58.6/defaults/cm.yaml
@@ -7,12 +7,6 @@ data:
   values.yaml: |
     ---
     priorityClassName: "dkp-critical-priority"
-    # overriding the default image due to this issue
-    # https://d2iq.atlassian.net/browse/D2IQ-94038
-    # cause by upstream bug
-    # https://github.com/grafana/grafana/issues/56087
-    image:
-      tag: 8.5.14
     datasources:
       datasources.yaml:
         apiVersion: 1

--- a/services/project-grafana-logging/6.58.6/defaults/cm.yaml
+++ b/services/project-grafana-logging/6.58.6/defaults/cm.yaml
@@ -57,6 +57,11 @@ data:
       type: ClusterIP
       port: 3000
 
+    serviceMonitor:
+      enabled: true
+      labels:
+        prometheus.kommander.d2iq.io/select: "true"
+
     resources:
       # keep request = limit to keep this container in guaranteed class
       limits:


### PR DESCRIPTION
**What problem does this PR solve?**:
We were overriding the grafana image to avoid this upstream bug https://github.com/grafana/grafana/issues/56087 but it has been fixed so ~using the latest / default image now~ -- latest image v10 appears to be breaking prometheus scraping of grafana metrics, pinning to latest 9.5 version for now.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
