### PR TITLE
revert: "feat: Rename deprecated secretRef to certSecretRef (#1925)"

### DIFF
--- a/common/airgapped/patch-add-secret-ref.yaml
+++ b/common/airgapped/patch-add-secret-ref.yaml
@@ -3,5 +3,5 @@ kind: HelmRepository
 metadata:
   name: not-used-in-a-patch
 spec:
-  certSecretRef:
+  secretRef:
     name: "tls-root-ca"


### PR DESCRIPTION
Reverts mesosphere/kommander-applications#1925

`secretRef` to `certSecretRef` is a bigger change than we initially anticipated. when we reintroduce this feature, we should:

- have a patch to remove the `secretRef` from HelmRepository resources.
- update the `caFile` to `ca.crt` in the secret data.