### PR TITLE
refactor: cleanup and use constructor func

### DIFF
--- a/apptests/appscenarios/appscenarios.go
+++ b/apptests/appscenarios/appscenarios.go
@@ -22,33 +22,6 @@ type AppScenario interface {
 	Name() string                                    // scenario name
 }
 
-type List map[string]AppScenario
-
-// Install runs all the scenarios in the list and returns the first error encountered, if any.
-func (s List) Install(ctx context.Context, env *environment.Env) error {
-	for _, sc := range s {
-		if err := sc.Install(ctx, env); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Get returns the associated scenario for the given application name, or nil if it does not exist.
-func Get(application string) AppScenario {
-	s, ok := scenariosList[application]
-	if !ok {
-		return nil
-	}
-	return s
-}
-
-// Has checks if the associated scenario for the given application exist.
-func Has(application string) bool {
-	_, ok := scenariosList[application]
-	return ok
-}
-
 // absolutePathTo returns the absolute path to the given application directory.
 func absolutePathTo(application string) (string, error) {
 	wd, err := os.Getwd()
@@ -84,11 +57,6 @@ func absolutePathTo(application string) (string, error) {
 
 	return matches[0], nil
 
-}
-
-// This is the ScenarioList of all available scenarios.
-var scenariosList = List{
-	"reloader": reloader{},
 }
 
 // getTestDataDir gets the directory path for test data

--- a/apptests/appscenarios/reloader_test.go
+++ b/apptests/appscenarios/reloader_test.go
@@ -18,17 +18,18 @@ import (
 )
 
 var (
-	r                 reloader
+	r                 *reloader
 	hr                *fluxhelmv2beta2.HelmRelease
 	deploymentList    *appsv1.DeploymentList
 	reloaderContainer corev1.Container
+	err               error
 )
 
 var _ = Describe("Reloader Install Test", Ordered, Label("reloader", "install"), func() {
 
 	It("should install successfully with default config", func() {
-		r = reloader{}
-		err := r.Install(ctx, env)
+		r = NewReloader()
+		err = r.Install(ctx, env)
 		Expect(err).To(BeNil())
 
 		hr = &fluxhelmv2beta2.HelmRelease{
@@ -92,7 +93,7 @@ var _ = Describe("Reloader Install Test", Ordered, Label("reloader", "install"),
 
 var _ = Describe("Reloader Upgrade Test", Ordered, Label("reloader", "upgrade"), func() {
 	It("should install the previous version successfully", func() {
-		r = reloader{}
+		r = NewReloader()
 		err := r.InstallPreviousVersion(ctx, env)
 		Expect(err).To(BeNil())
 
@@ -126,7 +127,7 @@ var _ = Describe("Reloader Upgrade Test", Ordered, Label("reloader", "upgrade"),
 
 	It("should upgrade reloader successfully", func() {
 		// this is installing the latest version of the reloader
-		err := r.Install(ctx, env)
+		err := r.InstallPreviousVersion(ctx, env)
 		Expect(err).To(BeNil())
 
 		hr = &fluxhelmv2beta2.HelmRelease{
@@ -161,7 +162,7 @@ var _ = Describe("Reloader Upgrade Test", Ordered, Label("reloader", "upgrade"),
 	})
 })
 
-func reloaderTestReload(r reloader) {
+func reloaderTestReload(r *reloader) {
 	err := r.ApplyNginxConfigmap(ctx, env, "nginx-cm-old.yaml")
 	Expect(err).To(BeNil())
 

--- a/apptests/constants/apps.go
+++ b/apptests/constants/apps.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	CertManager = "cert-manager"
+	Reloader    = "reloader"
+)


### PR DESCRIPTION
**What problem does this PR solve?**:
some functions are there when we decided to not use ginkgo.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
