### PR TITLE
feat: Add basic kubecost tests for install and upgrade

### DIFF
--- a/apptests/appscenarios/contants.go
+++ b/apptests/appscenarios/contants.go
@@ -10,4 +10,6 @@ const (
 
 	// Default path to upgrade k-apps repository
 	defaultUpgradeKAppsRepoPath = ".work/upgrade/kommander-applications"
+	// priority class names
+	dkpHighPriority = "dkp-high-priority"
 )

--- a/apptests/appscenarios/kubecost.go
+++ b/apptests/appscenarios/kubecost.go
@@ -1,0 +1,79 @@
+package appscenarios
+
+import (
+	"context"
+	"github.com/mesosphere/kommander-applications/apptests/environment"
+	"path/filepath"
+)
+
+type kubeCost struct{}
+
+func (r kubeCost) Name() string {
+	return "kubecost"
+}
+
+var _ AppScenario = (*reloader)(nil)
+
+func (r kubeCost) Install(ctx context.Context, env *environment.Env) error {
+	appPath, err := absolutePathTo(r.Name())
+	if err != nil {
+		return err
+	}
+
+	err = r.install(ctx, env, appPath)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func (r kubeCost) InstallPreviousVersion(ctx context.Context, env *environment.Env) error {
+	appPath, err := getkAppsUpgradePath(r.Name())
+	if err != nil {
+		return err
+	}
+
+	err = r.install(ctx, env, appPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r kubeCost) Upgrade(ctx context.Context, env *environment.Env) error {
+	appPath, err := absolutePathTo(r.Name())
+	if err != nil {
+		return err
+	}
+
+	err = r.install(ctx, env, appPath)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func (r kubeCost) install(ctx context.Context, env *environment.Env, appPath string) error {
+	// apply defaults configmaps first
+	defaultKustomization := filepath.Join(appPath, "/defaults")
+	err := env.ApplyKustomizations(ctx, defaultKustomization, map[string]string{
+		"releaseNamespace": kommanderNamespace,
+	})
+	if err != nil {
+		return err
+	}
+
+	// apply the kustomization for the helmrelease
+	releasePath := filepath.Join(appPath, "/")
+	err = env.ApplyKustomizations(ctx, releasePath, map[string]string{
+		"releaseNamespace": kommanderNamespace,
+	})
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/apptests/appscenarios/kubecost.go
+++ b/apptests/appscenarios/kubecost.go
@@ -2,6 +2,7 @@ package appscenarios
 
 import (
 	"context"
+	"github.com/mesosphere/kommander-applications/apptests/constants"
 	"github.com/mesosphere/kommander-applications/apptests/environment"
 	"path/filepath"
 )
@@ -9,7 +10,7 @@ import (
 type kubeCost struct{}
 
 func (r kubeCost) Name() string {
-	return "kubecost"
+	return constants.Karma
 }
 
 var _ AppScenario = (*reloader)(nil)

--- a/apptests/appscenarios/kubecost_test.go
+++ b/apptests/appscenarios/kubecost_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Installing kubecost", Ordered, Label("kubecost", "install"), f
 		Expect(err).To(BeNil())
 
 		for _, deployment := range deploymentList.Items {
-			Expect(deployment.Spec.Template.Spec.PriorityClassName).To(Equal("dkp-high-priority"))
+			Expect(deployment.Spec.Template.Spec.PriorityClassName).To(Equal(dkpHighPriority))
 		}
 	})
 

--- a/apptests/appscenarios/kubecost_test.go
+++ b/apptests/appscenarios/kubecost_test.go
@@ -1,0 +1,233 @@
+package appscenarios
+
+import (
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	fluxhelmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	apimeta "github.com/fluxcd/pkg/apis/meta"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Installing kubecost", Ordered, Label("kubecost", "install"), func() {
+
+	var (
+		kc             kubeCost
+		hr             *fluxhelmv2beta2.HelmRelease
+		deploymentList *appsv1.DeploymentList
+	)
+
+	It("should install successfully with default config", func() {
+		kc = kubeCost{}
+		err := kc.Install(ctx, env)
+		Expect(err).To(BeNil())
+
+		hr = &fluxhelmv2beta2.HelmRelease{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       fluxhelmv2beta2.HelmReleaseKind,
+				APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kc.Name(),
+				Namespace: kommanderNamespace,
+			},
+		}
+
+		// Check the status of the HelmReleases
+		Eventually(func() error {
+			err = k8sClient.Get(ctx, ctrlClient.ObjectKeyFromObject(hr), hr)
+			if err != nil {
+				return err
+			}
+
+			for _, cond := range hr.Status.Conditions {
+				if cond.Status == metav1.ConditionTrue &&
+					cond.Type == apimeta.ReadyCondition {
+					return nil
+				}
+			}
+			return fmt.Errorf("helm release not ready yet")
+		}).WithPolling(pollInterval).WithTimeout(5 * time.Minute).Should(Succeed())
+	})
+
+	It("should have a PriorityClass configured", func() {
+		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"helm.toolkit.fluxcd.io/name": kc.Name(),
+			},
+		})
+		Expect(err).To(BeNil())
+		listOptions := &ctrlClient.ListOptions{
+			LabelSelector: selector,
+		}
+		deploymentList = &appsv1.DeploymentList{}
+		err = k8sClient.List(ctx, deploymentList, listOptions)
+		Expect(err).To(BeNil())
+		Expect(deploymentList.Items).To(HaveLen(5))
+		Expect(err).To(BeNil())
+
+		for _, deployment := range deploymentList.Items {
+			Expect(deployment.Spec.Template.Spec.PriorityClassName).To(Equal("dkp-high-priority"))
+		}
+	})
+
+	It("should have access to the dashboard", func() {
+		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app.kubernetes.io/name": "cost-analyzer",
+			},
+		})
+		Expect(err).To(BeNil())
+		listOptions := &ctrlClient.ListOptions{
+			LabelSelector: selector,
+		}
+		podList := &corev1.PodList{}
+		err = k8sClient.List(ctx, podList, listOptions)
+		Expect(err).To(BeNil())
+		Expect(podList.Items).To(HaveLen(1))
+
+		res := restClientV1Pods.Get().Resource("pods").Namespace(podList.Items[0].Namespace).Name(podList.Items[0].Name + ":9090").SubResource("proxy").Suffix("").Do(ctx)
+		Expect(res.Error()).To(BeNil())
+
+		var statusCode int
+		res.StatusCode(&statusCode)
+		Expect(statusCode).To(Equal(200))
+
+		body, err := res.Raw()
+		Expect(err).To(BeNil())
+		Expect(string(body)).To(ContainSubstring("Kubecost"))
+	})
+
+})
+
+var _ = Describe("Upgrading kubecost", Ordered, Label("kubecost", "upgrade"), func() {
+	var (
+		kc kubeCost
+		hr *fluxhelmv2beta2.HelmRelease
+	)
+
+	It("should install the previous version successfully", func() {
+		kc = kubeCost{}
+		err := kc.InstallPreviousVersion(ctx, env)
+		Expect(err).To(BeNil())
+
+		hr = &fluxhelmv2beta2.HelmRelease{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       fluxhelmv2beta2.HelmReleaseKind,
+				APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kc.Name(),
+				Namespace: kommanderNamespace,
+			},
+		}
+
+		// Check the status of the HelmReleases
+		Eventually(func() error {
+			err = k8sClient.Get(ctx, ctrlClient.ObjectKeyFromObject(hr), hr)
+			if err != nil {
+				return err
+			}
+
+			for _, cond := range hr.Status.Conditions {
+				if cond.Status == metav1.ConditionTrue &&
+					cond.Type == apimeta.ReadyCondition {
+					return nil
+				}
+			}
+			return fmt.Errorf("helm release not ready yet")
+		}).WithPolling(pollInterval).WithTimeout(5 * time.Minute).Should(Succeed())
+	})
+
+	It("should have access to the dashboard before upgrade", func() {
+		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app.kubernetes.io/name": "cost-analyzer",
+			},
+		})
+		Expect(err).To(BeNil())
+		listOptions := &ctrlClient.ListOptions{
+			LabelSelector: selector,
+		}
+		podList := &corev1.PodList{}
+		err = k8sClient.List(ctx, podList, listOptions)
+		Expect(err).To(BeNil())
+		Expect(podList.Items).To(HaveLen(1))
+
+		res := restClientV1Pods.Get().Resource("pods").Namespace(podList.Items[0].Namespace).Name(podList.Items[0].Name + ":9090").SubResource("proxy").Suffix("").Do(ctx)
+		Expect(res.Error()).To(BeNil())
+
+		var statusCode int
+		res.StatusCode(&statusCode)
+		Expect(statusCode).To(Equal(200))
+
+		body, err := res.Raw()
+		Expect(err).To(BeNil())
+		Expect(string(body)).To(ContainSubstring("Kubecost"))
+	})
+
+	It("should upgrade kubecost successfully", func() {
+		err := kc.Upgrade(ctx, env)
+		Expect(err).To(BeNil())
+
+		hr = &fluxhelmv2beta2.HelmRelease{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       fluxhelmv2beta2.HelmReleaseKind,
+				APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kc.Name(),
+				Namespace: kommanderNamespace,
+			},
+		}
+
+		// Check the status of the HelmReleases
+		Eventually(func() error {
+			err = k8sClient.Get(ctx, ctrlClient.ObjectKeyFromObject(hr), hr)
+			if err != nil {
+				return err
+			}
+
+			for _, cond := range hr.Status.Conditions {
+				if cond.Status == metav1.ConditionTrue &&
+					cond.Type == apimeta.ReadyCondition {
+					return nil
+				}
+			}
+			return fmt.Errorf("helm release not ready yet")
+		}).WithPolling(pollInterval).WithTimeout(5 * time.Minute).Should(Succeed())
+	})
+
+	It("should have access to the dashboard after upgrade", func() {
+		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app.kubernetes.io/name": "cost-analyzer",
+			},
+		})
+		Expect(err).To(BeNil())
+		listOptions := &ctrlClient.ListOptions{
+			LabelSelector: selector,
+		}
+		podList := &corev1.PodList{}
+		err = k8sClient.List(ctx, podList, listOptions)
+		Expect(err).To(BeNil())
+		Expect(podList.Items).To(HaveLen(1))
+
+		res := restClientV1Pods.Get().Resource("pods").Namespace(podList.Items[0].Namespace).Name(podList.Items[0].Name + ":9090").SubResource("proxy").Suffix("").Do(ctx)
+		Expect(res.Error()).To(BeNil())
+
+		var statusCode int
+		res.StatusCode(&statusCode)
+		Expect(statusCode).To(Equal(200))
+
+		body, err := res.Raw()
+		Expect(err).To(BeNil())
+		Expect(string(body)).To(ContainSubstring("Kubecost"))
+	})
+})

--- a/apptests/appscenarios/suite_test.go
+++ b/apptests/appscenarios/suite_test.go
@@ -58,8 +58,8 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	//err := env.Destroy(ctx)
-	//Expect(err).ToNot(HaveOccurred())
+	err := env.Destroy(ctx)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 func TestApplications(t *testing.T) {

--- a/apptests/constants/apps.go
+++ b/apptests/constants/apps.go
@@ -1,6 +1,10 @@
 package constants
 
 const (
-	CertManager = "cert-manager"
-	Reloader    = "reloader"
+	CertManager  = "cert-manager"
+	Karma        = "karma"
+	KubeCost     = "kubecost"
+	Reloader     = "reloader"
+	Traefik      = "traefik"
+	KarmaTraefik = "karma-traefik"
 )


### PR DESCRIPTION
**What problem does this PR solve?**:

Adds basic application specific tests for Kubecost. Covers upgrade and install.

**Which issue(s) does this PR fix?**:

https://jira.nutanix.com/browse/D2IQ-100304


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
