### PR TITLE
fix(kommander): Add ai-nav apps to list of mgmt apps

### DIFF
--- a/services/kommander/0.8.0/defaults/cm.yaml
+++ b/services/kommander/0.8.0/defaults/cm.yaml
@@ -81,6 +81,8 @@ data:
       image:
         tag: v0.0.0-dev.0
     managementApps:
+    - "ai-navigator-app"
+    - "ai-nagivator-cluster-info-agent"
     - "centralized-grafana"
     - "centralized-kubecost"
     - "chartmuseum"


### PR DESCRIPTION
This ensures that the apps are handled during expansion to be removed.

**What problem does this PR solve?**:
ai navigator apps were sticking around post-expansion. in order to ensure that they are removed instead, we must add them to the list of management apps.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-99868

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
