### PR TITLE
fix: update workflow-dispatch action

### DIFF
--- a/.github/workflows/create-dev-tag.yml
+++ b/.github/workflows/create-dev-tag.yml
@@ -64,7 +64,7 @@ jobs:
         run: git push --force --tags origin ${{ env.TAG }}
 
       - name: Run release workflow
-        uses: benc-uk/workflow-dispatch@v121
+        uses: benc-uk/workflow-dispatch@v1.2.3
         with:
           workflow: release.yml
           ref: ${{ env.TAG }}


### PR DESCRIPTION
**What problem does this PR solve?**:
Dependabot didn't detect correctly necessary update. The version we're referencing in our workflow is not longer available.

The action is no longer available:

```
Unable to resolve action `benc-uk/workflow-dispatch@v121`, unable to find version `v121`
```

Dependabot log

```
updater | 2024/03/18 06:47:28 INFO <job_801440859> Checking if benc-uk/workflow-dispatch 121 needs updating
  proxy | 2024/03/18 06:47:28 [110] GET https://github.com:443/benc-uk/workflow-dispatch.git/info/refs?service=git-upload-pack
  proxy | 2024/03/18 06:47:28 [110] * authenticating git server request (host: github.com)
  proxy | 2024/03/18 06:47:28 [110] 200 https://github.com:443/benc-uk/workflow-dispatch.git/info/refs?service=git-upload-pack
updater | 2024/03/18 06:47:28 INFO <job_801440859> Latest version is 1
updater | 2024/03/18 06:47:28 INFO <job_801440859> No update needed for benc-uk/workflow-dispatch 121
```

https://github.com/marketplace/actions/workflow-dispatch

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
