### PR TITLE
feat: Conditional cluster teardown in app tests

### DIFF
--- a/.github/workflows/application-test-scenario-install.yaml
+++ b/.github/workflows/application-test-scenario-install.yaml
@@ -43,6 +43,8 @@ jobs:
 
     - name: Run install Test
       working-directory: apptests
+      env:
+        SKIP_CLUSTER_TEARDOWN: "true"
       run: |
         ginkgo --v --label-filter="install && (${{ inputs.apps }})" appscenarios
 

--- a/.github/workflows/application-test-scenario-upgrade.yaml
+++ b/.github/workflows/application-test-scenario-upgrade.yaml
@@ -59,6 +59,8 @@ jobs:
       run: go install github.com/onsi/ginkgo/v2/ginkgo
 
     - name: Run upgrade Test
+      env:
+        SKIP_CLUSTER_TEARDOWN: "true"
       working-directory: apptests
       run: |
         ginkgo --v --label-filter="upgrade && (${{ inputs.apps }})" appscenarios

--- a/apptests/appscenarios/certmanager_test.go
+++ b/apptests/appscenarios/certmanager_test.go
@@ -2,8 +2,7 @@ package appscenarios
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,6 +13,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,6 +31,10 @@ var _ = Describe("Cert-manager Tests", Ordered, Label("cert-manager"), func() {
 	})
 
 	AfterEach(OncePerOrdered, func() {
+		if os.Getenv("SKIP_CLUSTER_TEARDOWN") != "" {
+			return
+		}
+
 		err := env.Destroy(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/apptests/appscenarios/externaldns_test.go
+++ b/apptests/appscenarios/externaldns_test.go
@@ -2,6 +2,7 @@ package appscenarios
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,6 +29,10 @@ var _ = Describe("External DNS Tests", Label("external-dns"), func() {
 	})
 
 	AfterEach(OncePerOrdered, func() {
+		if os.Getenv("SKIP_CLUSTER_TEARDOWN") != "" {
+			return
+		}
+
 		err := env.Destroy(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/apptests/appscenarios/gatekeeper_test.go
+++ b/apptests/appscenarios/gatekeeper_test.go
@@ -2,6 +2,7 @@ package appscenarios
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -35,8 +36,12 @@ var _ = Describe("GateKeeper Tests", Label("gatekeeper"), func() {
 	})
 
 	AfterEach(OncePerOrdered, func() {
+		if os.Getenv("SKIP_CLUSTER_TEARDOWN") != "" {
+			return
+		}
+
 		err := env.Destroy(ctx)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Describe("GateKeeper Install Test", Ordered, Label("install"), func() {

--- a/apptests/appscenarios/karma_test.go
+++ b/apptests/appscenarios/karma_test.go
@@ -2,6 +2,7 @@ package appscenarios
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -43,6 +44,10 @@ var _ = Describe("Karma Tests", Label("karma"), func() {
 	})
 
 	AfterEach(OncePerOrdered, func() {
+		if os.Getenv("SKIP_CLUSTER_TEARDOWN") != "" {
+			return
+		}
+
 		err := env.Destroy(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/apptests/appscenarios/kommanderflux_test.go
+++ b/apptests/appscenarios/kommanderflux_test.go
@@ -2,6 +2,7 @@ package appscenarios
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -22,6 +23,10 @@ var _ = Describe("Kommander-flux Tests", Label("kommander-flux"), func() {
 	})
 
 	AfterEach(OncePerOrdered, func() {
+		if os.Getenv("SKIP_CLUSTER_TEARDOWN") != "" {
+			return
+		}
+
 		err := env.Destroy(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/apptests/appscenarios/kubecost_test.go
+++ b/apptests/appscenarios/kubecost_test.go
@@ -2,7 +2,7 @@ package appscenarios
 
 import (
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -11,6 +11,7 @@ import (
 	fluxhelmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
 	apimeta "github.com/fluxcd/pkg/apis/meta"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -28,9 +29,14 @@ var _ = Describe("Kubecost Tests", Label("kubecost"), func() {
 	})
 
 	AfterEach(OncePerOrdered, func() {
+		if os.Getenv("SKIP_CLUSTER_TEARDOWN") != "" {
+			return
+		}
+
 		err := env.Destroy(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
 	Describe("Installing kubecost", Ordered, Label("install"), func() {
 
 		var (

--- a/apptests/appscenarios/reloader_test.go
+++ b/apptests/appscenarios/reloader_test.go
@@ -30,6 +30,10 @@ var _ = Describe("Reloader Tests", Label("reloader"), func() {
 	})
 
 	AfterEach(OncePerOrdered, func() {
+		if os.Getenv("SKIP_CLUSTER_TEARDOWN") != "" {
+			return
+		}
+
 		err := env.Destroy(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/apptests/appscenarios/rookceph_test.go
+++ b/apptests/appscenarios/rookceph_test.go
@@ -2,6 +2,7 @@ package appscenarios
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -42,6 +43,10 @@ var _ = Describe("Rook Ceph Tests", Label("rook-ceph", "rook-ceph-cluster"), fun
 	})
 
 	AfterEach(OncePerOrdered, func() {
+		if os.Getenv("SKIP_CLUSTER_TEARDOWN") != "" {
+			return
+		}
+
 		err := env.Destroy(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/apptests/appscenarios/traefik_test.go
+++ b/apptests/appscenarios/traefik_test.go
@@ -2,6 +2,7 @@ package appscenarios
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -36,6 +37,10 @@ var _ = Describe("Traefik Tests", Label("traefik"), func() {
 	})
 
 	AfterEach(OncePerOrdered, func() {
+		if os.Getenv("SKIP_CLUSTER_TEARDOWN") != "" {
+			return
+		}
+
 		err := env.Destroy(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/apptests/appscenarios/velero_test.go
+++ b/apptests/appscenarios/velero_test.go
@@ -3,6 +3,7 @@ package appscenarios
 import (
 	"fmt"
 	"k8s.io/client-go/kubernetes"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -42,10 +43,13 @@ var _ = Describe("Velero Local Backup Tests", Label("velero"), func() {
 	})
 
 	AfterEach(OncePerOrdered, func() {
-		//err := env.Destroy(ctx)
-		//Expect(err).ToNot(HaveOccurred())
-	})
+		if os.Getenv("SKIP_CLUSTER_TEARDOWN") != "" {
+			return
+		}
 
+		err := env.Destroy(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
 	Describe("Installing Velero", Ordered, Label("install"), func() {
 
 		var (


### PR DESCRIPTION
**What problem does this PR solve?**:

Skips the teardown of the test cluster in the CI. THis allows the support bundle to be collected as needed.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
