### PR TITLE
fix: bump mesosphere/grafana-plugins image - cve fixes

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -1,5 +1,5 @@
 ignore:
-  - docker.io/mesosphere/grafana-plugins:v0.0.1
+  - ghcr.io/mesosphere/dkp-container-images/docker.io/mesosphere/grafana-plugins:v0.0.1-d2iq.0
   - docker.io/mesosphere/kommander2-kubetools
   - docker.io/nginxinc/nginx-unprivileged:1.24.0-alpine
   - docker.io/bitnami/external-dns:0.14.0-debian-11-r8

--- a/services/centralized-grafana/48.3.1/defaults/cm.yaml
+++ b/services/centralized-grafana/48.3.1/defaults/cm.yaml
@@ -118,7 +118,7 @@ data:
           mountPath: /var/lib/grafana/plugins/
       extraInitContainers:
         - name: grafana-plugins-install
-          image: mesosphere/grafana-plugins:v0.0.1
+          image: ghcr.io/mesosphere/dkp-container-images/docker.io/mesosphere/grafana-plugins:v0.0.1-d2iq.0
           command: ["/bin/sh", "-c", "cp -a /var/lib/grafana/plugins/. /var/lib/grafana/shared-plugins/"]
           volumeMounts:
           - name: plugins

--- a/services/grafana-logging/6.60.1/defaults/cm.yaml
+++ b/services/grafana-logging/6.60.1/defaults/cm.yaml
@@ -102,7 +102,7 @@ data:
         mountPath: /var/lib/grafana/plugins/
     extraInitContainers:
       - name: grafana-plugins-install
-        image: mesosphere/grafana-plugins:v0.0.1
+        image: ghcr.io/mesosphere/dkp-container-images/docker.io/mesosphere/grafana-plugins:v0.0.1-d2iq.0
         command: ["/bin/sh", "-c", "cp -a /var/lib/grafana/plugins/. /var/lib/grafana/shared-plugins/"]
         volumeMounts:
         - name: plugins

--- a/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.1/defaults/cm.yaml
@@ -431,7 +431,7 @@ data:
           mountPath: /var/lib/grafana/plugins/
       extraInitContainers:
         - name: grafana-plugins-install
-          image: mesosphere/grafana-plugins:v0.0.1
+          image: ghcr.io/mesosphere/dkp-container-images/docker.io/mesosphere/grafana-plugins:v0.0.1-d2iq.0
           command: ["/bin/sh", "-c", "cp -a /var/lib/grafana/plugins/. /var/lib/grafana/shared-plugins/"]
           volumeMounts:
           - name: plugins

--- a/services/project-grafana-logging/6.60.1/defaults/cm.yaml
+++ b/services/project-grafana-logging/6.60.1/defaults/cm.yaml
@@ -101,7 +101,7 @@ data:
         mountPath: /var/lib/grafana/plugins/
     extraInitContainers:
       - name: grafana-plugins-install
-        image: mesosphere/grafana-plugins:v0.0.1
+        image: ghcr.io/mesosphere/dkp-container-images/docker.io/mesosphere/grafana-plugins:v0.0.1-d2iq.0
         command: ["/bin/sh", "-c", "cp -a /var/lib/grafana/plugins/. /var/lib/grafana/shared-plugins/"]
         volumeMounts:
         - name: plugins


### PR DESCRIPTION
**What problem does this PR solve?**:
Image patched with copacetic - https://github.com/mesosphere/dkp-container-images/actions/runs/8005532506#summary-21865185492

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-99997

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
