### PR TITLE
fix: bump kubecost sidecar image

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -148,7 +148,7 @@ resources:
       - license_path: LICENSE.txt
         ref: ${image_tag}
         url: https://github.com/jimmidyson/configmap-reload
-  - container_image: docker.io/kiwigrid/k8s-sidecar:1.25.0
+  - container_image: docker.io/kiwigrid/k8s-sidecar:1.25.3
     sources:
       - license_path: LICENSE
         ref: ${image_tag}
@@ -519,11 +519,6 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/kiali/kiali
-  - container_image: quay.io/kiwigrid/k8s-sidecar:1.24.6
-    sources:
-      - license_path: LICENSE
-        ref: ${image_tag}
-        url: https://github.com/kiwigrid/k8s-sidecar
   - container_image: quay.io/kiwigrid/k8s-sidecar:1.25.1
     sources:
       - license_path: LICENSE

--- a/services/centralized-grafana/48.3.1/defaults/cm.yaml
+++ b/services/centralized-grafana/48.3.1/defaults/cm.yaml
@@ -23,6 +23,9 @@ data:
         labels:
           prometheus.kommander.d2iq.io/select: "true"
       sidecar:
+        image:
+          repository: kiwigrid/k8s-sidecar
+          tag: 1.25.3
         dashboards:
           enabled: true
           # label that the configmaps with dashboards are marked with

--- a/services/centralized-kubecost/0.37.1/defaults/cm.yaml
+++ b/services/centralized-kubecost/0.37.1/defaults/cm.yaml
@@ -69,6 +69,9 @@ data:
         # These values are set so that kubecost grafana dashboards are installed.
         # Grafana itself is not installed.
         sidecar:
+          image:
+            repository: kiwigrid/k8s-sidecar
+            tag: 1.25.3
           dashboards:
             enabled: true
             label: grafana_dashboard_kommander

--- a/services/grafana-logging/6.60.1/defaults/cm.yaml
+++ b/services/grafana-logging/6.60.1/defaults/cm.yaml
@@ -32,6 +32,10 @@ data:
       pathType: ImplementationSpecific
 
     sidecar:
+      sidecar:
+        image:
+          repository: kiwigrid/k8s-sidecar
+          tag: 1.25.3
       dashboards:
         enabled: true
         label: grafana_logging_dashboard

--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -351,6 +351,9 @@ data:
         path: /dkp/grafana
         pathType: ImplementationSpecific
       sidecar:
+        image:
+          repository: kiwigrid/k8s-sidecar
+          tag: 1.25.3  
         dashboards:
           enabled: true
           label: grafana_dashboard

--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -353,7 +353,7 @@ data:
       sidecar:
         image:
           repository: kiwigrid/k8s-sidecar
-          tag: 1.25.3  
+          tag: 1.25.3
         dashboards:
           enabled: true
           label: grafana_dashboard

--- a/services/kubecost/0.37.1/defaults/cm.yaml
+++ b/services/kubecost/0.37.1/defaults/cm.yaml
@@ -75,6 +75,10 @@ data:
           analytics:
             reporting_enabled: false
             check_for_updates: false
+        sidecar:
+          image:
+            repository: kiwigrid/k8s-sidecar
+            tag: 1.25.3
 
       kubecostProductConfigs:
         grafanaURL: "/dkp/kubecost/grafana"


### PR DESCRIPTION
**What problem does this PR solve?**:

Let's bump the kiwigrid/sidecar image to the latest one to avoid critical CVEs in auxiliary libraries.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
