### PR TITLE
chore(gitea): bump gitea container - cve fixes

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -90,10 +90,10 @@ resources:
       - license_path: LICENSE
         ref: v${image_tag}
         url: https://github.com/fluent/fluent-bit
-  - container_image: ghcr.io/mesosphere/gitea:1.19.2-d2iq-rootless
+  - container_image: ghcr.io/mesosphere/gitea:1.19.2-d2iq.1-rootless
     sources:
       - license_path: LICENSE
-        ref: v1.19.2-d2iq
+        ref: v1.19.2-d2iq.1
         url: https://github.com/mesosphere/gitea
   - container_image: docker.io/grafana/grafana:8.5.26
     sources:

--- a/services/gitea/8.2.0/defaults/cm.yaml
+++ b/services/gitea/8.2.0/defaults/cm.yaml
@@ -10,7 +10,7 @@ data:
     image:
       registry: ghcr.io
       repository: mesosphere/gitea
-      tag: 1.19.2-d2iq
+      tag: 1.19.2-d2iq.1
       rootless: true
     ingress:
       enabled: true


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumping gitea image - CVE fixes. Build id https://github.com/mesosphere/gitea/actions/runs/8018294220

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-100004

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
