### PR TITLE
fix: wrap the update call with retry

### DIFF
--- a/apptests/appscenarios/rookceph.go
+++ b/apptests/appscenarios/rookceph.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mesosphere/kommander-applications/apptests/environment"
 	"github.com/mesosphere/kommander-applications/apptests/flux"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -219,7 +220,10 @@ func (r rookCeph) applyRookCephOverrideCM(ctx context.Context, env *environment.
 		Kind: "ConfigMap",
 		Name: "rook-ceph-cluster-overrides",
 	})
-	err = genericClient.Update(ctx, hr)
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		return genericClient.Update(ctx, hr)
+	})
 
 	return nil
 }

--- a/apptests/appscenarios/traefik.go
+++ b/apptests/appscenarios/traefik.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	fluxhelmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
@@ -97,7 +98,10 @@ func (t traefik) install(ctx context.Context, env *environment.Env, appPath stri
 		Kind: "ConfigMap",
 		Name: traefikCMName,
 	})
-	err = genericClient.Update(ctx, hr)
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		return genericClient.Update(ctx, hr)
+	})
 
 	return err
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
traefik upgrade test currently has flake and the error is:

``` 
[FAILED] Expected
      <*errors.StatusError | 0xc0017bfcc0>: 
      Operation cannot be fulfilled on helmreleases.helm.toolkit.fluxcd.io "traefik": the object has been modified; please apply your changes to the latest version and try again
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "Operation cannot be fulfilled on helmreleases.helm.toolkit.fluxcd.io \"traefik\": the object has been modified; please apply your changes to the latest version and try again",
              Reason: "Conflict",
              Details: {
                  Name: "traefik",
                  Group: "helm.toolkit.fluxcd.io",
                  Kind: "helmreleases",
                  UID: "",
                  Causes: nil,
                  RetryAfterSeconds: 0,
              },
              Code: 409,
          },
      }
  to be nil
  In [It] at: /home/runner/work/kommander-applications/kommander-applications/apptests/appscenarios/traefik_test.go:177
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
