### PR TITLE
feat: bump grafana to the latest to fix critical CVEs

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -109,7 +109,7 @@ resources:
         notice_path: NOTICE.md
         ref: v${image_tag}
         url: https://github.com/grafana/grafana
-  - container_image: docker.io/grafana/grafana:10.0.3
+  - container_image: docker.io/grafana/grafana:10.3.3
     sources:
       - license_path: LICENSE
         notice_path: NOTICE.md

--- a/services/centralized-grafana/48.3.1/centralized-grafana.yaml
+++ b/services/centralized-grafana/48.3.1/centralized-grafana.yaml
@@ -43,4 +43,4 @@ data:
   # https://github.com/mesosphere/charts/tree/master/staging/kube-prometheus-stack/charts
   # Then, find the Grafana app version:
   # https://artifacthub.io/packages/helm/grafana/grafana/6.57.2
-  version: "10.0.3"
+  version: "10.3.3"

--- a/services/centralized-grafana/48.3.1/defaults/cm.yaml
+++ b/services/centralized-grafana/48.3.1/defaults/cm.yaml
@@ -13,6 +13,8 @@ data:
         enabled: true
     grafana:
       enabled: true
+      image:
+        tag: 10.3.3
       defaultDashboardsEnabled: true
       priorityClassName: "dkp-critical-priority"
       serviceMonitor:

--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -334,6 +334,8 @@ data:
             memory: 200Mi
     grafana:
       enabled: true
+      image:
+        tag: 10.3.3
       defaultDashboardsEnabled: true
       priorityClassName: "dkp-critical-priority"
       serviceMonitor:

--- a/services/kube-prometheus-stack/48.3.1/helmrelease/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/48.3.1/helmrelease/kube-prometheus-stack.yaml
@@ -77,4 +77,4 @@ data:
   # Since Grafana is a subchart of kube-prometheus-stack, get the version of the Grafana chart dependency at:
   # https://github.com/mesosphere/charts/tree/master/staging/kube-prometheus-stack/charts
   # Then, check https://artifacthub.io/packages/helm/grafana/grafana/ for app version
-  version: "10.0.3"
+  version: "10.3.3"

--- a/services/kube-prometheus-stack/metadata.yaml
+++ b/services/kube-prometheus-stack/metadata.yaml
@@ -27,7 +27,7 @@ overview: |-
 
   - [Prometheus Alertmanager Documentation - Overview](https://prometheus.io/docs/alerting/latest/alertmanager/)
 
-  ### Grafana (v10.0.3)
+  ### Grafana (v10.3.3)
   A monitoring dashboard from Grafana that can be used to visualize metrics collected by Prometheus.
 
   - [Grafana Documentation](https://grafana.com/docs/)


### PR DESCRIPTION
**What problem does this PR solve?**:
Update Grafana in KPS to the latest version to fix critical CVEs.
```
➜  ubuntu-dev git:(master) ✗ trivy image grafana/grafana:10.3.3 --severity CRITICAL
...
grafana/grafana:10.3.3 (alpine 3.18.4)

Total: 0 (CRITICAL: 0)
```
Manually tested Grafana runs without any issues and dashboards are working correctly:

<img width="1157" alt="Screenshot 2024-02-21 at 14 01 46" src="https://github.com/mesosphere/kommander-applications/assets/47157503/5e66b81c-65fa-4da0-94a1-cb58cf42574f">

**Which issue(s) does this PR fix?**:
https://d2iq.atlassian.net/browse/D2IQ-99993


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
