### PR TITLE
ci: Generate dev tags dynamically

### DIFF
--- a/.github/workflows/create-dev-tag.yml
+++ b/.github/workflows/create-dev-tag.yml
@@ -15,18 +15,41 @@ permissions:
   actions: write
 
 jobs:
+  generate-matrix:
+    runs-on:
+    - self-hosted
+    - small
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install NIX
+        uses: cachix/install-nix-action@v26
+
+      - name: Install devbox
+        uses: jetpack-io/devbox-install-action@v0.8.0
+        with:
+          enable-cache: true
+          skip-nix-installation: true
+
+      - name: Generate tag
+        run: |
+          # Overriding a variable that causes a conflict in legacy
+          # versions of gh-dkp
+          export GITHUB_REPOSITORY="kommander-applications"
+          OUT=$(devbox run -- make repo.supported-branches | sed -E 's/([^\]|^)"/\1\\"/g')
+          echo "::set-output name=matrix::$OUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
+
   create-dev-tag:
     runs-on:
     - self-hosted
     - small
     strategy:
       fail-fast: false
-      matrix:
-        branch:
-          - main
-          - release-2.5
-          - release-2.6
-          - release-2.7
+      matrix: fromJson(needs.generate-matrix.outputs.matrix)
 
     steps:
       - name: Checkout

--- a/make/repo.mk
+++ b/make/repo.mk
@@ -19,3 +19,7 @@ endif
 repo.dev.tag: ## Returns development tag
 repo.dev.tag: install-tool.gh-dkp
 	gh dkp generate dev-version --repository-owner $(GITHUB_ORG) --repository-name $(GITHUB_REPOSITORY)
+
+.PHONY: repo.supported-branches
+repo.supported-branches: install-tool.gh-dkp
+	gh dkp generate dev-versions --json | jq --raw-output --compact-output "[.releases[] | .branch_name]"


### PR DESCRIPTION
**What problem does this PR solve?**:
Let's generate dev version instead of hardcoding them.

Depends on https://github.com/mesosphere/gh-dkp/pull/451

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
