### PR TITLE
fix: Silence kommandercluster quota alert

### DIFF
--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -308,6 +308,7 @@ data:
           - receiver: 'null'
             matchers:
               - alertname =~ "InfoInhibitor|Watchdog"
+              - resourcequota = "one-kommandercluster-per-kommander-workspace"
         receivers:
         - name: 'null'
         templates:


### PR DESCRIPTION
**What problem does this PR solve?**:
Let's silence kommandercluster resource quota.

**Which issue(s) does this PR fix?**:
https://d2iq.atlassian.net/browse/D2IQ-99870


**Special notes for your reviewer**:
Shall we backport it?

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
