### PR TITLE
feat(ai-navigator): set proper resource limits and requests

### DIFF
--- a/services/ai-navigator-app/0.1.0/ai-navigator-app.yaml
+++ b/services/ai-navigator-app/0.1.0/ai-navigator-app.yaml
@@ -81,6 +81,13 @@ spec:
             initialDelaySeconds: 60
             timeoutSeconds: 30
             failureThreshold: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/services/ai-navigator-app/0.1.0/ai-navigator-app.yaml
+++ b/services/ai-navigator-app/0.1.0/ai-navigator-app.yaml
@@ -84,10 +84,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 64Mi
+              memory: 256Mi
             limits:
               cpu: 300m
-              memory: 512Mi
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/services/ai-navigator-app/0.1.0/defaults/cm.yaml
+++ b/services/ai-navigator-app/0.1.0/defaults/cm.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-data:
-  values.yaml: |
-    ---
-kind: ConfigMap
-metadata:
-  name: ai-navigation-app-0.1.0-d2iq-defaults
-  namespace: ${releaseNamespace}

--- a/services/ai-navigator-app/0.1.0/defaults/kustomization.yaml
+++ b/services/ai-navigator-app/0.1.0/defaults/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - cm.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:

I've ran 25 bot users which are constantly asking questions against the
service on the daily and it was inside the limits with a good margin.
It never went above 0.008 CPU usage and memory wasn't really much
affected, it stayed <30MB observed in our Grafana Dashboard.



**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://d2iq.atlassian.net/browse/D2IQ-99125

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
