### PR TITLE
fix: [backport-2.8] remove excessive label

### DIFF
--- a/charts/kommander-operator/Chart.yaml
+++ b/charts/kommander-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kommander-operator
 appVersion: "0.3.0"
-version: 0.3.0
+version: 0.3.1
 description: kommander-operator helm chart.
 maintainers:
   - name: azhovan

--- a/charts/kommander-operator/templates/rback_v1_clusterrole_operator_kommander-operator.yaml
+++ b/charts/kommander-operator/templates/rback_v1_clusterrole_operator_kommander-operator.yaml
@@ -18,7 +18,6 @@ kind: ClusterRole
 metadata:
   name: {{ .Chart.Name }}-view
   labels:
-    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.kommandercore.d2iq.com/aggregate-to-view: "true"
 rules:
   - apiGroups:
@@ -50,7 +49,6 @@ kind: ClusterRole
 metadata:
   name: {{ .Chart.Name }}-update
   labels:
-    rbac.authorization.k8s.io/aggregate-to-update: "true"
     rbac.kommandercore.d2iq.com/aggregate-to-update: "true"
 rules:
   - apiGroups:
@@ -76,7 +74,6 @@ kind: ClusterRole
 metadata:
   name: {{ .Chart.Name }}-admin
   labels:
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.kommandercore.d2iq.com/aggregate-to-admin: "true"
 rules:
   - apiGroups:


### PR DESCRIPTION
**What problem does this PR solve?**:
Currently kommander-federater-view is getting excessive permissions

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-100411

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
