### PR TITLE
chore: `IfNotPresent` pull policy for gitea

### DIFF
--- a/services/gitea/9.3.0/defaults/cm.yaml
+++ b/services/gitea/9.3.0/defaults/cm.yaml
@@ -9,6 +9,7 @@ data:
     priorityClassName: "dkp-critical-priority"
     image:
       rootless: true
+      pullPolicy: IfNotPresent
     ingress:
       enabled: true
       annotations:


### PR DESCRIPTION
**What problem does this PR solve?**:

Upstream uses `Always` https://gitea.com/gitea/helm-chart/src/commit/370775537323ba95fe93fe3d849ad46e860b8575/values.yaml  which does not seem efficient and is not consistent with what most other services use so this change overrides it to be more consistent.

More context https://d2iq.slack.com/archives/C01LNF6KML5/p1697577633844619?thread_ts=1697576272.378049&cid=C01LNF6KML5

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
