### PR TITLE
feat: Bump k8s and kubectl to 1.29.6

### DIFF
--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -7,7 +7,7 @@ k8s_versions:
   - 1.26.6
   - 1.27.6
   - 1.28.7
-  - 1.29.4
+  - 1.29.6
   - 1.30.1
 
 # paths to load (in that order)

--- a/apptests/appscenarios/contants.go
+++ b/apptests/appscenarios/contants.go
@@ -21,5 +21,5 @@ const (
 
 	// Velero constants
 	kubetoolsImageRepository = "bitnami/kubectl"
-	kubetoolsImageTag        = "1.29.2"
+	kubetoolsImageTag        = "1.29.6"
 )

--- a/common/build/list-images-values.yaml
+++ b/common/build/list-images-values.yaml
@@ -1,2 +1,3 @@
 secretName: unused
 commonName: unused
+kubectlImage: bitnami/kubectl:1.29.6

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -42,7 +42,7 @@ ignore:
   #     - url: https://github.com/bitnami/bitnami-docker-kubectl
   #       ref: ${image_tag}-debian-10-r31
   #       license_path: LICENSE
-  - docker.io/bitnami/kubectl:1.29.2
+  - docker.io/bitnami/kubectl:1.29.6
 
   # Fossa cannot scan C/CPP projects
   # See: https://docs.fossa.com/docs/c-cpp

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -44,6 +44,11 @@ ignore:
   #       license_path: LICENSE
   - docker.io/bitnami/kubectl:1.29.6
 
+  # This is getting included because cert-federation and cluster-observer charts are dynamically deployed with
+  # override values via Kommander controllers. So, the default kubectl image as defined in the chart's values.yaml
+  # is getting included here, even though the image is not used in the cluster.
+  - docker.io/bitnami/kubectl:1.29.2
+
   # Fossa cannot scan C/CPP projects
   # See: https://docs.fossa.com/docs/c-cpp
   # - container_image: docker.io/curlimages/curl:7.88.1

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -44,11 +44,6 @@ ignore:
   #       license_path: LICENSE
   - docker.io/bitnami/kubectl:1.29.6
 
-  # This is getting included because cert-federation and cluster-observer charts are dynamically deployed with
-  # override values via Kommander controllers. So, the default kubectl image as defined in the chart's values.yaml
-  # is getting included here, even though the image is not used in the cluster.
-  - docker.io/bitnami/kubectl:1.29.2
-
   # Fossa cannot scan C/CPP projects
   # See: https://docs.fossa.com/docs/c-cpp
   # - container_image: docker.io/curlimages/curl:7.88.1

--- a/services/ai-navigator-app/0.2.2/defaults/cm.yaml
+++ b/services/ai-navigator-app/0.2.2/defaults/cm.yaml
@@ -116,4 +116,4 @@ data:
     tolerations: []
 
     affinity: {}
-    kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}
+    kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}

--- a/services/centralized-kubecost/0.37.3/defaults/cm.yaml
+++ b/services/centralized-kubecost/0.37.3/defaults/cm.yaml
@@ -8,6 +8,7 @@ data:
     ---
     hooks:
       clusterID:
+        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
         priorityClassName: dkp-high-priority
 
     cost-analyzer:

--- a/services/centralized-kubecost/0.37.3/post-install-jobs/post-install-jobs.yaml
+++ b/services/centralized-kubecost/0.37.3/post-install-jobs/post-install-jobs.yaml
@@ -42,7 +42,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
           command:
             - sh
             - -c

--- a/services/centralized-kubecost/0.37.3/release/release.yaml
+++ b/services/centralized-kubecost/0.37.3/release/release.yaml
@@ -73,7 +73,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
           command:
             - sh
             - "-c"

--- a/services/dex/2.13.12/defaults/cm.yaml
+++ b/services/dex/2.13.12/defaults/cm.yaml
@@ -7,7 +7,7 @@ data:
   values.yaml: |-
     ---
     priorityClassName: "dkp-critical-priority"
-    kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
+    kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
     image: mesosphere/dex
     imageTag: v2.37.0-d2iq.4
     resources:

--- a/services/dkp-insights-management/1.1.1/defaults/cm.yaml
+++ b/services/dkp-insights-management/1.1.1/defaults/cm.yaml
@@ -34,7 +34,7 @@ data:
     insightsCRIngress:
       globalRateLimitAverageQPS: 100
       globalRateLimitBurst: 100
-    kubectlImage: bitnami/kubectl:1.29.2
+    kubectlImage: bitnami/kubectl:1.29.6
     managementCM:
       backendTokenTTL: 1h
       insightsTTL: 72h

--- a/services/dkp-insights/1.1.2/defaults/cm.yaml
+++ b/services/dkp-insights/1.1.2/defaults/cm.yaml
@@ -413,7 +413,7 @@ data:
             cpu: 100m
             memory: 512Mi
       schedule: '@every 35m'
-    kubectlImage: bitnami/kubectl:1.29.2
+    kubectlImage: bitnami/kubectl:1.29.6
     nova:
       baseEvaluationTimeout: 1m
       enabled: true

--- a/services/grafana-loki/0.78.5/grafana-loki-pre-install-jobs/pre-install.yaml
+++ b/services/grafana-loki/0.78.5/grafana-loki-pre-install-jobs/pre-install.yaml
@@ -46,7 +46,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: pre-install
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
           command:
             - sh
             - -c

--- a/services/istio/1.21.1/defaults/cm.yaml
+++ b/services/istio/1.21.1/defaults/cm.yaml
@@ -30,7 +30,7 @@ data:
           prometheus.kommander.d2iq.io/select: "true"
     global:
       image: ${kubetoolsImageRepository:=bitnami/kubectl}
-      tag: ${kubetoolsImageTag:=1.29.2}
+      tag: ${kubetoolsImageTag:=1.29.6}
       priorityClassName: "dkp-critical-priority"
     operator:
       # expose metrics for prometheus scraping

--- a/services/knative/1.10.5/defaults/cm.yaml
+++ b/services/knative/1.10.5/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
     global:
       priorityClassName: "dkp-high-priority"
       image: ${kubetoolsImageRepository:=bitnami/kubectl}
-      tag: ${kubetoolsImageTag:=1.29.2}
+      tag: ${kubetoolsImageTag:=1.29.6}
     eventing:
       enabled: false
     eventing-sources:

--- a/services/kommander/0.12.0/dynamic-helmreleases/cluster-observer/list-images-values.yaml
+++ b/services/kommander/0.12.0/dynamic-helmreleases/cluster-observer/list-images-values.yaml
@@ -1,0 +1,2 @@
+hooks:
+  kubectlImage: "bitnami/kubectl:1.29.6"

--- a/services/kube-prometheus-stack/48.3.2/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.2/defaults/cm.yaml
@@ -22,7 +22,7 @@ data:
     mesosphereResources:
       create: true
       hooks:
-        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
+        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
       rules:
         # addon alert rules are defaulted to false to prevent potential misfires if addons
         # are disabled.

--- a/services/kubecost/0.37.3/defaults/cm.yaml
+++ b/services/kubecost/0.37.3/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
     ---
     hooks:
       clusterID:
-        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
+        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
         priorityClassName: dkp-high-priority
 
     cost-analyzer:

--- a/services/kubefed/0.10.5/defaults/cm.yaml
+++ b/services/kubefed/0.10.5/defaults/cm.yaml
@@ -35,7 +35,7 @@ data:
       postInstallJob:
         repository: bitnami
         image: kubectl
-        tag: 1.29.2
+        tag: 1.29.6
     webhook:
       annotations:
         secret.reloader.stakater.com/reload: "kubefed-root-ca"

--- a/services/kubetunnel/0.0.33/defaults/cm.yaml
+++ b/services/kubetunnel/0.0.33/defaults/cm.yaml
@@ -17,7 +17,7 @@ data:
     hooks:
       kubectlImage:
         repository: "${kubetoolsImageRepository:=bitnami/kubectl}"
-        tag: "${kubetoolsImageTag:=1.29.2}"
+        tag: "${kubetoolsImageTag:=1.29.6}"
     controller:
       manager:
         resources:

--- a/services/project-grafana-loki/0.78.5/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.78.5/defaults/cm.yaml
@@ -26,6 +26,9 @@ data:
     ## END of dkp specific config overrides                           ##
     ####################################################################
 
+    # this is used in object-bucket-claims overrides
+    kubectlImage: bitnami/kubectl:1.29.6
+
     loki:
       ingesterFullname: loki-ingester
       annotations:

--- a/services/rook-ceph-cluster/1.14.2/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.14.2/defaults/cm.yaml
@@ -241,6 +241,9 @@ data:
           cpu: "500m"
           memory: "100Mi"
 
+    # this is used in object-bucket-claims overrides
+    kubectlImage: bitnami/kubectl:1.29.6
+
     #################################################################
     ## BEGIN NKP specific config overrides                         ##
     ## This is added as a workaround to use the same configmap for ##

--- a/services/rook-ceph-cluster/1.14.2/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.14.2/pre-install/ceph-crd-check.yaml
@@ -47,7 +47,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: pre-install
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
           command:
             - sh
             - -c
@@ -57,7 +57,7 @@ spec:
                 sleep 30
               done
         - name: pre-upgrade
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
           command:
             - sh
             - -c

--- a/services/thanos/15.4.1/jobs/jobs.yaml
+++ b/services/thanos/15.4.1/jobs/jobs.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
           command:
             - sh
             - "-c"

--- a/services/traefik/27.0.2/defaults/cm.yaml
+++ b/services/traefik/27.0.2/defaults/cm.yaml
@@ -39,7 +39,7 @@ data:
         app: traefik
       initContainers:
       - name: initialize-middleware
-        image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.2}"
+        image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
         command:
           - bash
         args:

--- a/services/velero/6.6.0/defaults/cm.yaml
+++ b/services/velero/6.6.0/defaults/cm.yaml
@@ -56,4 +56,4 @@ data:
       image:
         # If we don't override the version here, upstream chart will pull an image dynamically based on k8s cluster version.
         # which makes it harder to build airgapped tar bundles. So to make bundle collection predictable, we override the tag here.
-        tag: "${kubetoolsImageTag:=1.29.2}"
+        tag: "${kubetoolsImageTag:=1.29.6}"

--- a/services/velero/6.6.0/velero-pre-install.yaml
+++ b/services/velero/6.6.0/velero-pre-install.yaml
@@ -19,4 +19,4 @@ spec:
     substitute:
       releaseNamespace: ${releaseNamespace}
       kubetoolsImageRepository: ${kubetoolsImageRepository:=bitnami/kubectl}
-      kubetoolsImageTag: ${kubetoolsImageTag:=1.29.2}
+      kubetoolsImageTag: ${kubetoolsImageTag:=1.29.6}


### PR DESCRIPTION
**What problem does this PR solve?**:
bump k8s to 1.29.6
bump kubectl image in apps to 1.29.6

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-101202

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
