### PR TITLE
fix: gfd no longer uses its own image

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -411,11 +411,6 @@ resources:
       - license_path: validator/LICENSE
         ref: ${image_tag}
         url: https://github.com/NVIDIA/gpu-operator
-  - container_image: nvcr.io/nvidia/gpu-feature-discovery:v0.15.0-ubi8
-    sources:
-      - license_path: LICENSE
-        ref: ${image_tag%-ubi8}
-        url: https://github.com/NVIDIA/k8s-device-plugin
   - container_image: nvcr.io/nvidia/gpu-operator:v24.3.0
     sources:
       - license_path: LICENSE

--- a/services/nvidia-gpu-operator/24.3.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.3.0/defaults/cm.yaml
@@ -22,6 +22,8 @@ data:
       # https://github.com/NVIDIA/gpu-operator/issues/72#issuecomment-742023528
       version: v1.15.0-ubuntu20.04
     gfd:
+      # gfd is no longer published a standalone helm chart or image and instead uses
+      # the k8s-device-plugin image.
       enabled: true
       version: v0.15.0-ubi8
     dcgm:

--- a/services/nvidia-gpu-operator/24.3.0/helmrelease/extra-images.txt
+++ b/services/nvidia-gpu-operator/24.3.0/helmrelease/extra-images.txt
@@ -1,4 +1,3 @@
-nvcr.io/nvidia/gpu-feature-discovery:{{ .Values.gfd.version }}
 nvcr.io/nvidia/k8s/container-toolkit:{{ regexReplaceAllLiteral "-.+$" .Values.toolkit.version "" }}-ubuntu20.04
 nvcr.io/nvidia/k8s/container-toolkit:{{ regexReplaceAllLiteral "-.+$" .Values.toolkit.version "" }}-ubi8
 nvcr.io/nvidia/cloud-native/gpu-operator-validator:{{ .Values.validator.version }}


### PR DESCRIPTION
**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
