### PR TITLE
chore: drop unused fluxcd api import

### DIFF
--- a/apptests/flux/apply.go
+++ b/apptests/flux/apply.go
@@ -26,11 +26,7 @@ import (
 	"github.com/fluxcd/cli-utils/pkg/kstatus/polling"
 	"github.com/fluxcd/flux2/v2/pkg/manifestgen/kustomization"
 	helmv2b2 "github.com/fluxcd/helm-controller/api/v2beta2"
-	imageautov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
-	imagereflectv1 "github.com/fluxcd/image-reflector-controller/api/v1beta2"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1"
-	notificationv1b2 "github.com/fluxcd/notification-controller/api/v1beta2"
 	runclient "github.com/fluxcd/pkg/runtime/client"
 	"github.com/fluxcd/pkg/ssa"
 	"github.com/fluxcd/pkg/ssa/normalize"
@@ -156,10 +152,6 @@ func NewScheme() *apiruntime.Scheme {
 	_ = sourcev1.AddToScheme(scheme)
 	_ = kustomizev1.AddToScheme(scheme)
 	_ = helmv2b2.AddToScheme(scheme)
-	_ = notificationv1.AddToScheme(scheme)
-	_ = notificationv1b2.AddToScheme(scheme)
-	_ = imagereflectv1.AddToScheme(scheme)
-	_ = imageautov1.AddToScheme(scheme)
 	_ = traefikv1a1.AddToScheme(scheme)
 	return scheme
 }

--- a/apptests/go.mod
+++ b/apptests/go.mod
@@ -10,10 +10,7 @@ require (
 	github.com/fluxcd/cli-utils v0.36.0-flux.7
 	github.com/fluxcd/flux2/v2 v2.2.3
 	github.com/fluxcd/helm-controller/api v0.37.4
-	github.com/fluxcd/image-automation-controller/api v0.37.1
-	github.com/fluxcd/image-reflector-controller/api v0.31.2
 	github.com/fluxcd/kustomize-controller/api v1.2.2
-	github.com/fluxcd/notification-controller/api v1.2.4
 	github.com/fluxcd/pkg/apis/meta v1.5.0
 	github.com/fluxcd/pkg/runtime v0.47.1
 	github.com/fluxcd/pkg/ssa v0.39.1

--- a/apptests/go.sum
+++ b/apptests/go.sum
@@ -114,14 +114,8 @@ github.com/fluxcd/flux2/v2 v2.2.3 h1:sVeYLHIDGMTkT1ibbdz52z5y9pr456XSRULsehxqEXI
 github.com/fluxcd/flux2/v2 v2.2.3/go.mod h1:vDwnGaRVqeChwgg2eo6MtoF8NJ0OmBnE2tfRPa3PZrQ=
 github.com/fluxcd/helm-controller/api v0.37.4 h1:rkBMqYXexyf1s5BS8QpxGi691DsCi+yugIFCM5fNKLU=
 github.com/fluxcd/helm-controller/api v0.37.4/go.mod h1:KFdP5Lbrc4Vv+Jt4xRj6UUo3qiwdBqBPl1xiiAnBe9c=
-github.com/fluxcd/image-automation-controller/api v0.37.1 h1:zi1VfPoGuHsNtyTpueKbr4b/c+Ms7HjFocTAmixmYno=
-github.com/fluxcd/image-automation-controller/api v0.37.1/go.mod h1:7p0woxB275YzhdctzbxVMck0/hZt45bm0K12A0ABldo=
-github.com/fluxcd/image-reflector-controller/api v0.31.2 h1:s16ewwfuLBYuh8hENuVgU8SYsSNxRaA4f+AD60/+les=
-github.com/fluxcd/image-reflector-controller/api v0.31.2/go.mod h1:tV7g+KXQL3W8w5+fRJU7ubVGc4QAfx1C7XI5qrQvA3U=
 github.com/fluxcd/kustomize-controller/api v1.2.2 h1:LXRa2181usLsDkAJ86i/CnvCyPwhLcFUw9jBnXxTFJ4=
 github.com/fluxcd/kustomize-controller/api v1.2.2/go.mod h1:dfAaPQuuoWfExyWaeO7Kj2ZtfKQ4nDcJrt7AeAFlLZs=
-github.com/fluxcd/notification-controller/api v1.2.4 h1:H/C8XW5boncf8rzJjSe/MCr186Hgvw+arPat9XOaRlw=
-github.com/fluxcd/notification-controller/api v1.2.4/go.mod h1:LeHtKKTI3ew+FXY0oYtYqM68UYOArfBa/cy4pxAzN4M=
 github.com/fluxcd/pkg/apis/acl v0.3.0 h1:UOrKkBTOJK+OlZX7n8rWt2rdBmDCoTK+f5TY2LcZi8A=
 github.com/fluxcd/pkg/apis/acl v0.3.0/go.mod h1:WVF9XjSMVBZuU+HTTiSebGAWMgM7IYexFLyVWbK9bNY=
 github.com/fluxcd/pkg/apis/kustomize v1.3.0 h1:qvB46CfaOWcL1SyR2RiVWN/j7/035D0OtB1ltLN7rgI=


### PR DESCRIPTION
**What problem does this PR solve?**:
currently we are importing fluxcd notification and image controllers API, which we currently don't use

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
