### PR TITLE
fix(grafana-logging): Fix OOM issue after upgrade to v9+

### DIFF
--- a/services/grafana-logging/6.60.2/defaults/cm.yaml
+++ b/services/grafana-logging/6.60.2/defaults/cm.yaml
@@ -71,10 +71,10 @@ data:
       # keep request = limit to keep this container in guaranteed class
       limits:
         cpu: 300m
-        memory: 100Mi
+        memory: 200Mi
       requests:
         cpu: 200m
-        memory: 100Mi
+        memory: 200Mi
 
     readinessProbe:
       httpGet:

--- a/services/project-grafana-logging/6.60.2/defaults/cm.yaml
+++ b/services/project-grafana-logging/6.60.2/defaults/cm.yaml
@@ -69,10 +69,10 @@ data:
       # keep request = limit to keep this container in guaranteed class
       limits:
         cpu: 300m
-        memory: 100Mi
+        memory: 200Mi
       requests:
         cpu: 200m
-        memory: 100Mi
+        memory: 200Mi
 
     readinessProbe:
       httpGet:


### PR DESCRIPTION
Fix the Grafana logging out of memory issue after upgrade to v9+
The Grafana get OOM killed status and the pod is in the CrachBackLoopoff State which causing the 502 and 404 issue. 
<img width="1440" alt="Screenshot 2024-04-01 at 2 25 21 PM" src="https://github.com/mesosphere/kommander-applications/assets/85924024/79d0ab0f-3669-40f5-be4f-1b1482a7510f">

```
zihui.liu@C02F94FBML85 Desktop % k get pods -A | grep grafana-logging
kommander                           grafana-logging-68cf97499b-qvjvg                                    1/2     OOMKilled   8 (6m58s ago)   40m
```
After update the memory from 100Mi to 200Mi the issue has been solved. 
https://github.com/mesosphere/kommander-applications/blob/main/services/grafana-logging/6.60.2/defaults/cm.yaml#L75 
https://github.com/mesosphere/kommander-applications/blob/main/services/grafana-logging/6.60.2/defaults/cm.yaml#L78 
<img width="1435" alt="Screenshot 2024-04-01 at 2 25 49 PM" src="https://github.com/mesosphere/kommander-applications/assets/85924024/f086b1f2-9c71-442e-ac03-bc2e7403b292">
