### PR TITLE
fix: Modify files in the release archive (#2154)

### DIFF
--- a/hack/build-archive.sh
+++ b/hack/build-archive.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euox pipefail
+
+ARCHIVE_NAME=$1
+
+dir=$(mktemp --directory)
+
+tar -xvf "${ARCHIVE_NAME}" --directory "$dir"
+yq 'del(.resources[] | select(. == "ai-navigator-repos.yaml"))' --inplace "$dir"/common/helm-repositories/kustomization.yaml
+
+# update the modified time
+tar -cvzf "${ARCHIVE_NAME}" -C "$dir" .
+
+# cleanup
+rm -rf "$dir"

--- a/make/release.mk
+++ b/make/release.mk
@@ -15,6 +15,7 @@ release:
 								  ":(exclude)common/helm-repositories/ai-navigator-repos.yaml" \
 								  ":(exclude)services/ai-navigator-app" \
 								  ":(exclude)services/ai-navigator-cluster-info-agent"
+	./hack/build-archive.sh $(ARCHIVE_NAME)
 	aws s3 cp --acl $(S3_ACL) $(ARCHIVE_NAME) s3://$(S3_BUCKET)/$(S3_PATH)/
 	echo "Published to $(PUBLISHED_URL)"
 ifeq (,$(findstring dev,$(GIT_TAG)))


### PR DESCRIPTION
* fix: Modify files in the release archive

* fix: Path to a script



---------

**What problem does this PR solve?**:
backports https://github.com/mesosphere/kommander-applications/pull/2154 to release-2.8

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
