### PR TITLE
fix: taking psql bump from major to minor version (#1779)

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -3,7 +3,7 @@ ignore:
   - docker.io/mesosphere/kommander2-kubetools
   - docker.io/nginxinc/nginx-unprivileged:1.22.0-alpine
   - docker.io/bitnami/external-dns:0.13.6-debian-11-r11
-  - docker.io/bitnami/postgresql:12.17.0-debian-11-r16
+  - docker.io/bitnami/postgresql:11.22.0-debian-11-r4
   - docker.io/bitnami/postgresql:15.2.0-debian-11-r21
   - docker.io/bitnami/redis-cluster:7.0.12-debian-11-r2
   - docker.io/bitnami/memcached:1.6.15-debian-11-r8

--- a/services/gitea/8.2.0/defaults/cm.yaml
+++ b/services/gitea/8.2.0/defaults/cm.yaml
@@ -70,4 +70,4 @@ data:
       primary:
         priorityClassName: "dkp-critical-priority"
       image:
-        tag: 12.17.0-debian-11-r16
+        tag: 11.22.0-debian-11-r4


### PR DESCRIPTION
**What problem does this PR solve?**:
Reverting postgres docker container version bump.

A backport of https://github.com/mesosphere/kommander-applications/pull/1779

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
