### PR TITLE
fix: drop airgapped support for Insights flags that use `bitnami-shell` 

### DIFF
--- a/services/dkp-insights/1.0.1/helmrelease/list-images-values.yaml
+++ b/services/dkp-insights/1.0.1/helmrelease/list-images-values.yaml
@@ -1,8 +1,11 @@
 postgresql:
   metrics:
     enabled: true
-  volumePermissions:
-    enabled: true
+  # These sections are not supported because the `bitnami-shell` image required by them
+  # contains a number of critical vulnerabilities that are hard to remove:
+  #
+  # volumePermissions:
+  # tls:
 nova:
   helmRepositoryURLs: ["https://mesosphere.github.io/charts/stable"]
 trivy:


### PR DESCRIPTION
**What problem does this PR solve?**:
This prevents the `bitnami-shell` image with hard to remove critical CVEs from being pulled into the airgapped bundle by the `dkp-insights` app.

The side effect of this change is that without this image `postgres.tls` and `postgres.volumePermissions` become unusable in air-gapped environments. Note that we neither use these flags by default, nor can they add any significant amount of security in the Insights use case.

**Which issue(s) does this PR fix?**:
A backport of this PR into 2.7 will hopefully close https://github.com/mesosphere/kommander/issues/4129

**Checklist**

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
