### PR TITLE
fix(release): Omit ai-nav helmrepos from bundle

### DIFF
--- a/common/helm-repositories/ai-navigator-repos.yaml
+++ b/common/helm-repositories/ai-navigator-repos.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: mesosphere.github.io-ai-navigator-cluster-info-api-charts
+  namespace: kommander-flux
+spec:
+  interval: 10m
+  timeout: 1m
+  url: "${helmMirrorURL:=https://mesosphere.github.io/ai-navigator-cluster-info-api}"
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: mesosphere.github.io-ai-navigator-cluster-info-agent-charts
+  namespace: kommander-flux
+spec:
+  interval: 10m
+  timeout: 1m
+  url: "${helmMirrorURL:=https://mesosphere.github.io/ai-navigator-cluster-info-agent}"

--- a/common/helm-repositories/kustomization.yaml
+++ b/common/helm-repositories/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ai-navigator-repos.yaml
   - bitnami.yaml
   - cert-manager.yaml
   - dashboard.yaml

--- a/common/helm-repositories/mesosphere-repos.yaml
+++ b/common/helm-repositories/mesosphere-repos.yaml
@@ -50,23 +50,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/dkp-insights-charts-attached}"
----
-apiVersion: source.toolkit.fluxcd.io/v1beta2
-kind: HelmRepository
-metadata:
-  name: mesosphere.github.io-ai-navigator-cluster-info-api-charts
-  namespace: kommander-flux
-spec:
-  interval: 10m
-  timeout: 1m
-  url: "${helmMirrorURL:=https://mesosphere.github.io/ai-navigator-cluster-info-api}"
----
-apiVersion: source.toolkit.fluxcd.io/v1beta2
-kind: HelmRepository
-metadata:
-  name: mesosphere.github.io-ai-navigator-cluster-info-agent-charts
-  namespace: kommander-flux
-spec:
-  interval: 10m
-  timeout: 1m
-  url: "${helmMirrorURL:=https://mesosphere.github.io/ai-navigator-cluster-info-agent}"

--- a/make/release.mk
+++ b/make/release.mk
@@ -11,8 +11,10 @@ release:
 	# the connected customers download the k-apps from GitHub where it is still present
 	git archive --format "tar.gz" -o $(ARCHIVE_NAME) \
 								  $(GIT_TAG) -- \
-								  common services charts ":(exclude)services/ai-navigator-app" \
-								  common services charts ":(exclude)services/ai-navigator-cluster-info-agent"
+								  common services charts \
+								  ":(exclude)common/helm-repositories/ai-navigator-repos.yaml" \
+								  ":(exclude)services/ai-navigator-app" \
+								  ":(exclude)services/ai-navigator-cluster-info-agent"
 	aws s3 cp --acl $(S3_ACL) $(ARCHIVE_NAME) s3://$(S3_BUCKET)/$(S3_PATH)/
 	echo "Published to $(PUBLISHED_URL)"
 ifeq (,$(findstring dev,$(GIT_TAG)))


### PR DESCRIPTION
**What problem does this PR solve?**:
Separate ai-nav helmrepos to separate file so we can exclude it from the bundle. I am depending on this kcli bug https://jira.nutanix.com/browse/D2IQ-97040 to continue to exist to ensure that the `kustomize` won't fail (kustomization.yaml specifies ai-nav file which is removed)

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
