### PR TITLE
fix: Update gitea image to D2iQ fork to address CVEs.

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -91,11 +91,11 @@ resources:
       - license_path: LICENSE
         ref: v${image_tag}
         url: https://github.com/fluent/fluent-bit
-  - container_image: docker.io/gitea/gitea:1.19.2-rootless
+  - container_image: ghcr.io/mesosphere/gitea:1.19.2-d2iq-rootless
     sources:
       - license_path: LICENSE
-        ref: v${image_tag%-rootless}
-        url: https://github.com/go-gitea/gitea
+        ref: v1.19.2-d2iq
+        url: https://github.com/mesosphere/gitea
   - container_image: docker.io/grafana/grafana:8.5.26
     sources:
       - license_path: LICENSE

--- a/services/gitea/8.2.0/defaults/cm.yaml
+++ b/services/gitea/8.2.0/defaults/cm.yaml
@@ -8,6 +8,9 @@ data:
     ---
     priorityClassName: "dkp-critical-priority"
     image:
+      registry: ghcr.io
+      repository: mesosphere/gitea
+      tag: 1.19.2-d2iq
       rootless: true
     ingress:
       enabled: true


### PR DESCRIPTION
**What problem does this PR solve?**:

Backport of #1814 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
