### PR TITLE
feat: patch kcore status to kommander ver pre upgrade

### DIFF
--- a/charts/kommander-operator/templates/post_install_kommandercore_hook.yaml
+++ b/charts/kommander-operator/templates/post_install_kommandercore_hook.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -16,7 +16,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kommander-operator/templates/pre_upgrade_kommandercore_hook.yaml
+++ b/charts/kommander-operator/templates/pre_upgrade_kommandercore_hook.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Chart.Name }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Chart.Name }}-pre-upgrade
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Chart.Name }}-pre-upgrade
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+  pre_process_kcore.sh: |-
+    #!/bin/bash
+    set -eo pipefail
+
+    # get the version of kommander before upgrade
+    KOMMANDER_VERSION_PREUPGRADE=$(kubectl get helmrelease -n kommander kommander -o jsonpath='{.status.lastAppliedRevision}')
+    cat <<EOF > kcore_patch.yaml
+    apiVersion: dkp.d2iq.io/v1alpha1
+    kind: KommanderCore
+    metadata:
+      name: kommander-core
+    status:
+      version: $KOMMANDER_VERSION_PREUPGRADE
+    EOF
+
+    kubectl patch kommandercore kommander-core --subresource='status' --type='merge' --patch-file kcore_patch.yaml
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Chart.Name }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ .Chart.Name }}-pre-upgrade
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-pre-upgrade
+          image: "{{ .Values.kubetools.image.repository | default "mesosphere/kommander2-kubetools" }}:{{ .Values.kubetools.image.tag }}"
+          command: ["/bin/bash","-c"]
+          args: ["/bin/scripts/pre_process_kcore.sh"]
+          volumeMounts:
+            - name: script
+              mountPath: /bin/scripts
+      volumes:
+        - name: script
+          configMap:
+            defaultMode: 0770
+            name: {{ .Chart.Name }}-pre-upgrade
+      restartPolicy: OnFailure
+---

--- a/charts/kommander-operator/templates/pre_upgrade_kommandercore_hook.yaml
+++ b/charts/kommander-operator/templates/pre_upgrade_kommandercore_hook.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -17,7 +17,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kommander-operator/templates/pre_upgrade_kommandercore_hook.yaml
+++ b/charts/kommander-operator/templates/pre_upgrade_kommandercore_hook.yaml
@@ -41,6 +41,12 @@ data:
     #!/bin/bash
     set -eo pipefail
 
+    kcore_status=$(kubectl get kommandercore kommander-core -o jsonpath='{.status}')
+    # do nothing if the .status field is already populated
+    if [ -n "$kcore_status" ]; then
+      exit 0
+    fi
+
     # get the version of kommander before upgrade
     KOMMANDER_VERSION_PREUPGRADE=$(kubectl get helmrelease -n kommander kommander -o jsonpath='{.status.lastAppliedRevision}')
     cat <<EOF > kcore_patch.yaml

--- a/charts/kommander-operator/templates/pre_upgrade_kommandercore_hook.yaml
+++ b/charts/kommander-operator/templates/pre_upgrade_kommandercore_hook.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: remove this job in 2.8
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
**What problem does this PR solve?**:
pre 2.7 kommander core status.version is empty. This prevent 2.7 koperator from triggering the declarative upgrade logic.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-98960

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
