### PR TITLE
feat: reconfigure velero

### DIFF
--- a/services/velero/6.6.0/defaults/cm.yaml
+++ b/services/velero/6.6.0/defaults/cm.yaml
@@ -26,10 +26,17 @@ data:
             s3Url: http://rook-ceph-rgw-dkp-object-store.${releaseNamespace}.svc:80/
             s3ForcePathStyle: true
             insecureSkipTLSVerify: "true"
+      features: EnableCSI
+      uploaderType: kopia
       volumeSnapshotLocation:
         - config:
             region: "fallback"
           provider: "aws"
+    deployNodeAgent: true
+    nodeAgent:
+      annotations:
+        secret.reloader.stakater.com/reload: dkp-velero
+      priorityClassName: dkp-critical-priority
     credentials:
       # This is created by rook-ceph-cluster service. A ConfigMap and a Secret with same name as bucket are created.
       extraSecretRef: dkp-velero
@@ -47,7 +54,13 @@ data:
           servicemonitor.kommander.mesosphere.io/path: "metrics"
     initContainers:
       - name: velero-plugin-for-aws
-        image: velero/velero-plugin-for-aws:v1.7.0
+        image: velero/velero-plugin-for-aws:v1.9.2
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+          - mountPath: /target
+            name: plugins
+      - name: velero-plugin-for-csi
+        image: velero/velero-plugin-for-csi:v0.7.1
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - mountPath: /target


### PR DESCRIPTION
**What problem does this PR solve?**:

improve Velero default config to support NKE migration and typical config needs

- enable CSI support
- enable node agent for File System Backup
- update S3 plugin to the last version
- force kopia as uploader

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
- backup/restore CSI enabled apps
- use FSB to test node agent


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
- Add Velero CSI and node agent support
```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ]  If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).

i let you decide how to adress the version bump when only config change