### PR TITLE
ci(gha): Avoid automerge if let-me-merge-it label is appliesd

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,6 +1,6 @@
 name: "Automerge"
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
       - unlabeled
@@ -31,6 +31,7 @@ jobs:
         && contains(github.event.pull_request.labels.*.name, 'ready-for-review')
         && !contains(github.event.pull_request.labels.*.name, 'do-not-merge')
         && !contains(github.event.pull_request.labels.*.name, 'do-not-merge/testing')
+        && !contains(github.event.pull_request.labels.*.name, 'let-me-merge-it')
       run: gh pr merge --auto --squash "$PR_URL"
       env:
         PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
**What problem does this PR solve?**:
looks like automerge action has been reenabled - it should not automerge if the `let-me-merge-it` label is applied

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
