### PR TITLE
fix: bump fluentd image to kube-logging/fluentd:v1.16-full-build.122

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -19,12 +19,12 @@ ignore:
   - gcr.io/google_containers/pause:3.2
 
   # Fossa cannot scan and parse gemfile provided by the fluend project
-  # - container_image: ghcr.io/banzaicloud/fluentd:v1.14.6-alpine-5
+  # - container_image: ghcr.io/kube-logging/fluentd:v1.16-full-build.122
   #   sources:
   #     - url: https://github.com/fluent/fluentd
-  #       ref: ${image_tag%-alpine-5}
+  #       ref: v1.16.2
   #       license_path: LICENSE
-  - ghcr.io/banzaicloud/fluentd:v1.14.6-alpine-5
+  - ghcr.io/kube-logging/fluentd:v1.16-full-build.122
 
   # Fossa cannot scan C/CPP projects
   # See: https://docs.fossa.com/docs/c-cpp

--- a/services/logging-operator/4.2.3/defaults/cm.yaml
+++ b/services/logging-operator/4.2.3/defaults/cm.yaml
@@ -62,9 +62,9 @@ data:
     fluentd:
       podPriorityClassName: "dkp-critical-priority"
       image:
-        # Explicitly use the default image. This should be updated when logging-operator is upgraded.
-        repository: ghcr.io/banzaicloud/fluentd
-        tag: v1.14.6-alpine-5
+        # The image should be updated when logging-operator is upgraded.
+        repository: ghcr.io/kube-logging/fluentd
+        tag: v1.16-full-build.122
       resources:
        limits:
          memory: 400Mi


### PR DESCRIPTION
**What problem does this PR solve?**:
This updates the fluentd image to get rid of recent CVEs. 

**Which issue(s) does this PR fix?**:
Closes https://github.com/mesosphere/kommander/issues/4134

**Special notes for your reviewer**:
Tested by verifying presence of logs in Grafana Logging.
From a Fluentd changelog, a potential for some subtle breakage in some narrow case looks quite low: https://github.com/fluent/fluentd/blob/master/CHANGELOG.md

Apparently kube-logging is no longer solely driven by Cisco (who acquired Banzaicloud in 2019) and is being onboarded into CNCF Sandbox right now. See:
- Issue 42 in https://github.com/cncf/sandbox/issues
- https://axoflow.com/logging-operator-the-telemetry-pipeline-for-kubernetes/

**Does this PR introduce a user-facing change?**:
No

**Checklist**
FWICT both fluentd and the image building code are licensed under Apache 2.0, no changes here

- [x] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
