### PR TITLE
fix: Reduce Weaviate storage size

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -624,8 +624,3 @@ resources:
       - license_path: LICENSE
         ref: v${image_tag}
         url: https://github.com/weaviate/weaviate
-  - container_image: docker.io/library/alpine:3.18.4
-    sources:
-      - license_path: LICENSE
-        ref: master
-        url: https://github.com/alpinelinux/docker-alpine

--- a/services/ai-navigator-app/0.2.0/defaults/cm.yaml
+++ b/services/ai-navigator-app/0.2.0/defaults/cm.yaml
@@ -42,6 +42,8 @@ data:
         runAsUser: 65532
         fsGroup: 65532
         runAsGroup: 65532
+      storage:
+        size: 5Gi
 
     postgresql:
       enabled: true


### PR DESCRIPTION
**What problem does this PR solve?**:

By default, Weaviate vector db requests a PVC with 32Gi of storage size, which is probably too high given the amount of data collected. Also, this might cause the kommander e2e tests to fail on was pre-provisioned.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
