### PR TITLE
fix: disables telemetry transmission for Grafana

### DIFF
--- a/services/centralized-grafana/48.3.1/defaults/cm.yaml
+++ b/services/centralized-grafana/48.3.1/defaults/cm.yaml
@@ -74,6 +74,7 @@ data:
           default_home_dashboard_path: "/tmp/dashboards/global-overview.json"
         analytics:
           reporting_enabled: false
+          check_for_updates: false
 
       datasources:
         datasources.yaml:

--- a/services/centralized-grafana/48.3.1/defaults/cm.yaml
+++ b/services/centralized-grafana/48.3.1/defaults/cm.yaml
@@ -72,6 +72,8 @@ data:
           allow_loading_unsigned_plugins: "grafana-piechart-panel"
         dashboards:
           default_home_dashboard_path: "/tmp/dashboards/global-overview.json"
+        analytics:
+          reporting_enabled: false
 
       datasources:
         datasources.yaml:

--- a/services/grafana-logging/6.58.6/defaults/cm.yaml
+++ b/services/grafana-logging/6.58.6/defaults/cm.yaml
@@ -57,6 +57,7 @@ data:
         allow_loading_unsigned_plugins: "grafana-piechart-panel"
       analytics:
         reporting_enabled: false
+        check_for_updates: false
 
     service:
       type: ClusterIP

--- a/services/grafana-logging/6.58.6/defaults/cm.yaml
+++ b/services/grafana-logging/6.58.6/defaults/cm.yaml
@@ -55,6 +55,8 @@ data:
         auto_assign_org_role: Admin
       plugins:
         allow_loading_unsigned_plugins: "grafana-piechart-panel"
+      analytics:
+        reporting_enabled: false
 
     service:
       type: ClusterIP

--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -399,6 +399,9 @@ data:
           allow_loading_unsigned_plugins: "grafana-piechart-panel"
         dashboards:
           default_home_dashboard_path: "/tmp/dashboards/k8s-resources-cluster.json"
+        analytics:
+          reporting_enabled: false
+
       service:
         type: ClusterIP
         port: 3000

--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -401,6 +401,7 @@ data:
           default_home_dashboard_path: "/tmp/dashboards/k8s-resources-cluster.json"
         analytics:
           reporting_enabled: false
+          check_for_updates: false
 
       service:
         type: ClusterIP

--- a/services/kubecost/0.35.1/defaults/cm.yaml
+++ b/services/kubecost/0.35.1/defaults/cm.yaml
@@ -71,6 +71,8 @@ data:
             enabled: false
           users:
             auto_assign_org_role: Admin
+          analytics:
+            reporting_enabled: false
 
       kubecostProductConfigs:
         grafanaURL: "/dkp/kubecost/grafana"

--- a/services/kubecost/0.35.1/defaults/cm.yaml
+++ b/services/kubecost/0.35.1/defaults/cm.yaml
@@ -73,6 +73,7 @@ data:
             auto_assign_org_role: Admin
           analytics:
             reporting_enabled: false
+            check_for_updates: false
 
       kubecostProductConfigs:
         grafanaURL: "/dkp/kubecost/grafana"

--- a/services/project-grafana-logging/6.58.6/defaults/cm.yaml
+++ b/services/project-grafana-logging/6.58.6/defaults/cm.yaml
@@ -58,6 +58,7 @@ data:
         allow_loading_unsigned_plugins: "grafana-piechart-panel"
       analytics:
         reporting_enabled: false
+        check_for_updates: false
 
     service:
       type: ClusterIP

--- a/services/project-grafana-logging/6.58.6/defaults/cm.yaml
+++ b/services/project-grafana-logging/6.58.6/defaults/cm.yaml
@@ -56,6 +56,8 @@ data:
         auto_assign_org_role: Admin
       plugins:
         allow_loading_unsigned_plugins: "grafana-piechart-panel"
+      analytics:
+        reporting_enabled: false
 
     service:
       type: ClusterIP


### PR DESCRIPTION
**What problem does this PR solve?**:
Prevents Grafana from phoning home with telemetry data.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-99007

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
