### PR TITLE
ci: add (re)open events for prs and handle 2+ apps

### DIFF
--- a/.github/workflows/application-test-scenario-install.yaml
+++ b/.github/workflows/application-test-scenario-install.yaml
@@ -2,8 +2,8 @@ name: Application Specific Test - Install
 on:
   workflow_dispatch:
     inputs:
-      app:
-        description: 'The kommander application to test, e.g. reloader,kube-prometheus-stack'
+      apps:
+        description: 'The ginkgo label filter query of kommander applications to test, e.g. reloader, or reloader || cert-manager'
         required: true
         type: string
       version_ref:
@@ -12,8 +12,8 @@ on:
         type: string
   workflow_call:
     inputs:
-      app:
-        description: 'The kommander application to test, e.g. reloader,kube-prometheus-stack'
+      apps:
+        description: 'The ginkgo label filter query of kommander applications to test, e.g. reloader, or reloader || cert-manager'
         required: true
         type: string
       version_ref:
@@ -41,7 +41,7 @@ jobs:
       working-directory: apptests
       run: go install github.com/onsi/ginkgo/v2/ginkgo
 
-    - name: Run ${{ github.event.inputs.app }} install Test
+    - name: Run install Test
       working-directory: apptests
       run: |
-        ginkgo --label-filter="install && ${{ inputs.app }}" appscenarios
+        ginkgo --v --label-filter="install && (${{ inputs.apps }})" appscenarios

--- a/.github/workflows/application-test-scenario-upgrade.yaml
+++ b/.github/workflows/application-test-scenario-upgrade.yaml
@@ -2,8 +2,8 @@ name: Application Specific Test - Upgrade
 on:
   workflow_dispatch:
     inputs:
-      app:
-        description: 'The kommander application to test, e.g. reloader,kube-prometheus-stack'
+      apps:
+        description: 'The ginkgo label filter query of kommander applications to test, e.g. reloader, or reloader || cert-manager'
         required: true
         type: string
       from_version_ref:
@@ -16,8 +16,8 @@ on:
         type: string
   workflow_call:
     inputs:
-      app:
-        description: 'The kommander application to test, e.g. reloader,kube-prometheus-stack'
+      apps:
+        description: 'The ginkgo label filter query of kommander applications to test, e.g. reloader, or reloader || cert-manager'
         required: true
         type: string
       from_version_ref:
@@ -58,7 +58,7 @@ jobs:
       working-directory: apptests
       run: go install github.com/onsi/ginkgo/v2/ginkgo
 
-    - name: Run ${{ inputs.app }} upgrade Test
+    - name: Run upgrade Test
       working-directory: apptests
       run: |
-        ginkgo --label-filter="upgrade && ${{ inputs.app }}" appscenarios
+        ginkgo --v --label-filter="upgrade && (${{ inputs.apps }})" appscenarios

--- a/.github/workflows/application-test.yaml
+++ b/.github/workflows/application-test.yaml
@@ -141,10 +141,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: ${{ fromJson(needs.setup-pr.outputs.apps) }}
+        apps: ${{ fromJson(needs.setup-pr.outputs.apps) }}
     with:
       version_ref: ${{ github.head_ref }}
-      app: ${{ matrix.app }}
+      apps: ${{ matrix.apps }}
     secrets: inherit
 
   trigger-tests-all-apps-install-ondemand:
@@ -154,10 +154,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: ${{ fromJson(needs.setup-all-apps.outputs.apps) }}
+        apps: ${{ fromJson(needs.setup-all-apps.outputs.apps) }}
     with:
       version_ref: ${{ github.event.inputs.version_ref }}
-      app: ${{ matrix.app }}
+      apps: ${{ matrix.apps }}
 
   trigger-tests-all-apps-install-push:
     needs: setup-all-apps
@@ -166,10 +166,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: ${{ fromJson(needs.setup-all-apps.outputs.apps) }}
+        apps: ${{ fromJson(needs.setup-all-apps.outputs.apps) }}
     with:
       version_ref: "main"
-      app: ${{ matrix.app }}
+      apps: ${{ matrix.apps }}
 
   trigger-upgrade-tests-pr:
     needs:
@@ -180,9 +180,9 @@ jobs:
       fail-fast: false
       matrix:
         from: ${{ fromJson(needs.generate-upgrade-versions.outputs.from_versions) }}
-        app: ${{ fromJson(needs.setup-pr.outputs.apps) }}
+        apps: ${{ fromJson(needs.setup-pr.outputs.apps) }}
     with:
-      app: ${{ matrix.app }}
+      apps: ${{ matrix.apps }}
       from_version_ref: ${{ matrix.from }}
       to_version_ref: ${{ needs.generate-upgrade-versions.outputs.to_version }}
     secrets: inherit
@@ -197,9 +197,9 @@ jobs:
       fail-fast: false
       matrix:
         from: ${{ fromJson(needs.generate-upgrade-versions.outputs.from_versions) }}
-        app: ${{ fromJson(needs.setup-all-apps.outputs.apps) }}
+        apps: ${{ fromJson(needs.setup-all-apps.outputs.apps) }}
     with:
-      app: ${{ matrix.app }}
+      apps: ${{ matrix.apps }}
       from_version_ref: ${{ matrix.from }}
       to_version_ref: ${{ needs.generate-upgrade-versions.outputs.to_version }}
     secrets: inherit

--- a/.github/workflows/application-test.yaml
+++ b/.github/workflows/application-test.yaml
@@ -12,7 +12,7 @@ on:
         default: 'main'
         type: string
   pull_request:
-    types: [synchronize, labeled]
+    types: [synchronize, labeled, opened, reopened]
   push:
     branches:
       - main


### PR DESCRIPTION
for workflow dispatch

**What problem does this PR solve?**:
right not it doesnt trigger upon new PRs. also it cannot handle more than 1 app

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
