### PR TITLE
fix: used dedicated clusterrole for kcore hooks

### DIFF
--- a/charts/kommander-operator/templates/post_install_kommandercore_hook.yaml
+++ b/charts/kommander-operator/templates/post_install_kommandercore_hook.yaml
@@ -10,6 +10,25 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Chart.Name }}-installation
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - dkp.d2iq.io
+    resources:
+      - kommandercores
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Chart.Name }}-installation
@@ -20,12 +39,11 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: {{ .Chart.Name }}-installation
 subjects:
   - kind: ServiceAccount
     name: {{ .Chart.Name }}-installation
     namespace: {{ .Release.Namespace }}
-
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/kommander-operator/templates/post_install_kommandercore_hook.yaml
+++ b/charts/kommander-operator/templates/post_install_kommandercore_hook.yaml
@@ -27,6 +27,8 @@ rules:
       - list
       - watch
       - create
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/kommander-operator/templates/pre_upgrade_kommandercore_hook.yaml
+++ b/charts/kommander-operator/templates/pre_upgrade_kommandercore_hook.yaml
@@ -33,6 +33,7 @@ rules:
       - dkp.d2iq.io
     resources:
       - kommandercores
+      - kommandercores/status
     verbs:
       - patch
       - update

--- a/charts/kommander-operator/templates/pre_upgrade_kommandercore_hook.yaml
+++ b/charts/kommander-operator/templates/pre_upgrade_kommandercore_hook.yaml
@@ -11,6 +11,33 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Chart.Name }}-pre-upgrade
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - dkp.d2iq.io
+      - helm.toolkit.fluxcd.io
+    resources:
+      - kommandercores
+      - helmreleases
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - dkp.d2iq.io
+    resources:
+      - kommandercores
+    verbs:
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Chart.Name }}-pre-upgrade
@@ -21,7 +48,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: {{ .Chart.Name }}-pre-upgrade
 subjects:
   - kind: ServiceAccount
     name: {{ .Chart.Name }}-pre-upgrade


### PR DESCRIPTION
depends on https://github.com/mesosphere/kommander-applications/pull/1608

**What problem does this PR solve?**:
the kommandercore related jobs have been using cluster-admin clusterrole. although it's short lived, it's better to just drop that usage.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
