### PR TITLE
fix: nginx-unprivileged-alpine patched image with fixed CVE

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -2,7 +2,7 @@ ignore:
   - ghcr.io/mesosphere/git-operator:v0.2.0
   - ghcr.io/mesosphere/dkp-container-images/docker.io/mesosphere/grafana-plugins:v0.0.1-d2iq.0
   - docker.io/mesosphere/kommander2-kubetools
-  - docker.io/nginxinc/nginx-unprivileged:1.24.0-alpine
+  - ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.24.0-alpine-d2iq.0
   - docker.io/bitnami/external-dns:0.14.2-debian-12-r1
   - docker.io/bitnami/postgresql:11.22.0-debian-11-r4
   - docker.io/bitnami/postgresql:15.2.0-debian-11-r21

--- a/services/grafana-loki/0.78.5/defaults/cm.yaml
+++ b/services/grafana-loki/0.78.5/defaults/cm.yaml
@@ -186,7 +186,7 @@ data:
       image:
         # Override nginx image to address known CVEs.
         # As of 0.48.4, chart maintainers are still using 1.19-alpine.
-        tag: 1.24.0-alpine
+        tag: 1.24.0-alpine-d2iq.0
       nginxConfig:
         httpSnippet: |-
           client_max_body_size 10M;

--- a/services/project-grafana-loki/0.78.5/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.78.5/defaults/cm.yaml
@@ -194,7 +194,7 @@ data:
       image:
         # Override nginx image to address known CVEs.
         # As of 0.48.4, chart maintainers are still using 1.19-alpine.
-        tag: 1.24.0-alpine
+        tag: 1.24.0-alpine-d2iq.0
       verboseLogging: false
       nginxConfig:
         httpSnippet: |-


### PR DESCRIPTION
**What problem does this PR solve?**:
Patch ngin-unprivileged-alpine  image with fixed CVE's

workflow link:
https://github.com/mesosphere/dkp-container-images/actions/runs/9892771231

`sandhya.ravi@GT9X7CVF5F kommander-applications % trivy image ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.24.0-alpine-d2iq.0 --vuln-type os --ignore-unfixed | grep Total
2024-07-11T19:41:20+05:30	INFO	Vulnerability scanning is enabled
2024-07-11T19:41:20+05:30	INFO	Secret scanning is enabled
2024-07-11T19:41:20+05:30	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-07-11T19:41:20+05:30	INFO	Please see also https://aquasecurity.github.io/trivy/v0.53/docs/scanner/secret#recommendation for faster secret detection
2024-07-11T19:41:21+05:30	INFO	Detected OS	family="alpine" version="3.18.6"
2024-07-11T19:41:21+05:30	INFO	[alpine] Detecting vulnerabilities...	os_version="3.18" repository="3.18" pkg_num=64
Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)`

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-101394

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
