### PR TITLE
feat: Rename deprecated secretRef to certSecretRef

### DIFF
--- a/common/airgapped/patch-add-secret-ref.yaml
+++ b/common/airgapped/patch-add-secret-ref.yaml
@@ -3,5 +3,5 @@ kind: HelmRepository
 metadata:
   name: not-used-in-a-patch
 spec:
-  secretRef:
+  certSecretRef:
     name: "tls-root-ca"


### PR DESCRIPTION
**What problem does this PR solve?**:

Keeping up with Flux deprecations. Flux HelmRepository.spec.secretRef.name has been deprecated. Using spec.certSecretRef.name instead.

**Which issue(s) does this PR fix?**:

https://d2iq.atlassian.net/browse/D2IQ-99228


**Special notes for your reviewer**:


Tested with e2e tests against kommander-cli repo. [Created branch and mapped applications repositories](https://github.com/mesosphere/kommander-cli/pull/1295/files) to test against this branch. 

Ran an upgrade manually on airgapped and non-airgapped clusters. Upgraded from v2.7.0 to head (v2.8.0-dev) with the applications repo.

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
Flux HelmRepository.spec.secretRef.name has been deprecated. Use spec.certSecretRef.name instead. See: https://github.com/fluxcd/flux2/releases/tag/v2.1.0
```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
