### PR TITLE
fix: unpin KPS Grafana, update metrics path

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -108,7 +108,7 @@ resources:
         notice_path: NOTICE.md
         ref: v${image_tag}
         url: https://github.com/grafana/grafana
-  - container_image: docker.io/grafana/grafana:9.5.13
+  - container_image: docker.io/grafana/grafana:10.3.3
     sources:
       - license_path: LICENSE
         notice_path: NOTICE.md

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -108,7 +108,7 @@ resources:
         notice_path: NOTICE.md
         ref: v${image_tag}
         url: https://github.com/grafana/grafana
-  - container_image: docker.io/grafana/grafana:10.3.3
+  - container_image: docker.io/grafana/grafana:10.0.3
     sources:
       - license_path: LICENSE
         notice_path: NOTICE.md

--- a/services/centralized-grafana/48.3.1/centralized-grafana.yaml
+++ b/services/centralized-grafana/48.3.1/centralized-grafana.yaml
@@ -43,4 +43,4 @@ data:
   # https://github.com/mesosphere/charts/tree/master/staging/kube-prometheus-stack/charts
   # Then, find the Grafana app version:
   # https://artifacthub.io/packages/helm/grafana/grafana/6.57.2
-  version: "9.5.13"
+  version: "10.3.3"

--- a/services/centralized-grafana/48.3.1/centralized-grafana.yaml
+++ b/services/centralized-grafana/48.3.1/centralized-grafana.yaml
@@ -43,4 +43,4 @@ data:
   # https://github.com/mesosphere/charts/tree/master/staging/kube-prometheus-stack/charts
   # Then, find the Grafana app version:
   # https://artifacthub.io/packages/helm/grafana/grafana/6.57.2
-  version: "10.3.3"
+  version: "10.0.3"

--- a/services/centralized-grafana/48.3.1/defaults/cm.yaml
+++ b/services/centralized-grafana/48.3.1/defaults/cm.yaml
@@ -20,6 +20,7 @@ data:
       serviceMonitor:
         labels:
           prometheus.kommander.d2iq.io/select: "true"
+        path: "/dkp/grafana/metrics"
       sidecar:
         image:
           repository: kiwigrid/k8s-sidecar

--- a/services/centralized-grafana/48.3.1/defaults/cm.yaml
+++ b/services/centralized-grafana/48.3.1/defaults/cm.yaml
@@ -13,8 +13,6 @@ data:
         enabled: true
     grafana:
       enabled: true
-      image:
-        tag: 10.3.3
       defaultDashboardsEnabled: true
       priorityClassName: "dkp-critical-priority"
       serviceMonitor:

--- a/services/centralized-grafana/48.3.1/defaults/cm.yaml
+++ b/services/centralized-grafana/48.3.1/defaults/cm.yaml
@@ -13,10 +13,8 @@ data:
         enabled: true
     grafana:
       enabled: true
-      # pinning grafana to 9.5 since it appears that upgrading to v10 is causing issues with prometheus scraping
-      # grafana metrics
       image:
-        tag: 9.5.13
+        tag: 10.3.3
       defaultDashboardsEnabled: true
       priorityClassName: "dkp-critical-priority"
       serviceMonitor:

--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -341,6 +341,7 @@ data:
       serviceMonitor:
         labels:
           prometheus.kommander.d2iq.io/select: "true"
+        path: "/dkp/grafana/metrics"
       ingress:
         enabled: true
         annotations:

--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -334,10 +334,8 @@ data:
             memory: 200Mi
     grafana:
       enabled: true
-      # pinning grafana to 9.5 since it appears that upgrading to v10 is causing issues with prometheus scraping
-      # grafana metrics
       image:
-        tag: 9.5.13
+        tag: 10.3.3
       defaultDashboardsEnabled: true
       priorityClassName: "dkp-critical-priority"
       serviceMonitor:

--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -334,8 +334,6 @@ data:
             memory: 200Mi
     grafana:
       enabled: true
-      image:
-        tag: 10.3.3
       defaultDashboardsEnabled: true
       priorityClassName: "dkp-critical-priority"
       serviceMonitor:

--- a/services/kube-prometheus-stack/48.3.1/helmrelease/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/48.3.1/helmrelease/kube-prometheus-stack.yaml
@@ -77,4 +77,4 @@ data:
   # Since Grafana is a subchart of kube-prometheus-stack, get the version of the Grafana chart dependency at:
   # https://github.com/mesosphere/charts/tree/master/staging/kube-prometheus-stack/charts
   # Then, check https://artifacthub.io/packages/helm/grafana/grafana/ for app version
-  version: "10.3.3"
+  version: "10.0.3"

--- a/services/kube-prometheus-stack/48.3.1/helmrelease/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/48.3.1/helmrelease/kube-prometheus-stack.yaml
@@ -77,4 +77,4 @@ data:
   # Since Grafana is a subchart of kube-prometheus-stack, get the version of the Grafana chart dependency at:
   # https://github.com/mesosphere/charts/tree/master/staging/kube-prometheus-stack/charts
   # Then, check https://artifacthub.io/packages/helm/grafana/grafana/ for app version
-  version: "9.5.13"
+  version: "10.3.3"

--- a/services/kube-prometheus-stack/metadata.yaml
+++ b/services/kube-prometheus-stack/metadata.yaml
@@ -27,7 +27,7 @@ overview: |-
 
   - [Prometheus Alertmanager Documentation - Overview](https://prometheus.io/docs/alerting/latest/alertmanager/)
 
-  ### Grafana (v9.5.13)
+  ### Grafana (v10.3.3)
   A monitoring dashboard from Grafana that can be used to visualize metrics collected by Prometheus.
 
   - [Grafana Documentation](https://grafana.com/docs/)

--- a/services/kube-prometheus-stack/metadata.yaml
+++ b/services/kube-prometheus-stack/metadata.yaml
@@ -27,7 +27,7 @@ overview: |-
 
   - [Prometheus Alertmanager Documentation - Overview](https://prometheus.io/docs/alerting/latest/alertmanager/)
 
-  ### Grafana (v10.3.3)
+  ### Grafana (v10.0.3)
   A monitoring dashboard from Grafana that can be used to visualize metrics collected by Prometheus.
 
   - [Grafana Documentation](https://grafana.com/docs/)


### PR DESCRIPTION
**What problem does this PR solve?**:
This PR fixes the metrics scraping issue with Grafana v10+. Also, it bumps Grafana in KPS to the latest version (v10.3.3)

<img width="1054" alt="Screenshot 2024-02-16 at 12 37 52" src="https://github.com/mesosphere/kommander-applications/assets/47157503/f1b29643-eefb-46b7-b1c4-9c0a55fc0e0a">


<img width="1054" alt="Screenshot 2024-02-16 at 12 37 17" src="https://github.com/mesosphere/kommander-applications/assets/47157503/f09c7fbc-95e1-4256-b9ec-27a555f54a5d">


**Which issue(s) does this PR fix?**:
https://d2iq.atlassian.net/browse/D2IQ-99819


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
