### PR TITLE
fix: [backport-2.8] bump centr grafana and KPS chart version

### DIFF
--- a/services/centralized-grafana/48.3.2/centralized-grafana.yaml
+++ b/services/centralized-grafana/48.3.2/centralized-grafana.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-staging
         namespace: kommander-flux
-      version: 48.3.1
+      version: 48.3.2
   interval: 15s
   install:
     crds: CreateReplace

--- a/services/kube-prometheus-stack/48.3.2/helmrelease/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/48.3.2/helmrelease/kube-prometheus-stack.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-staging
         namespace: kommander-flux
-      version: 48.3.1
+      version: 48.3.2
   interval: 15s
   install:
     timeout: 5m0s


### PR DESCRIPTION
**What problem does this PR solve?**:
backport the KPS chart bump for 2.8 regarding the RBAC issue.

**Which issue(s) does this PR fix?**:
https://d2iq.atlassian.net/browse/D2IQ-100406

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
