### PR TITLE
fix: memcached patched image with fixed CVE

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -7,7 +7,7 @@ ignore:
   - docker.io/bitnami/postgresql:11.22.0-debian-11-r4
   - docker.io/bitnami/postgresql:15.2.0-debian-11-r21
   - docker.io/bitnami/redis-cluster:7.0.12-debian-11-r2
-  - docker.io/bitnami/memcached:1.6.19-debian-11-r7
+  - ghcr.io/mesosphere/dkp-container-images/docker.io/bitnami/memcached:1.6.19-debian-11-r7-d2iq.1
   - docker.io/library/busybox:1
   - gcr.io/kubecost1/cost-model:prod-1.106.7
   - gcr.io/kubecost1/frontend:prod-1.106.7

--- a/services/gitea/8.2.1/defaults/cm.yaml
+++ b/services/gitea/8.2.1/defaults/cm.yaml
@@ -9,8 +9,8 @@ data:
     priorityClassName: "dkp-critical-priority"
     image:
       registry: ghcr.io
-      repository: mesosphere/gitea
-      tag: 1.19.2-d2iq.1
+      repository: mesosphere/dkp-container-images/docker.io/bitnami/memcached
+      tag: 1.6.19-debian-11-r7-d2iq.1
       rootless: true
     ingress:
       enabled: true

--- a/services/gitea/8.2.1/defaults/cm.yaml
+++ b/services/gitea/8.2.1/defaults/cm.yaml
@@ -9,8 +9,8 @@ data:
     priorityClassName: "dkp-critical-priority"
     image:
       registry: ghcr.io
-      repository: mesosphere/dkp-container-images/docker.io/bitnami/memcached
-      tag: 1.6.19-debian-11-r7-d2iq.1
+      repository: mesosphere/gitea
+      tag: 1.19.2-d2iq.1
       rootless: true
     ingress:
       enabled: true
@@ -68,7 +68,9 @@ data:
     memcached:
       priorityClassName: "dkp-critical-priority"
       image:
-        tag: 1.6.19-debian-11-r7
+        registry: ghcr.io
+        repository: mesosphere/dkp-container-images/docker.io/bitnami/memcached
+        tag: 1.6.19-debian-11-r7-d2iq.1
     postgresql:
       primary:
         priorityClassName: "dkp-critical-priority"


### PR DESCRIPTION
**What problem does this PR solve?**:
Patch memcached image with fixed CVE's

workflow link:
https://github.com/mesosphere/dkp-container-images/actions/runs/9886039464

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-101394

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
