### PR TITLE
ci: Exclude apptests dir in list-images.sh script

### DIFF
--- a/hack/list-images.sh
+++ b/hack/list-images.sh
@@ -21,7 +21,7 @@ while IFS= read -r repofile; do
   envsubst -no-unset -no-digit -i "${repofile}" | \
     gojq --yaml-input --raw-output 'select(.spec.url != null) | (.metadata.name | gsub("\\."; "-"))+" "+.spec.url' | \
     xargs --max-lines=1 --no-run-if-empty -- helm repo add --force-update >&2
-done < <(grep --recursive --max-count=1 --files-with-matches '^kind: HelmRepository')
+done < <(grep --recursive --exclude-dir=apptests --max-count=1 --files-with-matches '^kind: HelmRepository')
 
 helm repo update >&2
 


### PR DESCRIPTION
**What problem does this PR solve?**:

Exclude the `apptests` dir in the `grep` part of the `list-images.sh` script. These charts/repos/images are added to the kommander install and are causing issues with the `HelmReleases` that exist in the `apptests` directory. 


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

Testing by overriding the kommander-applications` dir in this temp PR: https://github.com/mesosphere/kommander/pull/4500


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
