### PR TITLE
feat: add an app for git-operator

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -1,4 +1,5 @@
 ignore:
+  - ghcr.io/mesosphere/git-operator:v0.0.0-dev-ec01b70
   - ghcr.io/mesosphere/dkp-container-images/docker.io/mesosphere/grafana-plugins:v0.0.1-d2iq.0
   - docker.io/mesosphere/kommander2-kubetools
   - docker.io/nginxinc/nginx-unprivileged:1.24.0-alpine

--- a/services/git-operator/0.0.0/git-operator.yaml
+++ b/services/git-operator/0.0.0/git-operator.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: git-operator-manifests
+spec:
+  interval: 5m0s
+  url: "oci://ghcr.io/mesosphere/git-operator-manifests"
+  ref:
+    tag: v0.0.0-dev-ec01b70
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: git-operator-manifests
+spec:
+  interval: 10m
+  targetNamespace: default
+  sourceRef:
+    kind: OCIRepository
+    name: git-operator-manifests
+  path: "./default"
+  patches:
+  - patch: |
+      - op: test
+        path: "/spec/template/spec/containers/1/name"
+        value: "manager"
+      - op: replace
+        path: "/spec/template/spec/containers/1/image"
+        value: "ghcr.io/mesosphere/git-operator:v0.0.0-dev-ec01b70"
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: controller-manager
+  targetNamespace: git-operator-system
+  prune: true
+  timeout: 1m

--- a/services/git-operator/0.0.0/kustomization.yaml
+++ b/services/git-operator/0.0.0/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - git-operator.yaml

--- a/services/git-operator/metadata.yaml
+++ b/services/git-operator/metadata.yaml
@@ -1,0 +1,3 @@
+type: internal
+scope:
+  - workspace


### PR DESCRIPTION
**What problem does this PR solve?**:
Adds an app for the git-operator to facilitate development of kommander-operator.

**Which issue(s) does this PR fix?**:
- https://d2iq.atlassian.net/browse/D2IQ-100236



**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
NONE
```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
