### PR TITLE
fix(CVE): bump pkg:docker/bitnami/kubectl@1.24.1

### DIFF
--- a/services/kubecost/0.37.1/defaults/cm.yaml
+++ b/services/kubecost/0.37.1/defaults/cm.yaml
@@ -8,6 +8,7 @@ data:
     ---
     hooks:
       clusterID:
+        kubectlImage: "bitnami/kubectl:1.26.4"
         priorityClassName: dkp-high-priority
 
     cost-analyzer:


### PR DESCRIPTION
**What problem does this PR solve?**:

[Kubecost](https://github.com/mesosphere/charts/blob/6135b0df4858e916d6bd5705ca63a43c885153bf/stable/kubecost/values.yaml#L11) is using the `pkg:docker/bitnami/kubectl@1.24.1` image which has many CVEs, this PR exposes it in defaults so that we can easily track and bump it to versions which don't have this CVE.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
