### PR TITLE
chore: Use patches instead of patchesJson6902

### DIFF
--- a/services/cert-manager/bootstrap/kustomization.yaml
+++ b/services/cert-manager/bootstrap/kustomization.yaml
@@ -1,17 +1,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-patchesJson6902:
   # The name should be made consistent with one generated
   # by the KommanderAppDeployment controller.
   #
   # Also see federation/pkg/controllers/federated-manifests-workspace/prerequisites/
-  - patch: |
-      - op: replace
-        path: /metadata/name
-        value: cert-manager
-    target:
-      kind: HelmRelease
-      name: cert-manager
 resources:
-  - ../1.13.1/
-  - ../1.13.1/defaults/
+- ../1.13.1/
+- ../1.13.1/defaults/
+patches:
+- patch: |
+    - op: replace
+      path: /metadata/name
+      value: cert-manager
+  target:
+    kind: HelmRelease
+    name: cert-manager

--- a/services/gatekeeper/3.13.0/release/release.yaml
+++ b/services/gatekeeper/3.13.0/release/release.yaml
@@ -35,28 +35,28 @@ spec:
         # https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml#L29-L32
         # https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml#L29-L32
         # https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml#L93-L96
-        patchesJson6902:
-          - target:
-              version: v1
-              kind: MutatingWebhookConfiguration
-              name: gatekeeper-mutating-webhook-configuration
-            patch:
-              - op: remove
-                path: /webhooks/0/namespaceSelector/matchExpressions/1
-          - target:
-              version: v1
-              kind: ValidatingWebhookConfiguration
-              name: gatekeeper-validating-webhook-configuration
-            patch:
-              - op: remove
-                path: /webhooks/0/namespaceSelector/matchExpressions/1
-          - target:
-              version: v1
-              kind: ValidatingWebhookConfiguration
-              name: gatekeeper-validating-webhook-configuration
-            patch:
-              - op: remove
-                path: /webhooks/1/namespaceSelector/matchExpressions/0
+        patches:
+        - patch: |
+            - op: remove
+              path: /webhooks/0/namespaceSelector/matchExpressions/1
+          target:
+            kind: MutatingWebhookConfiguration
+            name: gatekeeper-mutating-webhook-configuration
+            version: v1
+        - patch: |
+            - op: remove
+              path: /webhooks/0/namespaceSelector/matchExpressions/1
+          target:
+            kind: ValidatingWebhookConfiguration
+            name: gatekeeper-validating-webhook-configuration
+            version: v1
+        - patch: |-
+            - op: remove
+              path: /webhooks/1/namespaceSelector/matchExpressions/0
+          target:
+            kind: ValidatingWebhookConfiguration
+            name: gatekeeper-validating-webhook-configuration
+            version: v1
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease

--- a/services/gatekeeper/bootstrap/kustomization.yaml
+++ b/services/gatekeeper/bootstrap/kustomization.yaml
@@ -1,17 +1,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-patchesJson6902:
   # The name should be made consistent with one generated
   # by the KommanderAppDeployment controller.
   #
   # Also see chart/kommander-bootstrap/templates/flux-resources.yaml
-  - patch: |
-      - op: replace
-        path: /metadata/name
-        value: gatekeeper
-    target:
-      kind: HelmRelease
-      name: gatekeeper
 resources:
-  - ../3.13.0/
-  - ../3.13.0/defaults/
+- ../3.13.0/
+- ../3.13.0/defaults/
+patches:
+- patch: |
+    - op: replace
+      path: /metadata/name
+      value: gatekeeper
+  target:
+    kind: HelmRelease
+    name: gatekeeper


### PR DESCRIPTION
**What problem does this PR solve?**:
Use patches instead if patchesJson6902. Done using `kustomize edit fix`.


**Which issue(s) does this PR fix?**:
https://d2iq.atlassian.net/browse/D2IQ-98758


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
