### PR TITLE
fix: bump nginx-unprivileged in *grafana-loki to 1.24.0-alpine

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -1,7 +1,7 @@
 ignore:
   - docker.io/mesosphere/grafana-plugins:v0.0.1
   - docker.io/mesosphere/kommander2-kubetools
-  - docker.io/nginxinc/nginx-unprivileged:1.22.0-alpine
+  - docker.io/nginxinc/nginx-unprivileged:1.24.0-alpine
   - docker.io/bitnami/external-dns:0.13.6-debian-11-r11
   - docker.io/bitnami/postgresql:11.22.0-debian-11-r4
   - docker.io/bitnami/postgresql:15.2.0-debian-11-r21

--- a/services/grafana-loki/0.74.6/defaults/cm.yaml
+++ b/services/grafana-loki/0.74.6/defaults/cm.yaml
@@ -185,7 +185,7 @@ data:
       image:
         # Override nginx image to address known CVEs.
         # As of 0.48.4, chart maintainers are still using 1.19-alpine.
-        tag: 1.22.0-alpine
+        tag: 1.24.0-alpine
       nginxConfig:
         httpSnippet: |-
           client_max_body_size 10M;

--- a/services/project-grafana-loki/0.74.6/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.74.6/defaults/cm.yaml
@@ -190,7 +190,7 @@ data:
       image:
         # Override nginx image to address known CVEs.
         # As of 0.48.4, chart maintainers are still using 1.19-alpine.
-        tag: 1.22.0-alpine
+        tag: 1.24.0-alpine
       verboseLogging: false
       nginxConfig:
         httpSnippet: |-


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumps the `nginx-unprivileged` image in grafana-loki and project-grafana-loki to avoid critical CVEs present in `1.22.0-alpine`

**Which issue(s) does this PR fix?**:
https://github.com/mesosphere/kommander/issues/4144

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
No
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
