### PR TITLE
fix: add a workaround to make the 5.x Velero chart adopt 4.x hook resources

### DIFF
--- a/services/velero/5.2.2/helmrelease/helmrelease.yaml
+++ b/services/velero/5.2.2/helmrelease/helmrelease.yaml
@@ -21,8 +21,6 @@ spec:
       retries: 30
   upgrade:
     crds: CreateReplace
-    remediation:
-      retries: 30
   releaseName: velero
   valuesFrom:
     - kind: ConfigMap

--- a/services/velero/5.2.2/helmrelease/helmrelease.yaml
+++ b/services/velero/5.2.2/helmrelease/helmrelease.yaml
@@ -3,6 +3,8 @@ kind: HelmRelease
 metadata:
   name: velero
   namespace: ${releaseNamespace}
+  annotations:
+    velero.kommander.d2iq.io/no-hooks-chart: "true"
 spec:
   chart:
     spec:

--- a/services/velero/5.2.2/kustomization.yaml
+++ b/services/velero/5.2.2/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 resources:
   - velero-pre-install.yaml
   - velero-post-install.yaml
+  - velero-v4-hooks-adoption.yaml
   - velero.yaml
   - grafana-dashboards

--- a/services/velero/5.2.2/v4-hooks-adoption/v4-hooks-adoption.yaml
+++ b/services/velero/5.2.2/v4-hooks-adoption/v4-hooks-adoption.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: velero-v4-hooks-adoption
+  namespace: ${releaseNamespace}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: velero-v4-hooks-adoption
+  namespace: ${releaseNamespace}
+rules:
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "list", "watch",]
+  - apiGroups: ["velero.io"]
+    resources: ["backupstoragelocations", "schedules", "volumesnapshotlocations"]
+    verbs: ["get", "list", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: velero-v4-hooks-adoption
+  namespace: ${releaseNamespace}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: velero-v4-hooks-adoption
+subjects:
+  - kind: ServiceAccount
+    name: velero-v4-hooks-adoption
+    namespace: ${releaseNamespace}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: velero-v4-hooks-adoption
+  namespace: ${releaseNamespace}
+spec:
+  template:
+    metadata:
+      name: velero-v4-hooks-adoption
+    spec:
+      serviceAccountName: velero-v4-hooks-adoption
+      restartPolicy: OnFailure
+      priorityClassName: dkp-critical-priority
+      containers:
+        - name: v4-hooks-adoption
+          image: ${kubetoolsImageRepository}:${kubetoolsImageTag}
+          command:
+            - sh
+            - -c
+            - |
+              timeout --preserve-status 15m /bin/bash <<'EOF'
+              set -o nounset
+              set -e
+              set -o pipefail
+
+              # Some of the resources that are owned by newer Velero chart versions, are installed by Helm hooks of a 4.x chart.
+              # As a result, it becomes necessary to annotate and label them appropriately,
+              # so that Helm will adopt them when installing a newer chart chart.
+              #
+              # This Job runs concurrently with updating and reconciling of the `velero` HelmRelease, because, on one side,
+              # the updated HelmRelease will never become Ready without these annotations/labels, but,
+              # on the other side, reconciling the HelmRelease when it still has a 4.x chart version set 
+              # will erase these annotations/labels.
+
+              echo "Waiting for the velero HelmRelease to be updated"
+              while ! kubectl wait helmrelease -n ${releaseNamespace} velero --for=jsonpath='{.metadata.annotations.velero\\.kommander\\.d2iq\\.io/no-hooks-chart}'=true --timeout=24h ; do
+                echo "Failed to wait for `velero` HelmRelease, retrying in 30 seconds..."
+                sleep 30
+              done
+
+              # Hook resources will be identified by matching the labels values set by 4.x charts,
+              # with the presence of some `helm.sh/chart` value used as an additional guard against
+              # users setting these values of `app.kubernetes.io` labels on their own resources.
+              #
+              # In case a newer chart (which does not use hooks to install these) is already present, this is a no-op.
+
+              echo "Labeling and annotating resources installed by a 4.x Velero Helm chart hooks to allow adoption by the new chart"
+              SELECTOR="app.kubernetes.io/managed-by=Helm,app.kubernetes.io/instance=velero,helm.sh/chart"
+
+              for groupKind in BackupStorageLocation.velero.io Schedule.velero.io VolumeSnapshotLocation.velero.io; do
+                kubectl annotate $groupKind -n ${releaseNamespace} -l "$SELECTOR" meta.helm.sh/release-name=velero meta.helm.sh/release-namespace=${releaseNamespace}
+                kubectl label $groupKind -n ${releaseNamespace} -l "$SELECTOR" app.kubernetes.io/managed-by=Helm
+              done
+
+              echo "Done labeling and annotating 4.x hook resources"
+              EOF

--- a/services/velero/5.2.2/velero-v4-hooks-adoption.yaml
+++ b/services/velero/5.2.2/velero-v4-hooks-adoption.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: velero-v4-hooks-adoption
+  namespace: ${releaseNamespace}
+spec:
+  dependsOn:
+    - name: velero-pre-install
+      namespace: ${releaseNamespace}
+  force: true
+  prune: true
+  wait: true
+  interval: 6h
+  retryInterval: 1m
+  path: ./services/velero/5.2.2/v4-hooks-adoption
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 1m
+  postBuild:
+    substitute:
+      releaseNamespace: ${releaseNamespace}
+      kubetoolsImageRepository: ${kubetoolsImageRepository:=bitnami/kubectl}
+      kubetoolsImageTag: ${kubetoolsImageTag:=1.27.9}


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
- Closes https://d2iq.atlassian.net/browse/D2IQ-99927
- Closes https://d2iq.atlassian.net/browse/D2IQ-99936

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
NONE

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
