### PR TITLE
fix(kubectl): Bump all kubectl image defaults to 1.29.2

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -46,6 +46,7 @@ ignore:
   - docker.io/bitnami/kubectl:1.24.1
   - docker.io/bitnami/kubectl:1.26.4
   - docker.io/bitnami/kubectl:1.27.9
+  - docker.io/bitnami/kubectl:1.29.2
 
   # Fossa cannot scan C/CPP projects
   # See: https://docs.fossa.com/docs/c-cpp

--- a/services/centralized-kubecost/0.37.2/post-install-jobs/post-install-jobs.yaml
+++ b/services/centralized-kubecost/0.37.2/post-install-jobs/post-install-jobs.yaml
@@ -42,7 +42,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.27.9}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
           command:
             - sh
             - -c

--- a/services/centralized-kubecost/0.37.2/release/release.yaml
+++ b/services/centralized-kubecost/0.37.2/release/release.yaml
@@ -73,7 +73,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.27.9}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
           command:
             - sh
             - "-c"

--- a/services/dex/2.13.8/defaults/cm.yaml
+++ b/services/dex/2.13.8/defaults/cm.yaml
@@ -7,7 +7,7 @@ data:
   values.yaml: |-
     ---
     priorityClassName: "dkp-critical-priority"
-    kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.27.9}"
+    kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
     image: mesosphere/dex
     imageTag: v2.37.0-d2iq.2
     resources:

--- a/services/grafana-loki/0.74.6/grafana-loki-pre-install-jobs/pre-install.yaml
+++ b/services/grafana-loki/0.74.6/grafana-loki-pre-install-jobs/pre-install.yaml
@@ -46,7 +46,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: pre-install
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.27.9}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
           command:
             - sh
             - -c

--- a/services/istio/1.20.2/defaults/cm.yaml
+++ b/services/istio/1.20.2/defaults/cm.yaml
@@ -30,7 +30,7 @@ data:
           prometheus.kommander.d2iq.io/select: "true"
     global:
       image: ${kubetoolsImageRepository:=bitnami/kubectl}
-      tag: ${kubetoolsImageTag:=1.27.9}
+      tag: ${kubetoolsImageTag:=1.29.2}
       priorityClassName: "dkp-critical-priority"
     operator:
       # expose metrics for prometheus scraping

--- a/services/knative/1.10.4/defaults/cm.yaml
+++ b/services/knative/1.10.4/defaults/cm.yaml
@@ -7,7 +7,7 @@ data:
   values.yaml: |
     global:
       priorityClassName: "dkp-high-priority"
-      kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.27.9}"
+      kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
     eventing:
       enabled: false
     eventing-sources:

--- a/services/knative/1.10.4/defaults/cm.yaml
+++ b/services/knative/1.10.4/defaults/cm.yaml
@@ -7,7 +7,6 @@ data:
   values.yaml: |
     global:
       priorityClassName: "dkp-high-priority"
-      kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
     eventing:
       enabled: false
     eventing-sources:

--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -22,7 +22,7 @@ data:
     mesosphereResources:
       create: true
       hooks:
-        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.27.9}"
+        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
       rules:
         # addon alert rules are defaulted to false to prevent potential misfires if addons
         # are disabled.

--- a/services/kubecost/0.37.2/defaults/cm.yaml
+++ b/services/kubecost/0.37.2/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
     ---
     hooks:
       clusterID:
-        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.27.9}"
+        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
         priorityClassName: dkp-high-priority
 
     cost-analyzer:

--- a/services/kubefed/0.10.4/defaults/cm.yaml
+++ b/services/kubefed/0.10.4/defaults/cm.yaml
@@ -35,7 +35,7 @@ data:
       postInstallJob:
         repository: bitnami
         image: kubectl
-        tag: 1.27.9
+        tag: 1.29.2
     webhook:
       annotations:
         secret.reloader.stakater.com/reload: "kubefed-root-ca"

--- a/services/kubetunnel/0.0.31/defaults/cm.yaml
+++ b/services/kubetunnel/0.0.31/defaults/cm.yaml
@@ -17,7 +17,7 @@ data:
     hooks:
       kubectlImage:
         repository: "${kubetoolsImageRepository:=bitnami/kubectl}"
-        tag: "${kubetoolsImageTag:=1.27.9}"
+        tag: "${kubetoolsImageTag:=1.29.2}"
     controller:
       manager:
         resources:

--- a/services/rook-ceph-cluster/1.13.2/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.13.2/pre-install/ceph-crd-check.yaml
@@ -47,7 +47,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: pre-install
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.27.9}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
           command:
             - sh
             - -c
@@ -57,7 +57,7 @@ spec:
                 sleep 30
               done
         - name: pre-upgrade
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.27.9}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
           command:
             - sh
             - -c

--- a/services/thanos/12.20.3/jobs/jobs.yaml
+++ b/services/thanos/12.20.3/jobs/jobs.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.27.9}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
           command:
             - sh
             - "-c"

--- a/services/traefik/26.0.0/defaults/cm.yaml
+++ b/services/traefik/26.0.0/defaults/cm.yaml
@@ -39,7 +39,7 @@ data:
         app: traefik
       initContainers:
       - name: initialize-middleware
-        image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.27.9}"
+        image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
         command:
           - bash
         args:

--- a/services/velero/5.2.2/defaults/cm.yaml
+++ b/services/velero/5.2.2/defaults/cm.yaml
@@ -47,4 +47,4 @@ data:
       image:
         # If we don't override the version here, upstream chart will pull an image dynamically based on k8s cluster version.
         # which makes it harder to build airgapped tar bundles. So to make bundle collection predictable, we override the tag here.
-        tag: "${kubetoolsImageTag:=1.27.9}"
+        tag: "${kubetoolsImageTag:=1.29.2}"

--- a/services/velero/5.2.2/velero-pre-install.yaml
+++ b/services/velero/5.2.2/velero-pre-install.yaml
@@ -19,4 +19,4 @@ spec:
     substitute:
       releaseNamespace: ${releaseNamespace}
       kubetoolsImageRepository: ${kubetoolsImageRepository:=bitnami/kubectl}
-      kubetoolsImageTag: ${kubetoolsImageTag:=1.27.9}
+      kubetoolsImageTag: ${kubetoolsImageTag:=1.29.2}


### PR DESCRIPTION
**What problem does this PR solve?**:
Bump kubectl image in values overrides to 1.29.2.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-99985

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
kubetools templating variables were added back recently, but I wanted to note that this variable is not actually getting substituted, so effectively we are still using the defaults and thus must still manually bump them here. we should revisit switching to using kubetools and getting it substituted when we get to implementing declarative installs (relevant jira ticket https://d2iq.atlassian.net/browse/D2IQ-87946)

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
