### PR TITLE
fix: open kommander branch body quoting

### DIFF
--- a/.github/workflows/kommander-branch.yaml
+++ b/.github/workflows/kommander-branch.yaml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Make test branch pointing to kommander-applications ref
         id: make-test-branch
+        env:
+          PULL_REQUEST_BODY: ${{ github.event.pull_request.body }}
         run: |
           cd kommander
           git config user.name d2iq-mergebot
@@ -72,7 +74,7 @@ jobs:
             if  [[ ${{ needs.get-kapps-branch-name.outputs.escaped_branch_name }} == chartbump/* ]] ;
             then
               # Update kuttl tests that reference the app being bumped
-              kapps=$(echo '${{ github.event.pull_request.body }}' | grep kapps:)
+              kapps=$(echo $PULL_REQUEST_BODY | grep kapps:)
               kapps=${kapps#"kapps:"}
               echo $kapps
               semver="(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)\.(0|[1-9]+[0-9]*)"


### PR DESCRIPTION
**What problem does this PR solve?**:
I think that this can fail in some cases when PR body contains `'` character.

https://github.com/mesosphere/kommander-applications/actions/runs/9888081767/job/27311190768?pr=2394

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
