### PR TITLE
feat: bump dex image

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -194,7 +194,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/mesosphere/dex-k8s-authenticator
-  - container_image: docker.io/mesosphere/dex:v2.37.0-d2iq.1
+  - container_image: docker.io/mesosphere/dex:v2.37.0-d2iq.2
     sources:
       - license_path: LICENSE
         ref: ${image_tag}

--- a/services/dex/2.13.6/defaults/cm.yaml
+++ b/services/dex/2.13.6/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
     ---
     priorityClassName: "dkp-critical-priority"
     image: mesosphere/dex
-    imageTag: v2.37.0-d2iq.1
+    imageTag: v2.37.0-d2iq.2
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
**What problem does this PR solve?**:

Bumping dex images to mitigate existing CVEs in d2iq v2.37.0-d2iq.1 image.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
