### PR TITLE
fix: Double memory resources for prometheus-adapter

### DIFF
--- a/services/prometheus-adapter/4.4.1/defaults/cm.yaml
+++ b/services/prometheus-adapter/4.4.1/defaults/cm.yaml
@@ -12,10 +12,10 @@ data:
     resources:
       limits:
          cpu: 2000m
-         memory: 2000Mi
+         memory: 4000Mi
       requests:
          cpu: 1000m
-         memory: 1000Mi
+         memory: 2000Mi
     metricsRelistInterval: 60s
     logLevel: 2
     rules:


### PR DESCRIPTION
**What problem does this PR solve?**:
Doubling resources for prometheus adapter as discussed here:
https://d2iq.slack.com/archives/CJZQDQMSR/p1696956332307929?thread_ts=1696954502.650439&cid=CJZQDQMSR

**Which issue(s) does this PR fix?**:
https://d2iq.atlassian.net/browse/D2IQ-99404

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
