### PR TITLE
fix: xxclude ai-nav info agent from the bundle

### DIFF
--- a/make/release.mk
+++ b/make/release.mk
@@ -11,7 +11,7 @@ release: install-tool.awscli
 	# the connected customers download the k-apps from GitHub where it is still present
 	git archive --format "tar.gz" -o $(ARCHIVE_NAME) \
 								  $(GIT_TAG) -- \
-								  common services charts ":(exclude)services/ai-navigator-app"
+								  common services charts ":(exclude)services/ai-navigator-app" \
 								  common services charts ":(exclude)services/ai-navigator-cluster-info-agent"
 	aws s3 cp --acl $(S3_ACL) $(ARCHIVE_NAME) s3://$(S3_BUCKET)/$(S3_PATH)/
 	echo "Published to $(PUBLISHED_URL)"

--- a/make/release.mk
+++ b/make/release.mk
@@ -7,10 +7,12 @@ release: ARCHIVE_NAME = kommander-applications-$(GIT_TAG).tar.gz
 release: PUBLISHED_URL = https://downloads.d2iq.com/dkp/$(GIT_TAG)/$(ARCHIVE_NAME)
 release: install-tool.awscli
 	# We don't want to have ai-navigator in airgapped bundle
+	# and we don't want to have ai-navigator-cluster-info-agent in airgapped bundle
 	# the connected customers download the k-apps from GitHub where it is still present
 	git archive --format "tar.gz" -o $(ARCHIVE_NAME) \
 								  $(GIT_TAG) -- \
 								  common services charts ":(exclude)services/ai-navigator-app"
+								  common services charts ":(exclude)services/ai-navigator-cluster-info-agent"
 	aws s3 cp --acl $(S3_ACL) $(ARCHIVE_NAME) s3://$(S3_BUCKET)/$(S3_PATH)/
 	echo "Published to $(PUBLISHED_URL)"
 ifeq (,$(findstring dev,$(GIT_TAG)))


### PR DESCRIPTION
**What problem does this PR solve?**:
The ai-navigator-cluster-info-agent would be in the airgapped bundle, and it shouldn't be

**Which issue(s) does this PR fix?**:
No JIRA - I just thought of it now, but I basically just tried to lift Mikołaj's change here and add the agent to this exclude:
https://github.com/mesosphere/kommander-applications/pull/1655

**Special notes for your reviewer**:
To be honest - I am mostly just hopeful that this will work the way I want it to.


**Does this PR introduce a user-facing change?**:
No change, this will just exclude it from the airgapped bundle (new feature, so no change to users)

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
