### PR TITLE
fix: remove kubernetes-nodes-containerd

### DIFF
--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -215,18 +215,6 @@ data:
               source_labels:
               - __meta_kubernetes_pod_name
               target_label: pod
-          - job_name: 'kubernetes-nodes-containerd'
-            metrics_path: /v1/metrics
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            kubernetes_sd_configs:
-              - role: node
-            relabel_configs:
-              - source_labels: [__address__]
-                regex: '(.*):10250'
-                replacement: '$${1}:1338'
-                target_label: __address__
           - job_name: 'gpu_metrics'
             metrics_path: /metrics
             tls_config:


### PR DESCRIPTION
**What problem does this PR solve?**:
`kubernetes-nodes-containerd` collects esoteric metrics which are not connected to a dashboard or any alerts. No d specific metrics (like memory use, etc) are scraped by the pods job. This PR removes this job

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-98666

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
