### PR TITLE
feat(kommander): Specify default mgmt apps in values

### DIFF
--- a/services/kommander/0.8.0/defaults/cm.yaml
+++ b/services/kommander/0.8.0/defaults/cm.yaml
@@ -97,6 +97,11 @@ data:
     - "thanos"
     - "traefik-forward-auth-mgmt"
     - "kubetunnel"
+    managementSSOApps:
+    - "dex"
+    - "dex-k8s-authenticator"
+    - "traefik"
+    - "traefik-forward-auth-mgmt"
     attached:
       prerequisites:
         defaultApps:

--- a/services/kommander/0.8.0/defaults/cm.yaml
+++ b/services/kommander/0.8.0/defaults/cm.yaml
@@ -97,9 +97,10 @@ data:
     - "thanos"
     - "traefik-forward-auth-mgmt"
     - "kubetunnel"
-    managementSSOApps:
+    defaultManagementApps:
     - "dex"
     - "dex-k8s-authenticator"
+    - "reloader"
     - "traefik"
     - "traefik-forward-auth-mgmt"
     attached:


### PR DESCRIPTION
**What problem does this PR solve?**:
Set newly added kommander values to define set of default apps that should be deployed to the mgmt cluster workspace by default. these apps (sso, reloader for now) must be part of the minimal set of apps for kommander functionality and ability of users to access the UI

This goes along with https://github.com/mesosphere/kommander/pull/4421 which consumes this new field

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://d2iq.atlassian.net/browse/D2IQ-100424

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
