### PR TITLE
fix: grafana patched image with fixed CVE

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -96,7 +96,7 @@ resources:
       - license_path: LICENSE
         ref: v1.19.2-d2iq.1
         url: https://github.com/mesosphere/gitea
-  - container_image: docker.io/grafana/grafana:10.3.3
+  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/grafana/grafana:10.3.3-d2iq.0
     sources:
       - license_path: LICENSE
         notice_path: NOTICE.md

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -100,7 +100,7 @@ resources:
     sources:
       - license_path: LICENSE
         notice_path: NOTICE.md
-        ref: v${image_tag}
+        ref: v10.3.3-d2iq.0
         url: https://github.com/grafana/grafana
   - container_image: docker.io/grafana/grafana:11.0.0
     sources:

--- a/services/grafana-logging/8.0.2/defaults/cm.yaml
+++ b/services/grafana-logging/8.0.2/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
     ---
     priorityClassName: "dkp-critical-priority"
     image:
-      tag: 10.3.3
+      tag: 10.3.3-d2iq.0
     datasources:
       datasources.yaml:
         apiVersion: 1

--- a/services/grafana-logging/8.0.2/defaults/cm.yaml
+++ b/services/grafana-logging/8.0.2/defaults/cm.yaml
@@ -8,6 +8,8 @@ data:
     ---
     priorityClassName: "dkp-critical-priority"
     image:
+      registry: ghcr.io
+      repository: mesosphere/dkp-container-images/docker.io/grafana/grafana
       tag: 10.3.3-d2iq.0
     datasources:
       datasources.yaml:

--- a/services/grafana-logging/8.0.2/grafana.yaml
+++ b/services/grafana-logging/8.0.2/grafana.yaml
@@ -39,7 +39,7 @@ data:
   dashboardLink: "/dkp/logging/grafana"
   docsLink: "https://grafana.com/docs/"
   # Check https://artifacthub.io/packages/helm/grafana/grafana/6.58.6 for app version
-  version: "10.3.3"
+  version: "10.3.3-d2iq.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/kubecost/0.37.3/defaults/cm.yaml
+++ b/services/kubecost/0.37.3/defaults/cm.yaml
@@ -49,7 +49,7 @@ data:
       grafana:
         priorityClassName: dkp-high-priority
         image:
-          tag: 10.3.3
+          tag: 10.3.3-d2iq.0
         ingress:
           enabled: true
           annotations:

--- a/services/kubecost/0.37.3/defaults/cm.yaml
+++ b/services/kubecost/0.37.3/defaults/cm.yaml
@@ -49,6 +49,8 @@ data:
       grafana:
         priorityClassName: dkp-high-priority
         image:
+          registry: ghcr.io
+          repository: mesosphere/dkp-container-images/docker.io/grafana/grafana
           tag: 10.3.3-d2iq.0
         ingress:
           enabled: true

--- a/services/project-grafana-logging/8.0.2/defaults/cm.yaml
+++ b/services/project-grafana-logging/8.0.2/defaults/cm.yaml
@@ -9,6 +9,8 @@ data:
     priorityClassName: "dkp-critical-priority"
     # pinning grafana to 8.5 since it appears that v9+ is causing the kubernetes audit dashboard to crash
     image:
+      registry: ghcr.io
+      repository: mesosphere/dkp-container-images/docker.io/grafana/grafana
       tag: 10.3.3-d2iq.0
     datasources:
       datasources.yaml:

--- a/services/project-grafana-logging/8.0.2/defaults/cm.yaml
+++ b/services/project-grafana-logging/8.0.2/defaults/cm.yaml
@@ -9,7 +9,7 @@ data:
     priorityClassName: "dkp-critical-priority"
     # pinning grafana to 8.5 since it appears that v9+ is causing the kubernetes audit dashboard to crash
     image:
-      tag: 10.3.3
+      tag: 10.3.3-d2iq.0
     datasources:
       datasources.yaml:
         apiVersion: 1


### PR DESCRIPTION
**What problem does this PR solve?**:
Patch kubecost image with fixed CVE's

workflow link:
https://github.com/mesosphere/dkp-container-images/actions/runs/9887688910

```
sandhya.ravi@GT9X7CVF5F kommander-applications % trivy image ghcr.io/mesosphere/dkp-container-images/docker.io/grafana/grafana:10.3.3-d2iq.0 --vuln-type os --ignore-unfixed | grep Total
2024-07-11T13:53:38+05:30	INFO	Vulnerability scanning is enabled
2024-07-11T13:53:38+05:30	INFO	Secret scanning is enabled
2024-07-11T13:53:38+05:30	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-07-11T13:53:38+05:30	INFO	Please see also https://aquasecurity.github.io/trivy/v0.53/docs/scanner/secret#recommendation for faster secret detection
2024-07-11T13:53:40+05:30	INFO	Detected OS	family="alpine" version="3.18.4"
2024-07-11T13:53:40+05:30	INFO	[alpine] Detecting vulnerabilities...	os_version="3.18" repository="3.18" pkg_num=31
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-101394

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
