### PR TITLE
feat(koperator): Revert to using arbitrary chart version

### DIFF
--- a/charts/kommander-operator/Chart.yaml
+++ b/charts/kommander-operator/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v2
 name: kommander-operator
-appVersion: "0.2.0"
-version: 0.2.0
+appVersion: "0.3.0"
+version: 0.3.0
 description: kommander-operator helm chart.
 maintainers:
   - name: azhovan
+  - name: gracedo

--- a/charts/kommander-operator/Chart.yaml
+++ b/charts/kommander-operator/Chart.yaml
@@ -1,8 +1,7 @@
 apiVersion: v2
 name: kommander-operator
-appVersion: 2.7.0-dev
-version: 2.7.0-dev
+appVersion: "0.2.0"
+version: 0.2.0
 description: kommander-operator helm chart.
 maintainers:
   - name: azhovan
-  - name: gracedo

--- a/charts/kommander-operator/templates/deployment.yaml
+++ b/charts/kommander-operator/templates/deployment.yaml
@@ -28,8 +28,6 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.kommanderoperator.image.repository }}:{{ .Values.kommanderoperator.image.tag }}"
           imagePullPolicy: {{ .Values.kommanderoperator.image.pullPolicy }}
-          args:
-            - --kommander-version={{ .Chart.Version }}
           ports:
             - name: http
               containerPort: 80

--- a/charts/kommander-operator/templates/post_install_kommandercore_hook.yaml
+++ b/charts/kommander-operator/templates/post_install_kommandercore_hook.yaml
@@ -42,7 +42,7 @@ data:
     set -eo pipefail
 
 
-    cat <<EOF | kubectl apply -f -
+    cat <<EOF | kubectl apply --server-side -f -
     apiVersion: dkp.d2iq.io/v1alpha1
     kind: KommanderCore
     metadata:

--- a/charts/kommander-operator/templates/post_install_kommandercore_hook.yaml
+++ b/charts/kommander-operator/templates/post_install_kommandercore_hook.yaml
@@ -42,13 +42,11 @@ data:
     set -eo pipefail
 
 
-    cat <<EOF | kubectl apply --server-side -f -
+    cat <<EOF | kubectl apply -f -
     apiVersion: dkp.d2iq.io/v1alpha1
     kind: KommanderCore
     metadata:
       name: kommander-core
-    spec:
-      version: {{ .Chart.Version }}
     EOF
 ---
 apiVersion: batch/v1

--- a/charts/kommander-operator/templates/rback_v1_clusterrole_operator_kommander-operator.yaml
+++ b/charts/kommander-operator/templates/rback_v1_clusterrole_operator_kommander-operator.yaml
@@ -39,6 +39,7 @@ rules:
       - kommanderclusters
       - gitrepositories
       - secrets
+      - events
     verbs:
       - get
       - list
@@ -65,6 +66,7 @@ rules:
       - kustomizations
       - federatednamespaces
       - kommanderclusters
+      - events
     verbs:
       - patch
       - update
@@ -102,4 +104,10 @@ rules:
     verbs:
       - deletecollection
       - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
 ---

--- a/charts/kommander-operator/values.yaml
+++ b/charts/kommander-operator/values.yaml
@@ -1,5 +1,4 @@
 # Default values for kommander-operator
-# this is using a nginx image at the moment that will be replaced by proper image
 
 replicaCount: 1
 kommanderoperator:

--- a/charts/kommander-operator/values.yaml
+++ b/charts/kommander-operator/values.yaml
@@ -1,4 +1,5 @@
 # Default values for kommander-operator
+# this is using a nginx image at the moment that will be replaced by proper image
 
 replicaCount: 1
 kommanderoperator:

--- a/common/kommander-operator/helmrelease.yaml
+++ b/common/kommander-operator/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
         kind: GitRepository
         name: management
         namespace: kommander-flux
-      version: 2.7.0-dev
+      version: 0.2.0
   interval: 15s
   install:
     crds: CreateReplace

--- a/common/kommander-operator/helmrelease.yaml
+++ b/common/kommander-operator/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
         kind: GitRepository
         name: management
         namespace: kommander-flux
-      version: 0.2.0
+      version: 0.3.0
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:
After additional discussions, it looks like we can simplify things by avoiding the syncing of koperator chart version with dkp/kommander version (involves pre/postrelease jobs, and postrelease jobs right now are risky since those bumps are not reviewed prior to releasing). Instead, we can follow the "kcli way" of getting its version which is set at build time via goreleaser ldflags https://github.com/mesosphere/kommander-cli/blob/97eb1585529a8b3183eb306d1bcdf85186a6ad86/.goreleaser.yml#L22-L27. This is how the kcli will be triggering ugprade, by using this version to update `kommandercore` (and `workspace`) with, so we should do the same in the kommander operator (and other controllers). Instead of using the chart version and passing the version down through flags, use the version as set at build time.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-97955

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
