### PR TITLE
chore: debug list-images.sh script

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,7 @@
-use asdf
+# Automatically sets up your devbox environment whenever you cd into this
+# directory via our direnv integration:
+
+eval "$(devbox generate direnv --print-envrc)"
+
+# check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
+# for more details

--- a/hack/list-images.sh
+++ b/hack/list-images.sh
@@ -108,6 +108,7 @@ for dir in $(find . -type f -name "*.yaml" -print0 | xargs --null --max-lines=1 
       extra_args+=('--extra-images-file' 'extra-images.txt')
     fi
 
+    >&2 echo -e " + ${dir}${hr}\n"
     envsubst -no-unset -no-digit -i "$(basename "${hr}")" | \
       gojq --yaml-input --raw-output --arg repoRoot "${REPO_ROOT}" \
         $'select(.spec.chart.spec.sourceRef.name != null) |
@@ -116,7 +117,8 @@ for dir in $(find . -type f -name "*.yaml" -print0 | xargs --null --max-lines=1 
           elif .spec.chart.spec.sourceRef.kind == "GitRepository" then
             $repoRoot+"/"+.spec.chart.spec.chart
           end' | \
-      xargs --max-lines=1 --no-run-if-empty -- helm list-images --unique "${extra_args[@]}" >>"${IMAGES_FILE}"
+      xargs --max-lines=1 --no-run-if-empty -- helm list-images --unique "${extra_args[@]}" | >&2 tee -a "${IMAGES_FILE}"
+      >&2 echo
     popd &>/dev/null
   done < <(grep --recursive --max-count=1 --files-with-matches '^kind: HelmRelease')
   popd &>/dev/null


### PR DESCRIPTION
**What problem does this PR solve?**:
* Fixes envrc to use devbox.
* Adds debug output to `list-images.sh` script so its possible to identify where an images comes from

```
 + ./common/build/kommander-cert-federation.yaml

docker.io/bitnami/kubectl:1.29.2
quay.io/kubernetes-multicluster/kubefed:v0.9.1

 + ./common/kommander-operator/helmrelease.yaml

docker.io/mesosphere/kommander2-core-installer:v2.8.0-dev
docker.io/mesosphere/kommander2-kubetools:v2.8.0-dev

 + ./services/ai-navigator-app/0.2.1/helmrelease/helmrelease.yaml

docker.io/bitnami/kubectl:1.26.4
docker.io/bitnami/postgresql:15.2.0-debian-11-r21
docker.io/mesosphere/ai-navigator-cluster-info-api:v0.1.0
docker.io/semitechnologies/weaviate:1.21.4

...
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
