### PR TITLE
fix(kubecost): Bump grafana to 10.3.3 to resolve CVE-2023-49569

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -100,12 +100,6 @@ resources:
         notice_path: NOTICE.md
         ref: v${image_tag}
         url: https://github.com/grafana/grafana
-  - container_image: docker.io/grafana/grafana:9.4.7
-    sources:
-      - license_path: LICENSE
-        notice_path: NOTICE.md
-        ref: v${image_tag}
-        url: https://github.com/grafana/grafana
   - container_image: docker.io/grafana/grafana:10.3.3
     sources:
       - license_path: LICENSE

--- a/services/kubecost/0.37.3/defaults/cm.yaml
+++ b/services/kubecost/0.37.3/defaults/cm.yaml
@@ -48,6 +48,8 @@ data:
 
       grafana:
         priorityClassName: dkp-high-priority
+        image:
+          tag: 10.3.3
         ingress:
           enabled: true
           annotations:
@@ -64,6 +66,7 @@ data:
             protocol: http
             enable_gzip: true
             root_url: "%(protocol)s://%(domain)s:%(http_port)s/dkp/kubecost/grafana"
+            serve_from_sub_path: false # Set to false on Grafana v10+
           auth.proxy:
             enabled: true
             header_name: X-Forwarded-User


### PR DESCRIPTION
**What problem does this PR solve?**:
- Bumps version of grafana deployed by kubecost to 10.3.3 to resolve a CVE

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-99992

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
I tested this manually on the daily cluster

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
