### PR TITLE
chore: remove use of MESOSPHERECI_USER_TOKEN

### DIFF
--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -1,4 +1,8 @@
 name: Check licenses.d2iq.yaml
+
+permissions:
+  contents: write
+
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
@@ -18,7 +22,6 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup asdf
         uses: asdf-vm/actions/setup@v2
       - name: Generate image list
@@ -34,11 +37,13 @@ jobs:
         continue-on-error: true
         if: |
           contains(github.event.pull_request.labels.*.name, 'update-licenses')
-        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.11
+        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.13
         with:
-          args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --update-licenses
+          args: >-
+            validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml
+            --check-sources --check-sources-skip-gh-org mesosphere --update-licenses
         env:
-          GITHUB_TOKEN: "${{ secrets.MESOSPHERECI_USER_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Import GPG key
         if: |
           contains(github.event.pull_request.labels.*.name, 'update-licenses')
@@ -60,10 +65,12 @@ jobs:
             git push --force-with-lease
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run validation
-        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.11
+        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.13
         with:
-          args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=github
+          args: >-
+            validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml
+            --check-sources --check-sources-skip-gh-org mesosphere --output-format=github
         env:
-          GITHUB_TOKEN: "${{ secrets.MESOSPHERECI_USER_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
**What problem does this PR solve?**:
Updates `dkp-licenses-cli` to a version that accepts new parameter for validation command, that allows to skip validating licenses file presence for given GH organization.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
