### PR TITLE
fix: bump grafana to 9.5.13

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -101,7 +101,7 @@ resources:
         notice_path: NOTICE.md
         ref: v${image_tag}
         url: https://github.com/grafana/grafana
-  - container_image: docker.io/grafana/grafana:9.5.7
+  - container_image: docker.io/grafana/grafana:9.5.13
     sources:
       - license_path: LICENSE
         notice_path: NOTICE.md

--- a/services/centralized-grafana/48.3.1/centralized-grafana.yaml
+++ b/services/centralized-grafana/48.3.1/centralized-grafana.yaml
@@ -43,4 +43,4 @@ data:
   # https://github.com/mesosphere/charts/tree/master/staging/kube-prometheus-stack/charts
   # Then, find the Grafana app version:
   # https://artifacthub.io/packages/helm/grafana/grafana/6.57.2
-  version: "9.5.7"
+  version: "9.5.13"

--- a/services/centralized-grafana/48.3.1/defaults/cm.yaml
+++ b/services/centralized-grafana/48.3.1/defaults/cm.yaml
@@ -16,7 +16,7 @@ data:
       # pinning grafana to 9.5 since it appears that upgrading to v10 is causing issues with prometheus scraping
       # grafana metrics
       image:
-        tag: 9.5.7
+        tag: 9.5.13
       defaultDashboardsEnabled: true
       priorityClassName: "dkp-critical-priority"
       serviceMonitor:

--- a/services/grafana-logging/6.60.1/defaults/cm.yaml
+++ b/services/grafana-logging/6.60.1/defaults/cm.yaml
@@ -10,7 +10,7 @@ data:
     # pinning grafana to 9.5 since it appears that upgrading to v10 is causing issues with prometheus scraping
     # grafana metrics
     image:
-      tag: 9.5.7
+      tag: 9.5.13
     datasources:
       datasources.yaml:
         apiVersion: 1

--- a/services/grafana-logging/6.60.1/grafana.yaml
+++ b/services/grafana-logging/6.60.1/grafana.yaml
@@ -39,7 +39,7 @@ data:
   dashboardLink: "/dkp/logging/grafana"
   docsLink: "https://grafana.com/docs/"
   # Check https://artifacthub.io/packages/helm/grafana/grafana/6.58.6 for app version
-  version: "9.5.7"
+  version: "9.5.13"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -334,7 +334,7 @@ data:
       # pinning grafana to 9.5 since it appears that upgrading to v10 is causing issues with prometheus scraping
       # grafana metrics
       image:
-        tag: 9.5.7
+        tag: 9.5.13
       defaultDashboardsEnabled: true
       priorityClassName: "dkp-critical-priority"
       serviceMonitor:

--- a/services/kube-prometheus-stack/48.3.1/helmrelease/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/48.3.1/helmrelease/kube-prometheus-stack.yaml
@@ -77,4 +77,4 @@ data:
   # Since Grafana is a subchart of kube-prometheus-stack, get the version of the Grafana chart dependency at:
   # https://github.com/mesosphere/charts/tree/master/staging/kube-prometheus-stack/charts
   # Then, check https://artifacthub.io/packages/helm/grafana/grafana/ for app version
-  version: "9.5.7"
+  version: "9.5.13"

--- a/services/kube-prometheus-stack/metadata.yaml
+++ b/services/kube-prometheus-stack/metadata.yaml
@@ -27,7 +27,7 @@ overview: |-
 
   - [Prometheus Alertmanager Documentation - Overview](https://prometheus.io/docs/alerting/latest/alertmanager/)
 
-  ### Grafana (v9.5.7)
+  ### Grafana (v9.5.13)
   A monitoring dashboard from Grafana that can be used to visualize metrics collected by Prometheus.
 
   - [Grafana Documentation](https://grafana.com/docs/)

--- a/services/project-grafana-logging/6.60.1/defaults/cm.yaml
+++ b/services/project-grafana-logging/6.60.1/defaults/cm.yaml
@@ -10,7 +10,7 @@ data:
     # pinning grafana to 9.5 since it appears that upgrading to v10 is causing issues with prometheus scraping
     # grafana metrics
     image:
-      tag: 9.5.7
+      tag: 9.5.13
     datasources:
       datasources.yaml:
         apiVersion: 1


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumps Grafana image to avoid critical CVEs present in 9.5.7

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
Closes https://github.com/mesosphere/kommander/issues/4145

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
No

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
