### PR TITLE
chore: bump priorityclass for notification controller

### DIFF
--- a/hack/flux/flux-update-kustomization.yaml
+++ b/hack/flux/flux-update-kustomization.yaml
@@ -77,4 +77,4 @@ patches:
     patch: |-
       - op: add
         path: /spec/template/spec/priorityClassName
-        value: dkp-critical-priority
+        value: system-cluster-critical

--- a/services/kommander-flux/2.2.3/templates/apps_v1_deployment_notification-controller.yaml
+++ b/services/kommander-flux/2.2.3/templates/apps_v1_deployment_notification-controller.yaml
@@ -78,7 +78,7 @@ spec:
           name: temp
       nodeSelector:
         kubernetes.io/os: linux
-      priorityClassName: dkp-critical-priority
+      priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 1337
       serviceAccountName: notification-controller


### PR DESCRIPTION
**What problem does this PR solve?**:

Now that flux is deployed in kommander bootstrapper job before cloning the k-apps repo, i think its easier to deploy it with standard priority classes set up. 

Alternative is to skip notification controller deployment at the start but I felt the approach in this PR keeps things more consistent. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
