### PR TITLE
ci: Fix dev version generation

### DIFF
--- a/.github/workflows/create-dev-tag.yml
+++ b/.github/workflows/create-dev-tag.yml
@@ -16,6 +16,9 @@ permissions:
 
 jobs:
   generate-matrix:
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
     runs-on:
     - self-hosted
     - small
@@ -34,22 +37,24 @@ jobs:
           skip-nix-installation: true
 
       - name: Generate tag
+        id: set-matrix
         run: |
-          # Overriding a variable that causes a conflict in legacy
-          # versions of gh-dkp
           export GITHUB_REPOSITORY="kommander-applications"
-          OUT=$(devbox run -- make repo.supported-branches | sed -E 's/([^\]|^)"/\1\\"/g')
-          echo "::set-output name=matrix::$OUT"
+          OUT=$(devbox run -- make repo.supported-branches | tail -n 1)
+          echo "matrix=$OUT" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
 
   create-dev-tag:
+    needs: generate-matrix
+
     runs-on:
     - self-hosted
     - small
     strategy:
       fail-fast: false
-      matrix: fromJson(needs.generate-matrix.outputs.matrix)
+      matrix:
+        branch: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
**What problem does this PR solve?**:
Fix the dev taggin job

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
