### PR TITLE
ci(test): Bump k8s to 1.27.6

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -9,13 +9,13 @@ E2E_TIMEOUT       ?= 120m
 # flexible with our testing as well as testing against the same patch version as we deliver
 # by default with DKP.
 # See https://github.com/mesosphere/kind-docker-image-automation/ for the build repo.
-E2E_KINDEST_IMAGE ?= "ghcr.io/mesosphere/kind-node-ci:v1.26.6"
+E2E_KINDEST_IMAGE ?= "ghcr.io/mesosphere/kind-node-ci:v1.27.5"
 
 # Kommander applications are upgraded on the previous k8s version first, before the cluster
 # is upgraded. Therefore, for the upgrade test, we should use the previous k8s version to
 # more accurately mimic an actual upgrade scenario.
 E2E_KINDEST_IMAGE_FOR_UPGRADE_TEST ?= "ghcr.io/mesosphere/kind-node-ci:v1.26.6"
-UPGRADE_FROM_VERSION ?= "v2.6.0-dev"
+UPGRADE_FROM_VERSION ?= "v2.6.1-dev"
 
 # (aweris): This should be a temporary workaround for v2.3.0 development. If you're still see clone test in v2.4.0
 # it means "a temporary workaround" actually means "permanent solution".

--- a/make/test.mk
+++ b/make/test.mk
@@ -9,7 +9,7 @@ E2E_TIMEOUT       ?= 120m
 # flexible with our testing as well as testing against the same patch version as we deliver
 # by default with DKP.
 # See https://github.com/mesosphere/kind-docker-image-automation/ for the build repo.
-E2E_KINDEST_IMAGE ?= "ghcr.io/mesosphere/kind-node-ci:v1.27.5"
+E2E_KINDEST_IMAGE ?= "ghcr.io/mesosphere/kind-node-ci:v1.27.6"
 
 # Kommander applications are upgraded on the previous k8s version first, before the cluster
 # is upgraded. Therefore, for the upgrade test, we should use the previous k8s version to


### PR DESCRIPTION
**What problem does this PR solve?**:
update e2e tests with k8s 1.27

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-98552

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
