### PR TITLE
fix: bump dex-controller to fix trustedPeers logic

### DIFF
--- a/services/dex/2.13.6/defaults/cm.yaml
+++ b/services/dex/2.13.6/defaults/cm.yaml
@@ -104,6 +104,8 @@ data:
         manager:
           dexConfigSecretName: dex
           dexDeploymentName: dex
+        image:
+          tag: v0.13.1
       deployment:
         annotations:
           secret.reloader.stakater.com/reload: dex-dex-controller-webhook-server-cert # If a fullNameOverride has been set, change the value of "dex-dex-controller" accordingly.


### PR DESCRIPTION
Bump dex-controller image version to fix an issue with trustedPeers logic.
