### PR TITLE
fix: override with a higher memory limit

### DIFF
--- a/services/velero/6.0.0/defaults/cm.yaml
+++ b/services/velero/6.0.0/defaults/cm.yaml
@@ -7,6 +7,15 @@ data:
   values.yaml: |
     ---
     priorityClassName: "dkp-critical-priority"
+    resources:
+      # these are from the chart defaults
+      # except memory limit, which the default 512Mi can be short when it's during a restoration run
+      requests:
+        cpu: 500m
+        memory: 128Mi
+      limits:
+        cpu: 1000m
+        memory: 2Gi
     configuration:
       backupStorageLocation:
         - bucket: dkp-velero


### PR DESCRIPTION
and also explicitly put the chart defaults down in our default CM

**What problem does this PR solve?**:
velero can be OOM killed in restoration process

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-100937

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
