### PR TITLE
feat: add an Ingress for git-operator

### DIFF
--- a/services/git-operator/0.0.0/git-operator.yaml
+++ b/services/git-operator/0.0.0/git-operator.yaml
@@ -28,6 +28,11 @@ spec:
   prune: true
   timeout: 1m
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: git-operator-system
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/services/git-operator/0.0.0/git-operator.yaml
+++ b/services/git-operator/0.0.0/git-operator.yaml
@@ -27,3 +27,24 @@ spec:
   targetNamespace: git-operator-system
   prune: true
   timeout: 1m
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: kommander-stripprefixes@kubernetescrd
+    traefik.ingress.kubernetes.io/router.tls: "true"
+  name: git-operator-git
+  namespace: git-operator-system
+spec:
+  ingressClassName: kommander-traefik
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: git-operator-git
+            port:
+              name: http
+        path: /dkp/kommander/git-operator
+        pathType: Prefix

--- a/services/traefik/27.0.2/defaults/cm.yaml
+++ b/services/traefik/27.0.2/defaults/cm.yaml
@@ -58,9 +58,9 @@ data:
                   - /dkp/api-server
                   - /dkp/kommander/ceph-dashboard
                   - /dkp/kommander/dashboard
+                  - /dkp/kommander/git-operator
                   - /dkp/kommander/gitserver
                   - /dkp/kommander/git
-                  - /dkp/kommander/git-operator
                   - /dkp/kommander/helm-mirror
                   - /dkp/kommander/kubecost/frontend
                   - /dkp/kommander/kubecost/query

--- a/services/traefik/27.0.2/defaults/cm.yaml
+++ b/services/traefik/27.0.2/defaults/cm.yaml
@@ -60,6 +60,7 @@ data:
                   - /dkp/kommander/dashboard
                   - /dkp/kommander/gitserver
                   - /dkp/kommander/git
+                  - /dkp/kommander/git-operator
                   - /dkp/kommander/helm-mirror
                   - /dkp/kommander/kubecost/frontend
                   - /dkp/kommander/kubecost/query


### PR DESCRIPTION
**What problem does this PR solve?**:
Makes it possible for Flux on attached clusters to access the platform Git repository in GitOperator-based installations. 

To avoid complicating migration from Gitea (which is exposed using  the `dkp/kommander/git` prefix), GitOperator is exposed using a different prefix.

**Which issue(s) does this PR fix?**:
- Prerequisite to https://jira.nutanix.com/browse/NCN-100835

**Special notes for your reviewer**:
Will be used by https://github.com/mesosphere/kommander/pull/4623

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
