### PR TITLE
fix: add general kommander overrides cm

### DIFF
--- a/hack/release/pkg/appversion/appversion_test.go
+++ b/hack/release/pkg/appversion/appversion_test.go
@@ -30,7 +30,7 @@ func TestReplaceContent(t *testing.T) {
 	dir := fetchRepo(t)
 	changes, err := ReplaceContent(context.Background(), dir, "0.99.99")
 	require.NoError(t, err)
-	assert.Equal(t, 5, changes)
+	assert.Equal(t, 4, changes)
 }
 
 func fetchRepo(t *testing.T) string {

--- a/services/kommander/0.8.0/kommander.yaml
+++ b/services/kommander/0.8.0/kommander.yaml
@@ -36,5 +36,5 @@ spec:
     - kind: ConfigMap
       name: kommander-0.8.0-d2iq-defaults
     - kind: ConfigMap
-      name: kommander-0.8.0-overrides
+      name: kommander-overrides
       optional: true


### PR DESCRIPTION
**What problem does this PR solve?**:
Remove versioning from the optional kommander chart overrides CM.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-100445

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
