### PR TITLE
fix(promadapter): Bump version in hr path

### DIFF
--- a/services/prometheus-adapter/4.10.0/prometheus-adapter-helmrelease.yaml
+++ b/services/prometheus-adapter/4.10.0/prometheus-adapter-helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   wait: true
   interval: 6h
   retryInterval: 1m
-  path: ./services/prometheus-adapter/4.9.0/helmrelease
+  path: ./services/prometheus-adapter/4.10.0/helmrelease
   sourceRef:
     kind: GitRepository
     name: management


### PR DESCRIPTION
**What problem does this PR solve?**:
fix bloodhound parsing error due to one of the paths not including a version bump (not sure why validation did not run on the offending pr)

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
