### PR TITLE
chore(kommander-cert-federation): bump chart to v0.0.11

### DIFF
--- a/common/build/kommander-cert-federation.yaml
+++ b/common/build/kommander-cert-federation.yaml
@@ -22,5 +22,5 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: "0.0.10"
+      version: "0.0.11"
   interval: 15s

--- a/common/build/kommander-cert-federation.yaml
+++ b/common/build/kommander-cert-federation.yaml
@@ -22,5 +22,5 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: "0.0.9"
+      version: "0.0.10"
   interval: 15s

--- a/common/build/kommander-cert-federation.yaml
+++ b/common/build/kommander-cert-federation.yaml
@@ -22,5 +22,5 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: "0.0.8"
+      version: "0.0.9"
   interval: 15s

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -518,11 +518,6 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/kiwigrid/k8s-sidecar
-  - container_image: quay.io/kubernetes-multicluster/kubefed:v0.9.1
-    sources:
-      - license_path: LICENSE
-        ref: ${image_tag}
-        url: https://github.com/kubernetes-sigs/kubefed
   - container_image: quay.io/kubernetes_incubator/nfs-provisioner:v2.3.0
     sources:
       - license_path: LICENSE


### PR DESCRIPTION
**What problem does this PR solve?**:
Chart bump updates `kubefed` image and fixes critical CVEs.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
JIRA: https://d2iq.atlassian.net/browse/D2IQ-100008

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
