### PR TITLE
fix: Fix Kubernetes Audit Dashboard failing in Grafana Logging v9+

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -93,12 +93,6 @@ resources:
       - license_path: LICENSE
         ref: v1.19.2-d2iq.1
         url: https://github.com/mesosphere/gitea
-  - container_image: docker.io/grafana/grafana:8.5.26
-    sources:
-      - license_path: LICENSE
-        notice_path: NOTICE.md
-        ref: v${image_tag}
-        url: https://github.com/grafana/grafana
   - container_image: docker.io/grafana/grafana:10.3.3
     sources:
       - license_path: LICENSE

--- a/services/fluent-bit/0.43.0/grafana-dashboards-logging/audit.json
+++ b/services/fluent-bit/0.43.0/grafana-dashboards-logging/audit.json
@@ -87,7 +87,10 @@
       "title": "Namespace",
       "transformations": [
         {
-          "id": "labelsToFields"
+          "id": "extractFields",
+          "options": {
+            "source": "labels"
+          }
         },
         {
           "id": "groupBy",
@@ -197,8 +200,10 @@
       "title": "Resource",
       "transformations": [
         {
-          "id": "labelsToFields",
-          "options": {}
+          "id": "extractFields",
+          "options": {
+            "source": "labels"
+          }
         },
         {
           "id": "groupBy",
@@ -264,7 +269,7 @@
       "title": "Audit log",
       "transformations": [
         {
-          "id": "labelsToFields",
+          "id": "extractFields",
           "options": {}
         },
         {
@@ -356,8 +361,10 @@
       "title": "Verb",
       "transformations": [
         {
-          "id": "labelsToFields",
-          "options": {}
+          "id": "extractFields",
+          "options": {
+            "source": "labels"
+          }
         },
         {
           "id": "groupBy",
@@ -448,8 +455,10 @@
       "title": "Username",
       "transformations": [
         {
-          "id": "labelsToFields",
-          "options": {}
+          "id": "extractFields",
+          "options": {
+            "source": "labels"
+          }
         },
         {
           "id": "groupBy",

--- a/services/grafana-logging/6.60.2/defaults/cm.yaml
+++ b/services/grafana-logging/6.60.2/defaults/cm.yaml
@@ -7,9 +7,8 @@ data:
   values.yaml: |
     ---
     priorityClassName: "dkp-critical-priority"
-    # pinning grafana to 8.5 since it appears that v9+ is causing the kubernetes audit dashboard to crash
     image:
-      tag: 8.5.26
+      tag: 10.3.3
     datasources:
       datasources.yaml:
         apiVersion: 1

--- a/services/grafana-logging/6.60.2/grafana.yaml
+++ b/services/grafana-logging/6.60.2/grafana.yaml
@@ -39,7 +39,7 @@ data:
   dashboardLink: "/dkp/logging/grafana"
   docsLink: "https://grafana.com/docs/"
   # Check https://artifacthub.io/packages/helm/grafana/grafana/6.58.6 for app version
-  version: "8.5.26"
+  version: "10.3.3"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/project-grafana-logging/6.60.2/defaults/cm.yaml
+++ b/services/project-grafana-logging/6.60.2/defaults/cm.yaml
@@ -9,7 +9,7 @@ data:
     priorityClassName: "dkp-critical-priority"
     # pinning grafana to 8.5 since it appears that v9+ is causing the kubernetes audit dashboard to crash
     image:
-      tag: 8.5.26
+      tag: 10.3.3
     datasources:
       datasources.yaml:
         apiVersion: 1


### PR DESCRIPTION
Cherry-pick changes in https://github.com/mesosphere/kommander-applications/pull/2119 to release-2.8 branch.

**What problem does this PR solve?**:
Kubernetes Audit Dashboard failing in Grafana Logging v9+

**Which issue(s) does this PR fix?**:
https://d2iq.atlassian.net/browse/D2IQ-99728


**Special notes for your reviewer**:
Upgraded the Grafana version to version 10.4.2 which is the latest version. 

Test result in Grafana 10.3.3


<img width="1920" alt="Screenshot 2024-04-11 at 3 57 18 PM" src="https://github.com/mesosphere/kommander-applications/assets/85924024/fdd04054-4bf4-40d3-a559-3a4812576d43">



