### PR TITLE
feat: Update name of HR

### DIFF
--- a/services/ai-navigator-app/0.2.0/defaults/cm.yaml
+++ b/services/ai-navigator-app/0.2.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ai-navigator-cluster-info-api-0.2.0-d2iq-defaults
+  name: ai-navigator-app-0.2.0-d2iq-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/ai-navigator-app/0.2.0/helmrelease.yaml
+++ b/services/ai-navigator-app/0.2.0/helmrelease.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
-  name: ai-navigator-app
+  name: ai-navigator-app-helmrelease
   namespace: ${releaseNamespace}
 spec:
   force: false

--- a/services/ai-navigator-app/0.2.0/helmrelease.yaml
+++ b/services/ai-navigator-app/0.2.0/helmrelease.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
-  name: ai-navigator-cluster-info-api-helmrelease
+  name: ai-navigator-app
   namespace: ${releaseNamespace}
 spec:
   force: false

--- a/services/ai-navigator-app/0.2.0/helmrelease/helmrelease.yaml
+++ b/services/ai-navigator-app/0.2.0/helmrelease/helmrelease.yaml
@@ -1,7 +1,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
-  name: ai-navigator-cluster-info-api
+  name: ai-navigator-app
   namespace: ${releaseNamespace}
 spec:
   chart:

--- a/services/ai-navigator-app/0.2.0/helmrelease/helmrelease.yaml
+++ b/services/ai-navigator-app/0.2.0/helmrelease/helmrelease.yaml
@@ -23,4 +23,4 @@ spec:
       retries: 30
   valuesFrom:
     - kind: ConfigMap
-      name: ai-navigator-cluster-info-api-0.2.0-d2iq-defaults
+      name: ai-navigator-app-0.2.0-d2iq-defaults


### PR DESCRIPTION
**What problem does this PR solve?**:

The HR had a different name from the AP name. There is a requirement in Kommander that this name match for charts that will get the override. This fixes the inability to add config overrides in the UI, etc. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://d2iq.atlassian.net/browse/D2IQ-99867

**Special notes for your reviewer**:

- Tested in a local cluster against kapps branch.
- Check for correct mapping of config maps 

<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
