### PR TITLE
fix: bump ghostunnel image to address critical CVEs

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -199,10 +199,10 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/mesosphere/dex
-  - container_image: docker.io/mesosphere/ghostunnel:v1.7.1-server-backend-proxy
+  - container_image: docker.io/mesosphere/ghostunnel:v1.7.1-server-backend-proxy.1
     sources:
       - license_path: LICENSE
-        ref: ${image_tag%-server-backend-proxy}
+        ref: ${image_tag%-server-backend-proxy.1}
         url: https://github.com/ghostunnel/ghostunnel
   - container_image: docker.io/mesosphere/insights-management:v1.0.1
     sources:

--- a/services/kommander/0.8.0/dynamic-helmreleases/mtls-proxy/list-images-values.yaml
+++ b/services/kommander/0.8.0/dynamic-helmreleases/mtls-proxy/list-images-values.yaml
@@ -2,4 +2,4 @@ target: unused
 certSecretName: unused
 image:
   repository: mesosphere/ghostunnel
-  tag: v1.7.1-server-backend-proxy
+  tag: v1.7.1-server-backend-proxy.1


### PR DESCRIPTION
**What problem does this PR solve?**:

```
trivy image mesosphere/ghostunnel:v1.7.1-server-backend-proxy.1 --severity CRITICAL
2023-12-19T11:31:05.768+0100    INFO    Vulnerability scanning is enabled
2023-12-19T11:31:05.768+0100    INFO    Secret scanning is enabled
2023-12-19T11:31:05.768+0100    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-12-19T11:31:05.768+0100    INFO    Please see also https://aquasecurity.github.io/trivy/v0.48/docs/scanner/secret/#recommendation for faster secret detection
2023-12-19T11:31:07.006+0100    INFO    Detected OS: alpine
2023-12-19T11:31:07.006+0100    INFO    Detecting Alpine vulnerabilities...
2023-12-19T11:31:07.010+0100    INFO    Number of language-specific files: 1
2023-12-19T11:31:07.010+0100    INFO    Detecting gobinary vulnerabilities...

mesosphere/ghostunnel:v1.7.1-server-backend-proxy.1 (alpine 3.18.5)

Total: 0 (CRITICAL: 0)
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
