### PR TITLE
feat: verify the health of the kube-prometheus-stack deployment

### DIFF
--- a/services/kube-prometheus-stack/48.3.1/helmrelease.yaml
+++ b/services/kube-prometheus-stack/48.3.1/helmrelease.yaml
@@ -20,3 +20,8 @@ spec:
   postBuild:
     substitute:
       releaseNamespace: ${releaseNamespace}
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: kps-kube-prometheus-stack-operator
+      namespace: ${releaseNamespace}


### PR DESCRIPTION
**What problem does this PR solve?**:
This PR uses the `kube-prometheus` **deployment** as a reference point to check the `health` status of the rollout. The kustomization for kube-prometheus will only be ready when the deployment is healthy

**Which issue(s) does this PR fix?**:
https://d2iq.atlassian.net/browse/D2IQ-94596


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
