### PR TITLE
refactor: use traefik object to install traefik

### DIFF
--- a/apptests/appscenarios/karma.go
+++ b/apptests/appscenarios/karma.go
@@ -70,21 +70,3 @@ func (k karma) install(ctx context.Context, env *environment.Env, appPath string
 
 	return err
 }
-
-func (k karma) ApplyTraefikOverrideCM(ctx context.Context, env *environment.Env, cmName string) error {
-	testDataPath, err := getTestDataDir()
-	if err != nil {
-		return err
-	}
-	cmPath := filepath.Join(testDataPath, "traefik", "override-cm.yaml")
-	err = env.ApplyYAML(ctx, cmPath, map[string]string{
-		"name":      cmName,
-		"namespace": kommanderNamespace,
-	})
-	if err != nil {
-		return err
-	}
-
-	return nil
-
-}


### PR DESCRIPTION
**What problem does this PR solve?**:
use `traefik` object to install traefik in karma test

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
