### PR TITLE
fix: Enable startup probe for gitea's postgres

### DIFF
--- a/services/gitea/9.3.0/defaults/cm.yaml
+++ b/services/gitea/9.3.0/defaults/cm.yaml
@@ -51,13 +51,6 @@ data:
 
       startupProbe:
         enabled: true
-        tcpSocket:
-          port: http
-        initialDelaySeconds: 60
-        timeoutSeconds: 1
-        periodSeconds: 10
-        successThreshold: 1
-        failureThreshold: 10
       # We use startupProbe unlike the default configuration,
       # to shorten readiness time, set initialDelaySeconds to 5 seconds.
       livenessProbe:
@@ -88,6 +81,8 @@ data:
       enabled: true
       primary:
         priorityClassName: "dkp-critical-priority"
+        startupProbe:
+          enabled: true
       image:
         tag: 11.16.0-debian-11-r9
     persistence:


### PR DESCRIPTION
**What problem does this PR solve?**:
It looks like (at least in one case), gitea tried to connect to postgres pod and connection was refused. It cased a restart of gitea pod and timed out gitea installation.

**Which issue(s) does this PR fix?**:
https://d2iq.atlassian.net/browse/D2IQ-99546

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
