### PR TITLE
chore: bump object-bucket-claim chart to 0.1.9

### DIFF
--- a/services/rook-ceph-cluster/1.13.2/objectbucketclaims/helmrelease.yaml
+++ b/services/rook-ceph-cluster/1.13.2/objectbucketclaims/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: 0.1.7
+      version: 0.1.9
   timeout: 20m
   interval: 15s
   install:


### PR DESCRIPTION
**What problem does this PR solve?**:

Brings in a fix for object-bucket-claims behaviour on rollbacks and slow upgrades (see https://github.com/mesosphere/charts/pull/1479)

**Which issue(s) does this PR fix?**:
- Part of the fix for https://d2iq.atlassian.net/browse/D2IQ-99927

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
