### PR TITLE
fix: Pin grafana-logging to 8.5

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -95,6 +95,12 @@ resources:
       - license_path: LICENSE
         ref: v${image_tag%-rootless}
         url: https://github.com/go-gitea/gitea
+  - container_image: docker.io/grafana/grafana:8.5.26
+    sources:
+      - license_path: LICENSE
+        notice_path: NOTICE.md
+        ref: v${image_tag}
+        url: https://github.com/grafana/grafana
   - container_image: docker.io/grafana/grafana:9.4.7
     sources:
       - license_path: LICENSE

--- a/services/grafana-logging/6.60.1/defaults/cm.yaml
+++ b/services/grafana-logging/6.60.1/defaults/cm.yaml
@@ -7,10 +7,9 @@ data:
   values.yaml: |
     ---
     priorityClassName: "dkp-critical-priority"
-    # pinning grafana to 9.5 since it appears that upgrading to v10 is causing issues with prometheus scraping
-    # grafana metrics
+    # pinning grafana to 8.5 since it appears that v9+ is causing the kubernetes audit dashboard to crash
     image:
-      tag: 9.5.7
+      tag: 8.5.26
     datasources:
       datasources.yaml:
         apiVersion: 1

--- a/services/grafana-logging/6.60.1/grafana.yaml
+++ b/services/grafana-logging/6.60.1/grafana.yaml
@@ -39,7 +39,7 @@ data:
   dashboardLink: "/dkp/logging/grafana"
   docsLink: "https://grafana.com/docs/"
   # Check https://artifacthub.io/packages/helm/grafana/grafana/6.58.6 for app version
-  version: "9.5.7"
+  version: "8.5.26"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/project-grafana-logging/6.60.1/defaults/cm.yaml
+++ b/services/project-grafana-logging/6.60.1/defaults/cm.yaml
@@ -7,10 +7,9 @@ data:
   values.yaml: |
     ---
     priorityClassName: "dkp-critical-priority"
-    # pinning grafana to 9.5 since it appears that upgrading to v10 is causing issues with prometheus scraping
-    # grafana metrics
+    # pinning grafana to 8.5 since it appears that v9+ is causing the kubernetes audit dashboard to crash
     image:
-      tag: 9.5.7
+      tag: 8.5.26
     datasources:
       datasources.yaml:
         apiVersion: 1


### PR DESCRIPTION
**What problem does this PR solve?**:
Pin grafana-logging to 8.5.26 which is the latest functioning version of grafana that loads the kubernetes audit dashboard successfully. Using 9+ causes the dashboard to crash upon loading, and after fixing the mem to avoid the crash, only the audit logs panel shows data. In interest of time and release timeline, let's just use grafana 8.5 and continue to investigate why newer grafana versions are causing these issues.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-99725

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
![image](https://github.com/mesosphere/kommander-applications/assets/5897740/630e9b5c-b0fb-4de8-bd5e-6c3ae3318c33)


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
