### PR TITLE
ci: Set labels on dependabot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       - "mesosphere/kommander"
     reviewers:
       - "mesosphere/kommander"
+    labels:
+      - "dependencies"
+      - "ok-to-test"
+      - "ready-for-review"
   - package-ecosystem: "gomod"
     directory: "/apptests"
     schedule:
@@ -16,6 +20,11 @@ updates:
       - "mesosphere/kommander"
     reviewers:
       - "mesosphere/kommander"
+    labels:
+      - "dependencies"
+      - "ok-to-test"
+      - "ready-for-review"
+      - "services/reloader"
   - package-ecosystem: "gomod"
     directory: "/magefiles"
     schedule:
@@ -24,9 +33,19 @@ updates:
       - "mesosphere/kommander"
     reviewers:
       - "mesosphere/kommander"
+    labels:
+      - "dependencies"
+      - "ok-to-test"
+      - "ready-for-review"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     assignees:
       - "mesosphere/kommander"
+    reviewers:
+      - "mesosphere/kommander"
+    labels:
+      - "dependencies"
+      - "ok-to-test"
+      - "ready-for-review"


### PR DESCRIPTION
**What problem does this PR solve?**:
adding labels to set automatically on dependabot prs to run tests, and for application test dep updates, adding a services label as well to run an actual app test 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
