### PR TITLE
feat(koperator): Update chart version, pass version into deployment

### DIFF
--- a/charts/kommander-operator/Chart.yaml
+++ b/charts/kommander-operator/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v2
 name: kommander-operator
-appVersion: "0.2.0"
-version: 0.2.0
+appVersion: 2.7.0-dev
+version: 2.7.0-dev
 description: kommander-operator helm chart.
 maintainers:
   - name: azhovan
+  - name: gracedo

--- a/charts/kommander-operator/templates/deployment.yaml
+++ b/charts/kommander-operator/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.kommanderoperator.image.repository }}:{{ .Values.kommanderoperator.image.tag }}"
           imagePullPolicy: {{ .Values.kommanderoperator.image.pullPolicy }}
+          args:
+            - --kommander-version={{ .Chart.Version }}
           ports:
             - name: http
               containerPort: 80

--- a/charts/kommander-operator/templates/post_install_kommandercore_hook.yaml
+++ b/charts/kommander-operator/templates/post_install_kommandercore_hook.yaml
@@ -42,11 +42,13 @@ data:
     set -eo pipefail
 
 
-    cat <<EOF | kubectl apply -f -
+    cat <<EOF | kubectl apply --server-side -f -
     apiVersion: dkp.d2iq.io/v1alpha1
     kind: KommanderCore
     metadata:
       name: kommander-core
+    spec:
+      version: {{ .Chart.Version }}
     EOF
 ---
 apiVersion: batch/v1

--- a/charts/kommander-operator/values.yaml
+++ b/charts/kommander-operator/values.yaml
@@ -1,5 +1,4 @@
 # Default values for kommander-operator
-# this is using a nginx image at the moment that will be replaced by proper image
 
 replicaCount: 1
 kommanderoperator:

--- a/common/kommander-operator/helmrelease.yaml
+++ b/common/kommander-operator/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
         kind: GitRepository
         name: management
         namespace: kommander-flux
-      version: 0.2.0
+      version: 2.7.0-dev
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:
- updates operator helm chart version to be in line with dkp version
- pass chart version into deployment args
- set kommandercore spec version to chart version in post-install

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-97955

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
