### PR TITLE
build: drop ai-navigator images from listing for bundle

### DIFF
--- a/hack/list-images.sh
+++ b/hack/list-images.sh
@@ -132,11 +132,12 @@ gojq --yaml-input --raw-output 'select(.kind | test("^(?:Deployment|Job|CronJob|
                                 ./services/velero/*/{pre,post}-install/* \
                                 >>"${IMAGES_FILE}"
 
-# Ensure that all images are fully qualified to ensure usniqueness of images in the image bundle.
+# Ensure that all images are fully qualified to ensure uniqueness of images in the image bundle.
 sed --expression='s|^docker.io/||' \
     --expression='s|\(^[^/]\+$\)|library/\1|' \
     --expression='s|\(^[^/]\+/[^/]\+$\)|docker.io/\1|' \
     --expression='s|\(^[^:]\+:\?$\)|\1:latest|' \
     --expression='/^[[:space:]]*$/d' \
+    --expression='/ai-navigator-/d' \
     "${IMAGES_FILE}" | \
   sort --unique


### PR DESCRIPTION
**What problem does this PR solve?**:

ai-navigator images need not be populated in the airgapped bundle as it does not work (yet) in airgapped environments.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-99753

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
