### PR TITLE
chore: bump centralized grafana resource limits

### DIFF
--- a/services/centralized-grafana/48.3.2/defaults/cm.yaml
+++ b/services/centralized-grafana/48.3.2/defaults/cm.yaml
@@ -97,13 +97,12 @@ data:
         type: ClusterIP
         port: 80
       resources:
-        # keep request = limit to keep this container in guaranteed class
         limits:
-          cpu: 300m
-          memory: 100Mi
+          cpu: 2000m
+          memory: 10922Mi
         requests:
           cpu: 200m
-          memory: 100Mi
+          memory: 200Mi
 
       rbac:
         pspUseAppArmor: false


### PR DESCRIPTION
**What problem does this PR solve?**:
after upgrading to grafana 10, the default memory limit is no longer enough. KPS k-app has been bumped but centralized grafana resource limit bump was missed.

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-100776


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
