### PR TITLE
fix: [backport-2.7] velero with bumped limits 

### DIFF
--- a/services/velero/4.1.2/defaults/cm.yaml
+++ b/services/velero/4.1.2/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: velero-4.1.1-d2iq-defaults
+  name: velero-4.1.2-d2iq-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/velero/4.1.2/helmrelease/helmrelease.yaml
+++ b/services/velero/4.1.2/helmrelease/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: vmware-tanzu.github.io
         namespace: kommander-flux
-      version: 4.1.1
+      version: 4.1.2
   interval: 15s
   install:
     crds: CreateReplace
@@ -24,7 +24,7 @@ spec:
   releaseName: velero
   valuesFrom:
     - kind: ConfigMap
-      name: velero-4.1.1-d2iq-defaults
+      name: velero-4.1.2-d2iq-defaults
   targetNamespace: ${releaseNamespace}
 ---
 # This ingress is needed to make Traefik configure an additional route

--- a/services/velero/4.1.2/velero-post-install.yaml
+++ b/services/velero/4.1.2/velero-post-install.yaml
@@ -12,7 +12,7 @@ spec:
   wait: true
   interval: 6h
   retryInterval: 1m
-  path: ./services/velero/4.1.1/post-install
+  path: ./services/velero/4.1.2/post-install
   sourceRef:
     kind: GitRepository
     name: management

--- a/services/velero/4.1.2/velero-pre-install.yaml
+++ b/services/velero/4.1.2/velero-pre-install.yaml
@@ -9,7 +9,7 @@ spec:
   wait: true
   interval: 6h
   retryInterval: 1m
-  path: ./services/velero/4.1.1/pre-install
+  path: ./services/velero/4.1.2/pre-install
   sourceRef:
     kind: GitRepository
     name: management

--- a/services/velero/4.1.2/velero.yaml
+++ b/services/velero/4.1.2/velero.yaml
@@ -12,7 +12,7 @@ spec:
   wait: true
   interval: 6h
   retryInterval: 1m
-  path: ./services/velero/4.1.1/helmrelease
+  path: ./services/velero/4.1.2/helmrelease
   sourceRef:
     kind: GitRepository
     name: management


### PR DESCRIPTION
**What problem does this PR solve?**:
missed bumps for velero limits fix

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
