### PR TITLE
feat: updates nvidia values to use all latest and pins toolkit

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -33,7 +33,7 @@ ignore:
   #     - url: https://github.com/NVIDIA/DCGM
   #       ref: ${image_tag}
   #       license_path: LICENSE
-  - nvcr.io/nvidia/cloud-native/dcgm:3.1.8-1-ubuntu20.04
+  - nvcr.io/nvidia/cloud-native/dcgm:3.3.0-1-ubuntu22.04
 
   # Incorrect mapping was provided
   # - container_image: docker.io/bitnami/kubectl:1.19.7
@@ -427,30 +427,30 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/NVIDIA/gpu-operator
-  - container_image: nvcr.io/nvidia/k8s-device-plugin:v0.14.1-ubi8
+  - container_image: nvcr.io/nvidia/k8s-device-plugin:v0.14.5-ubi8
     sources:
       - license_path: LICENSE
         ref: ${image_tag%-ubi8}
         url: https://github.com/NVIDIA/k8s-device-plugin
-  - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.13.1-centos7
+  - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.14.6-ubuntu20.04
     sources:
       - license_path: LICENSE
-        ref: ${image_tag%-centos7}
+        ref: ${image_tag}
         url: https://github.com/NVIDIA/nvidia-container-toolkit
-  - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.13.1-ubi8
+  - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.14.6-ubi8
     sources:
       - license_path: LICENSE
-        ref: ${image_tag%-ubi8}
+        ref: ${image_tag}
         url: https://github.com/NVIDIA/nvidia-container-toolkit
-  - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.13.1-ubuntu20.04
+  - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.14.6-centos7
     sources:
       - license_path: LICENSE
-        ref: ${image_tag%-ubuntu20.04}
+        ref: ${image_tag}
         url: https://github.com/NVIDIA/nvidia-container-toolkit
-  - container_image: nvcr.io/nvidia/k8s/dcgm-exporter:3.1.8-3.1.5-ubuntu20.04
+  - container_image: nvcr.io/nvidia/k8s/dcgm-exporter:3.3.0-3.2.0-ubuntu22.04
     sources:
       - license_path: LICENSE
-        ref: ${image_tag%-ubuntu20.04}
+        ref: ${image_tag}
         url: https://github.com/NVIDIA/dcgm-exporter
   - container_image: quay.io/brancz/kube-rbac-proxy:v0.14.2
     sources:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -435,22 +435,22 @@ resources:
   - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.14.6-ubuntu20.04
     sources:
       - license_path: LICENSE
-        ref: ${image_tag}
+        ref: ${image_tag%-ubuntu20.04}
         url: https://github.com/NVIDIA/nvidia-container-toolkit
   - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.14.6-ubi8
     sources:
       - license_path: LICENSE
-        ref: ${image_tag}
+        ref: ${image_tag%-ubi8}
         url: https://github.com/NVIDIA/nvidia-container-toolkit
   - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.14.6-centos7
     sources:
       - license_path: LICENSE
-        ref: ${image_tag}
+        ref: ${image_tag%-centos7}
         url: https://github.com/NVIDIA/nvidia-container-toolkit
   - container_image: nvcr.io/nvidia/k8s/dcgm-exporter:3.3.0-3.2.0-ubuntu22.04
     sources:
       - license_path: LICENSE
-        ref: ${image_tag}
+        ref: ${image_tag%-ubuntu22.04}
         url: https://github.com/NVIDIA/dcgm-exporter
   - container_image: quay.io/brancz/kube-rbac-proxy:v0.14.2
     sources:

--- a/services/nvidia-gpu-operator/23.9.2/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/23.9.2/defaults/cm.yaml
@@ -13,27 +13,22 @@ data:
       config:
         # Create a ConfigMap (default: false)
         create: false
-      version: v0.14.1-ubi8
+      version: v0.14.5-ubi8
     toolkit:
       # toolkit needs to be set on per OS
       # see: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html#bare-metal-passthrough-with-default-configurations-on-centos
       # this comment explains the dependency on the hosts
       # version of libc.so
       # https://github.com/NVIDIA/gpu-operator/issues/72#issuecomment-742023528
-      version: v1.13.1-ubuntu20.04
+      version: v1.14.6-ubuntu20.04
     gfd:
       enabled: true
       version: v0.8.1-ubi8
     dcgm:
       enabled: true
-      version: 3.1.8-1-ubuntu20.04
+      version: 3.3.0-1-ubuntu22.04
     dcgmExporter:
       enabled: true
-      version: 3.1.8-3.1.5-ubuntu20.04
+      version: 3.3.0-3.2.0-ubuntu22.04
     validator:
-      # we are using a newer version of the validator pod that
-      # removes the compat libs from the container
-      # this can cause a mismatch in cuda versions
-      # see: https://github.com/NVIDIA/gpu-operator/issues/389#issuecomment-1215781064
-      # for more details
       version: v23.9.2


### PR DESCRIPTION
**What problem does this PR solve?**:
This updates the nvidia gpu operator chart to use newer values for the component versions.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
