### PR TITLE
fix: add a defaults Kustomization expected by the CLI to git-operator

### DIFF
--- a/services/git-operator/0.0.0/defaults/kustomization.yaml
+++ b/services/git-operator/0.0.0/defaults/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []


### PR DESCRIPTION
**What problem does this PR solve?**:

Allows to use the app installation code in the CLI

**Which issue(s) does this PR fix?**:
Yet another prerequisite to https://jira.nutanix.com/browse/NCN-99979

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
