### PR TITLE
fix: Rebuild karma image to bring back TLS server name support (#1809)

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -218,10 +218,10 @@ resources:
     sources:
       - ref: ${image_tag}
         url: https://github.com/mesosphere/dkp-insights
-  - container_image: docker.io/mesosphere/karma:v0.88-d2iq-server-name.1
+  - container_image: docker.io/mesosphere/karma:v0.88-d2iq-server-name.2
     sources:
       - license_path: LICENSE
-        ref: ${image_tag%-d2iq-server-name.1}
+        ref: ${image_tag%-d2iq-server-name.2}
         url: https://github.com/prymitive/karma
   - container_image: docker.io/mesosphere/kommander2-appmanagement-config-api:${kommander}
     sources:

--- a/services/karma/2.0.3/defaults/cm.yaml
+++ b/services/karma/2.0.3/defaults/cm.yaml
@@ -11,7 +11,7 @@ data:
       # TODO(https://jira.d2iq.com/browse/D2IQ-78091)
       # switch back to upstream
       repository: mesosphere/karma
-      tag: v0.88-d2iq-server-name.1
+      tag: v0.88-d2iq-server-name.2
 
     service:
       labels:


### PR DESCRIPTION
**What problem does this PR solve?**:
Backport of https://github.com/mesosphere/kommander-applications/pull/1809

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
