### PR TITLE
chore: remove use of MESOSPHERECI_USER_TOKEN (2.5)

### DIFF
--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -34,8 +34,10 @@ jobs:
           cat images.txt
       - name: Run validation
         id: runValidation
-        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.9
+        uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.13
         with:
-          args: validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml --check-sources --output-format=github
+          args: >-
+            validate container-images-mapping --input=images.txt --mapping-file=licenses.d2iq.yaml
+            --check-sources --check-sources-skip-gh-org mesosphere --output-format=github
         env:
-          GITHUB_TOKEN: "${{ secrets.MERGEBOT_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
**What problem does this PR solve?**:
Backport of https://github.com/mesosphere/kommander-applications/pull/1881

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-99871

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).