### PR TITLE
fix(centralized-grafana): Correct metrics path

### DIFF
--- a/services/centralized-grafana/48.3.1/defaults/cm.yaml
+++ b/services/centralized-grafana/48.3.1/defaults/cm.yaml
@@ -18,7 +18,7 @@ data:
       serviceMonitor:
         labels:
           prometheus.kommander.d2iq.io/select: "true"
-        path: "/dkp/grafana/metrics"
+        path: "/dkp/kommander/monitoring/grafana/metrics"
       sidecar:
         image:
           repository: kiwigrid/k8s-sidecar


### PR DESCRIPTION
**What problem does this PR solve?**:
Noticed the centralized-grafana metrics target was still down, realized this grafana's path is different so fixed it and checked that the target is back up

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
