### PR TITLE
chore: Adjust livenessprobe in gitea

### DIFF
--- a/services/gitea/9.3.0/defaults/cm.yaml
+++ b/services/gitea/9.3.0/defaults/cm.yaml
@@ -58,6 +58,10 @@ data:
         periodSeconds: 10
         successThreshold: 1
         failureThreshold: 10
+      # We use startupProbe unlike the default configuration,
+      # to shorten readiness time, set initialDelaySeconds to 5 seconds.
+      livenessProbe:
+        initialDelaySeconds: 5
     deployment:
       annotations:
         secret.reloader.stakater.com/reload: ${tlsCertificateSecret}


### PR DESCRIPTION
**What problem does this PR solve?**:

It seems we can shorted the time gitea becomes ready by tuning livenessProbe's initial delay.

https://d2iq.slack.com/archives/C03P4F14M7E/p1697803003706169?thread_ts=1697798961.547819&cid=C03P4F14M7E

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
