### PR TITLE
chore: Bump memcached to a default for gitea chart

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -6,7 +6,7 @@ ignore:
   - docker.io/bitnami/postgresql:11.22.0-debian-11-r4
   - docker.io/bitnami/postgresql:15.2.0-debian-11-r21
   - docker.io/bitnami/redis-cluster:7.0.12-debian-11-r2
-  - docker.io/bitnami/memcached:1.6.15-debian-11-r8
+  - docker.io/bitnami/memcached:1.6.19-debian-11-r7
   - docker.io/library/busybox:1
   - gcr.io/kubecost1/cost-model:prod-1.106.5
   - gcr.io/kubecost1/frontend:prod-1.106.5

--- a/services/gitea/8.2.0/defaults/cm.yaml
+++ b/services/gitea/8.2.0/defaults/cm.yaml
@@ -65,7 +65,7 @@ data:
     memcached:
       priorityClassName: "dkp-critical-priority"
       image:
-        tag: 1.6.15-debian-11-r8
+        tag: 1.6.19-debian-11-r7
     postgresql:
       primary:
         priorityClassName: "dkp-critical-priority"


### PR DESCRIPTION
**What problem does this PR solve?**:
Bump memcached to address a number of CVEs.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
