### PR TITLE
fix: Exclude ai-navigator-app from the bundle (#1655)

### DIFF
--- a/make/release.mk
+++ b/make/release.mk
@@ -6,9 +6,11 @@ S3_ACL ?= "bucket-owner-full-control"
 release: ARCHIVE_NAME = kommander-applications-$(GIT_TAG).tar.gz
 release: PUBLISHED_URL = https://downloads.d2iq.com/dkp/$(GIT_TAG)/$(ARCHIVE_NAME)
 release: install-tool.awscli
+	# We don't want to have ai-navigator in airgapped bundle
+	# connected customers download k-apps from github where it's still present
 	git archive --format "tar.gz" -o $(ARCHIVE_NAME) \
 								  $(GIT_TAG) -- \
-								  common services charts
+								  common services charts ":(exclude)services/ai-navigator-app"
 	aws s3 cp --acl $(S3_ACL) $(ARCHIVE_NAME) s3://$(S3_BUCKET)/$(S3_PATH)/
 	echo "Published to $(PUBLISHED_URL)"
 ifeq (,$(findstring dev,$(GIT_TAG)))

--- a/make/release.mk
+++ b/make/release.mk
@@ -7,7 +7,7 @@ release: ARCHIVE_NAME = kommander-applications-$(GIT_TAG).tar.gz
 release: PUBLISHED_URL = https://downloads.d2iq.com/dkp/$(GIT_TAG)/$(ARCHIVE_NAME)
 release: install-tool.awscli
 	# We don't want to have ai-navigator in airgapped bundle
-	# connected customers download k-apps from github where it's still present
+	# the connected customers download the k-apps from GitHub where it is still present
 	git archive --format "tar.gz" -o $(ARCHIVE_NAME) \
 								  $(GIT_TAG) -- \
 								  common services charts ":(exclude)services/ai-navigator-app"


### PR DESCRIPTION
**What problem does this PR solve?**:
Let's exclude ai-navigator-app also in main branch (following https://github.com/mesosphere/kommander-applications/pull/1655).

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
