### PR TITLE
fix: bump kubectl image to v1.27.9

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -45,6 +45,7 @@ ignore:
   - docker.io/bitnami/kubectl:1.22.0
   - docker.io/bitnami/kubectl:1.24.1
   - docker.io/bitnami/kubectl:1.26.4
+  - docker.io/bitnami/kubectl:1.27.9
 
   # Fossa cannot scan C/CPP projects
   # See: https://docs.fossa.com/docs/c-cpp

--- a/services/centralized-kubecost/0.37.2/post-install-jobs/post-install-jobs.yaml
+++ b/services/centralized-kubecost/0.37.2/post-install-jobs/post-install-jobs.yaml
@@ -42,7 +42,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.26.4
+          image: bitnami/kubectl:1.27.9
           command:
             - sh
             - -c

--- a/services/centralized-kubecost/0.37.2/release/release.yaml
+++ b/services/centralized-kubecost/0.37.2/release/release.yaml
@@ -73,7 +73,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.26.4
+          image: bitnami/kubectl:1.27.9
           command:
             - sh
             - "-c"

--- a/services/grafana-loki/0.74.6/grafana-loki-pre-install-jobs/pre-install.yaml
+++ b/services/grafana-loki/0.74.6/grafana-loki-pre-install-jobs/pre-install.yaml
@@ -46,7 +46,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: pre-install
-          image: bitnami/kubectl:1.26.4
+          image: bitnami/kubectl:1.27.9
           command:
             - sh
             - -c

--- a/services/istio/1.17.2/defaults/cm.yaml
+++ b/services/istio/1.17.2/defaults/cm.yaml
@@ -30,7 +30,7 @@ data:
           prometheus.kommander.d2iq.io/select: "true"
     global:
       image: bitnami/kubectl
-      tag: 1.26.4
+      tag: 1.27.9
       priorityClassName: "dkp-critical-priority"
     operator:
       # expose metrics for prometheus scraping

--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -21,6 +21,8 @@ data:
             sha: ""
     mesosphereResources:
       create: true
+      hooks:
+        kubectlImage: bitnami/kubectl:1.27.9
       rules:
         # addon alert rules are defaulted to false to prevent potential misfires if addons
         # are disabled.

--- a/services/kubecost/0.37.2/defaults/cm.yaml
+++ b/services/kubecost/0.37.2/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
     ---
     hooks:
       clusterID:
-        kubectlImage: "bitnami/kubectl:1.26.4"
+        kubectlImage: "bitnami/kubectl:1.27.9"
         priorityClassName: dkp-high-priority
 
     cost-analyzer:

--- a/services/kubefed/0.10.4/defaults/cm.yaml
+++ b/services/kubefed/0.10.4/defaults/cm.yaml
@@ -35,7 +35,7 @@ data:
       postInstallJob:
         repository: bitnami
         image: kubectl
-        tag: 1.26.4
+        tag: 1.27.9
     webhook:
       annotations:
         secret.reloader.stakater.com/reload: "kubefed-root-ca"

--- a/services/kubetunnel/0.0.31/defaults/cm.yaml
+++ b/services/kubetunnel/0.0.31/defaults/cm.yaml
@@ -17,7 +17,7 @@ data:
     hooks:
       kubectlImage:
         repository: bitnami/kubectl
-        tag: 1.26.4
+        tag: 1.27.9
     controller:
       manager:
         resources:

--- a/services/rook-ceph-cluster/1.12.6/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.12.6/pre-install/ceph-crd-check.yaml
@@ -47,7 +47,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: pre-install
-          image: bitnami/kubectl:1.26.4
+          image: bitnami/kubectl:1.27.9
           command:
             - sh
             - -c
@@ -57,7 +57,7 @@ spec:
                 sleep 30
               done
         - name: pre-upgrade
-          image: bitnami/kubectl:1.26.4
+          image: bitnami/kubectl:1.27.9
           command:
             - sh
             - -c

--- a/services/thanos/12.13.13/jobs/jobs.yaml
+++ b/services/thanos/12.13.13/jobs/jobs.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.26.4
+          image: bitnami/kubectl:1.27.9
           command:
             - sh
             - "-c"

--- a/services/traefik/24.0.0/defaults/cm.yaml
+++ b/services/traefik/24.0.0/defaults/cm.yaml
@@ -39,7 +39,7 @@ data:
         app: traefik
       initContainers:
       - name: initialize-middleware
-        image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.26.4}"
+        image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.27.9}"
         command:
           - bash
         args:

--- a/services/velero/4.1.1/defaults/cm.yaml
+++ b/services/velero/4.1.1/defaults/cm.yaml
@@ -47,4 +47,4 @@ data:
       image:
         # If we don't override the version here, upstream chart will pull an image dynamically based on k8s cluster version.
         # which makes it harder to build airgapped tar bundles. So to make bundle collection predictable, we override the tag here.
-        tag: 1.26.4
+        tag: 1.27.9

--- a/services/velero/4.1.1/pre-install/pre-install-job.yaml
+++ b/services/velero/4.1.1/pre-install/pre-install-job.yaml
@@ -46,7 +46,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: pre-install
-          image: bitnami/kubectl:1.26.4
+          image: bitnami/kubectl:1.27.9
           command:
             - sh
             - -c


### PR DESCRIPTION
**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
