### PR TITLE
chore(rook-ceph): use custom patched images with fixed CVEs

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -291,7 +291,7 @@ resources:
         ref: ${image_tag}
         url: https://github.com/open-policy-agent/gatekeeper
   - container_image: docker.io/openpolicyagent/gatekeeper:v3.14.0
-    sourc docker.io/rook/cephes:
+    sources:
       - license_path: LICENSE
         notice_path: NOTICE
         ref: ${image_tag}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -291,12 +291,12 @@ resources:
         ref: ${image_tag}
         url: https://github.com/open-policy-agent/gatekeeper
   - container_image: docker.io/openpolicyagent/gatekeeper:v3.14.0
-    sources:
+    sourc docker.io/rook/cephes:
       - license_path: LICENSE
         notice_path: NOTICE
         ref: ${image_tag}
         url: https://github.com/open-policy-agent/gatekeeper
-  - container_image: docker.io/rook/ceph:v1.13.2
+  - container_image: ghcr.io/mesosphere/dkp-container-images/rook/ceph:v1.13.2
     sources:
       - license_path: LICENSE
         ref: ${image_tag}
@@ -457,7 +457,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/brancz/kube-rbac-proxy
-  - container_image: quay.io/ceph/ceph:v18.2.1
+  - container_image: ghcr.io/mesosphere/dkp-container-images/ceph/ceph:v18.2.1
     sources:
       - license_path: COPYING
         ref: ${image_tag}

--- a/services/rook-ceph-cluster/1.13.2/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.13.2/defaults/cm.yaml
@@ -22,6 +22,11 @@ data:
           prometheus.kommander.d2iq.io/select: "true"
       dataDirHostPath: /var/lib/rook
 
+      cephVersion:
+        # This image was patched to fix CVEs. To build new version of the image:
+        # See: https://github.com/mesosphere/dkp-container-images
+        image: ghcr.io/mesosphere/dkp-container-images/ceph/ceph:v18.2.1
+
       resources:
         mgr-sidecar:
           limits:

--- a/services/rook-ceph/1.13.2/defaults/cm.yaml
+++ b/services/rook-ceph/1.13.2/defaults/cm.yaml
@@ -6,6 +6,11 @@ metadata:
 data:
   values.yaml: |
     ---
+    image:
+      # This image was patched to fix CVEs. To build new version of the image:
+      # See: https://github.com/mesosphere/dkp-container-images
+      repository: ghcr.io/mesosphere/dkp-container-images/rook/ceph
+
     crds:
       # CRDs are not installed with "crds" directory and If this flag is disabled post-install, the cluster may be DESTROYED.
       # If the CRDs are deleted in this case, see the disaster recovery guide to restore them.


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumps rook ceph container images with fixed CVEs.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-100005

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
