### PR TITLE
ci(gha): Fix labeler workflow after tooling bump

### DIFF
--- a/.github/services-pr-labeler.yaml
+++ b/.github/services-pr-labeler.yaml
@@ -1,48 +1,56 @@
 open-kommander-pr:
-  - services/cert-manager/**
-  - services/chartmuseum/**
-  - services/external-dns/**
-  - services/fluent-bit/**
-  - services/gatekeeper/**
-  - services/istio/**
-  - services/jaeger/**
-  - services/kiali/**
-  - services/nvidia-gpu-operator/**
-  - services/kube-oidc-proxy/**
-  - services/logging-operator/**
-  - services/project-grafana-logging/**
-  - services/project-grafana-loki/**
-  - services/project-logging/**
-  - services/reloader/**
-  - services/rook-ceph/**
-  - services/rook-ceph-cluster/**
-  - services/thanos/**
-  - services/traefik-forward-auth/**
-  - services/traefik-forward-auth-mgmt/**
-  - services/kubecost/**
-  - services/centralized-kubecost/**
+- changed-files:
+  - any-glob-to-any-file:
+    - services/cert-manager/**
+    - services/chartmuseum/**
+    - services/external-dns/**
+    - services/fluent-bit/**
+    - services/gatekeeper/**
+    - services/istio/**
+    - services/jaeger/**
+    - services/kiali/**
+    - services/nvidia-gpu-operator/**
+    - services/kube-oidc-proxy/**
+    - services/logging-operator/**
+    - services/project-grafana-logging/**
+    - services/project-grafana-loki/**
+    - services/project-logging/**
+    - services/reloader/**
+    - services/rook-ceph/**
+    - services/rook-ceph-cluster/**
+    - services/thanos/**
+    - services/traefik-forward-auth/**
+    - services/traefik-forward-auth-mgmt/**
+    - services/kubecost/**
+    - services/centralized-kubecost/**
 
 # this should be the same list as above open-kommander-pr
 do-not-merge/testing:
-  - services/cert-manager/**
-  - services/external-dns/**
-  - services/fluent-bit/**
-  - services/istio/**
-  - services/jaeger/**
-  - services/kiali/**
-  - services/kube-oidc-proxy/**
-  - services/logging-operator/**
-  - services/project-grafana-logging/**
-  - services/project-grafana-loki/**
-  - services/project-logging/**
-  - services/reloader/**
-  - services/rook-ceph/**
-  - services/rook-ceph-cluster/**
-  - services/traefik-forward-auth/**
-  - services/traefik-forward-auth-mgmt/**
+- changed-files:
+  - any-glob-to-any-file:
+    - services/cert-manager/**
+    - services/external-dns/**
+    - services/fluent-bit/**
+    - services/istio/**
+    - services/jaeger/**
+    - services/kiali/**
+    - services/kube-oidc-proxy/**
+    - services/logging-operator/**
+    - services/project-grafana-logging/**
+    - services/project-grafana-loki/**
+    - services/project-logging/**
+    - services/reloader/**
+    - services/rook-ceph/**
+    - services/rook-ceph-cluster/**
+    - services/traefik-forward-auth/**
+    - services/traefik-forward-auth-mgmt/**
 
 ok-to-test:
-  - services/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - services/**/*
 
 update-licenses:
-  - services/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - services/**/*

--- a/.github/services-pr-labeler.yaml
+++ b/.github/services-pr-labeler.yaml
@@ -1,6 +1,7 @@
 open-kommander-pr:
 - changed-files:
   - any-glob-to-any-file:
+    - services/centralized-kubecost/**
     - services/cert-manager/**
     - services/chartmuseum/**
     - services/external-dns/**
@@ -9,9 +10,11 @@ open-kommander-pr:
     - services/istio/**
     - services/jaeger/**
     - services/kiali/**
-    - services/nvidia-gpu-operator/**
     - services/kube-oidc-proxy/**
+    - services/kube-prometheus-stack/**
+    - services/kubecost/**
     - services/logging-operator/**
+    - services/nvidia-gpu-operator/**
     - services/project-grafana-logging/**
     - services/project-grafana-loki/**
     - services/project-logging/**
@@ -21,27 +24,32 @@ open-kommander-pr:
     - services/thanos/**
     - services/traefik-forward-auth/**
     - services/traefik-forward-auth-mgmt/**
-    - services/kubecost/**
-    - services/centralized-kubecost/**
 
 # this should be the same list as above open-kommander-pr
 do-not-merge/testing:
 - changed-files:
   - any-glob-to-any-file:
+    - services/centralized-kubecost/**
     - services/cert-manager/**
+    - services/chartmuseum/**
     - services/external-dns/**
     - services/fluent-bit/**
+    - services/gatekeeper/**
     - services/istio/**
     - services/jaeger/**
     - services/kiali/**
     - services/kube-oidc-proxy/**
+    - services/kube-prometheus-stack/**
+    - services/kubecost/**
     - services/logging-operator/**
+    - services/nvidia-gpu-operator/**
     - services/project-grafana-logging/**
     - services/project-grafana-loki/**
     - services/project-logging/**
     - services/reloader/**
     - services/rook-ceph/**
     - services/rook-ceph-cluster/**
+    - services/thanos/**
     - services/traefik-forward-auth/**
     - services/traefik-forward-auth-mgmt/**
 

--- a/make/workflows.mk
+++ b/make/workflows.mk
@@ -1,10 +1,10 @@
 .PHONY: workflow-labeler-yaml-update
-# ls -d services/* | awk 'NR > 1' | sed p
-#   Output path to all services (e.g. "services/centralized-grafana"), printing each line twice
-# awk 'NR % 2 { print $$0 ":" } !(NR % 2) {print "  - " $$0 "/**";}'
-#   For every odd line, suffix with ":" (This is the label name to be applied)
-#   For every even line, format it like "  - services/centralized-grafana/**" (This is the changed file path for which to apply the label)
-# The output file is formatted as required by the labeler workflow.
+# ls -d services/* | awk 'NR > 1'
+#   Output path to all services (e.g. "services/centralized-grafana"), printing each line twice.
+# awk '{ print $$0 ":\n- changed-files:\n  - any-glob-to-any-file:\n    - " $$0 "/**" }'
+#   For every line (service), apply the required configuraton file structure for each match object.
+# Each service points to the changed path glob for which to apply the label.
+# The output file is formatted as required by the labeler workflow (https://github.com/actions/labeler).
 workflow-labeler-yaml-update: ## Updates .github/service-labeler.yaml for use with labeler GH action
 workflow-labeler-yaml-update: ; $(info $(M) updating .github/service-labeler.yaml with latest services)
-	ls -d services/* | awk 'NR > 1' | sed p | awk 'NR % 2 { print $$0 ":" } !(NR % 2) {print "  - " $$0 "/**";}' > .github/service-labeler.yaml
+	ls -d services/* | awk 'NR > 1' | awk '{ print $$0 ":\n- changed-files:\n  - any-glob-to-any-file:\n    - " $$0 "/**" }' > .github/service-labeler.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:
labeler workflow bump contained breaking changes in the labeler config file

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
