### PR TITLE
feat: Release DKP-Insights v1.0.0-dev.8 (2.7)

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -204,11 +204,11 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag%-server-backend-proxy}
         url: https://github.com/ghostunnel/ghostunnel
-  - container_image: docker.io/mesosphere/insights-management:v1.0.0-dev.7
+  - container_image: docker.io/mesosphere/insights-management:v1.0.0-dev.8
     sources:
       - ref: ${image_tag}
         url: https://github.com/mesosphere/dkp-insights
-  - container_image: docker.io/mesosphere/insights:v1.0.0-dev.7
+  - container_image: docker.io/mesosphere/insights:v1.0.0-dev.8
     sources:
       - ref: ${image_tag}
         url: https://github.com/mesosphere/dkp-insights

--- a/services/dkp-insights-management/1.0.0/defaults/cm.yaml
+++ b/services/dkp-insights-management/1.0.0/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: dkp-insights-management-1.0.0-dev.7-d2iq-defaults
+  name: dkp-insights-management-1.0.0-dev.8-d2iq-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |
@@ -30,7 +30,7 @@ data:
       imagePullPolicy: IfNotPresent
       registry: docker.io
       repository: mesosphere/insights-management
-      tag: v1.0.0-dev.7
+      tag: v1.0.0-dev.8
     insightsCRIngress:
       globalRateLimitAverageQPS: 100
       globalRateLimitBurst: 100

--- a/services/dkp-insights-management/1.0.0/helmrelease/helmrelease.yaml
+++ b/services/dkp-insights-management/1.0.0/helmrelease/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-dkp-insights-charts-management
         namespace: kommander-flux
-      version: v1.0.0-dev.7
+      version: v1.0.0-dev.8
   dependsOn:
     - name: kubefed
       namespace: ${releaseNamespace}
@@ -28,4 +28,4 @@ spec:
       retries: 30
   valuesFrom:
     - kind: ConfigMap
-      name: dkp-insights-management-1.0.0-dev.7-d2iq-defaults
+      name: dkp-insights-management-1.0.0-dev.8-d2iq-defaults

--- a/services/dkp-insights/1.0.0/defaults/cm.yaml
+++ b/services/dkp-insights/1.0.0/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: dkp-insights-1.0.0-dev.7-d2iq-defaults
+  name: dkp-insights-1.0.0-dev.8-d2iq-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |
@@ -265,7 +265,7 @@ data:
       imagePullPolicy: IfNotPresent
       registry: docker.io
       repository: mesosphere/insights
-      tag: v1.0.0-dev.7
+      tag: v1.0.0-dev.8
     initdb:
       resources:
         limits:

--- a/services/dkp-insights/1.0.0/helmrelease/helmrelease.yaml
+++ b/services/dkp-insights/1.0.0/helmrelease/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-dkp-insights-charts-attached
         namespace: kommander-flux
-      version: v1.0.0-dev.7
+      version: v1.0.0-dev.8
   install:
     remediation:
       retries: 30
@@ -24,4 +24,4 @@ spec:
       strategy: uninstall
   valuesFrom:
     - kind: ConfigMap
-      name: dkp-insights-1.0.0-dev.7-d2iq-defaults
+      name: dkp-insights-1.0.0-dev.8-d2iq-defaults


### PR DESCRIPTION
* feat: Release DKP-Insights Backend v1.0.0-dev.8

Release DKP-Insights Backend v1.0.0-dev.8

---------

**What problem does this PR solve?**:
backports https://github.com/mesosphere/kommander-applications/pull/1738 to `release-2.7`

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
