### PR TITLE
feat(obc): Bump to 0.1.11

### DIFF
--- a/services/project-grafana-loki/0.74.6/object-bucket-claims.yaml
+++ b/services/project-grafana-loki/0.74.6/object-bucket-claims.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: 0.1.9
+      version: 0.1.11
   interval: 15s
   install:
     crds: CreateReplace

--- a/services/rook-ceph-cluster/1.13.2/objectbucketclaims/helmrelease.yaml
+++ b/services/rook-ceph-cluster/1.13.2/objectbucketclaims/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: 0.1.9
+      version: 0.1.11
   timeout: 20m
   interval: 15s
   install:


### PR DESCRIPTION
**What problem does this PR solve?**:
bump OBC to latest which adds templating for k8s version and defaults it to 1.29.2

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-99984

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
