### PR TITLE
fix: gpu-operator validator and k8s device plugin image with fixed CVE

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -386,12 +386,12 @@ resources:
   - container_image: nvcr.io/nvidia/cloud-native/gpu-operator-validator:v24.3.0-d2iq.0
     sources:
       - license_path: validator/LICENSE
-        ref: ${image_tag}
+        ref: v24.3.0
         url: https://github.com/NVIDIA/gpu-operator
   - container_image: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator:v24.3.0-d2iq.0
     sources:
       - license_path: LICENSE
-        ref: ${image_tag}
+        ref: v24.3.0
         url: https://github.com/NVIDIA/gpu-operator
   - container_image: nvcr.io/nvidia/k8s-device-plugin:v0.15.0-ubi8
     sources:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -388,7 +388,7 @@ resources:
       - license_path: validator/LICENSE
         ref: ${image_tag}
         url: https://github.com/NVIDIA/gpu-operator
-  - container_image: nvcr.io/nvidia/gpu-operator:v24.3.0
+  - container_image: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator:v24.3.0-d2iq.0
     sources:
       - license_path: LICENSE
         ref: ${image_tag}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -393,10 +393,10 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/NVIDIA/gpu-operator
-  - container_image: nvcr.io/nvidia/k8s-device-plugin:v0.15.0-ubi8
+  - container_image: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/k8s-device-plugin:v0.15.0-ubi8-d2iq.0
     sources:
       - license_path: LICENSE
-        ref: ${image_tag%-ubi8}
+        ref: ${image_tag%-ubi8-d2iq.0}
         url: https://github.com/NVIDIA/k8s-device-plugin
   - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.15.0-ubuntu20.04
     sources:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -383,15 +383,15 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/stakater/Reloader
-  - container_image: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator:v24.3.0-d2iq.0
-    sources:
-      - license_path: validator/LICENSE
-        ref: v24.3.0
-        url: https://github.com/NVIDIA/gpu-operator
   - container_image: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/cloud-native/gpu-operator-validator:v24.3.0-d2iq.0
     sources:
+      - license_path: validator/LICENSE
+        ref: v${image_tag%-d2iq.0}
+        url: https://github.com/NVIDIA/gpu-operator
+  - container_image: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator:v24.3.0-d2iq.0
+    sources:
       - license_path: LICENSE
-        ref: v24.3.0
+        ref: v${image_tag%-d2iq.0}
         url: https://github.com/NVIDIA/gpu-operator
   - container_image: nvcr.io/nvidia/k8s-device-plugin:v0.15.0-ubi8
     sources:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -388,10 +388,10 @@ resources:
       - license_path: validator/LICENSE
         ref: ${image_tag%-d2iq.0}
         url: https://github.com/NVIDIA/gpu-operator
-  - container_image: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator:v24.3.0-d2iq.0
+  - container_image: nvcr.io/nvidia/gpu-operator:v24.3.0
     sources:
       - license_path: LICENSE
-        ref: ${image_tag%-d2iq.0}
+        ref: ${image_tag}
         url: https://github.com/NVIDIA/gpu-operator
   - container_image: nvcr.io/nvidia/k8s-device-plugin:v0.15.0-ubi8
     sources:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -386,12 +386,12 @@ resources:
   - container_image: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/cloud-native/gpu-operator-validator:v24.3.0-d2iq.0
     sources:
       - license_path: validator/LICENSE
-        ref: v${image_tag%-d2iq.0}
+        ref: ${image_tag%-d2iq.0}
         url: https://github.com/NVIDIA/gpu-operator
   - container_image: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator:v24.3.0-d2iq.0
     sources:
       - license_path: LICENSE
-        ref: v${image_tag%-d2iq.0}
+        ref: ${image_tag%-d2iq.0}
         url: https://github.com/NVIDIA/gpu-operator
   - container_image: nvcr.io/nvidia/k8s-device-plugin:v0.15.0-ubi8
     sources:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -383,12 +383,12 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/stakater/Reloader
-  - container_image: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/cloud-native/gpu-operator-validator:v24.3.0-d2iq.0
+  - container_image: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator:v24.3.0-d2iq.0
     sources:
       - license_path: validator/LICENSE
         ref: v24.3.0
         url: https://github.com/NVIDIA/gpu-operator
-  - container_image: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator:v24.3.0-d2iq.0
+  - container_image: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/cloud-native/gpu-operator-validator:v24.3.0-d2iq.0
     sources:
       - license_path: LICENSE
         ref: v24.3.0

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -383,7 +383,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/stakater/Reloader
-  - container_image: nvcr.io/nvidia/cloud-native/gpu-operator-validator:v24.3.0-d2iq.0
+  - container_image: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/cloud-native/gpu-operator-validator:v24.3.0-d2iq.0
     sources:
       - license_path: validator/LICENSE
         ref: v24.3.0

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -383,7 +383,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/stakater/Reloader
-  - container_image: nvcr.io/nvidia/cloud-native/gpu-operator-validator:v24.3.0
+  - container_image: nvcr.io/nvidia/cloud-native/gpu-operator-validator:v24.3.0-d2iq.0
     sources:
       - license_path: validator/LICENSE
         ref: ${image_tag}

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   values.yaml: |
     image:
-      repository: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/cloud-native/gpu-operator-validator
+      repository: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator
       tag: v24.3.0-d2iq.0
     nfd:
       enabled: false

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
@@ -36,4 +36,4 @@ data:
       enabled: true
       version: 3.3.5-3.4.1-ubuntu22.04
     validator:
-      version: v24.3.0-d2iq.0
+      version: v24.3.0

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
@@ -37,3 +37,6 @@ data:
       version: 3.3.5-3.4.1-ubuntu22.04
     validator:
       version: v24.3.0
+      image:
+        repository: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/cloud-native/gpu-operator-validator
+        tag: v24.3.0-d2iq.0

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
@@ -13,7 +13,7 @@ data:
       config:
         # Create a ConfigMap (default: false)
         create: false
-      version: v0.15.0-ubi8
+      version: v0.15.0-ubi8-d2iq.0
     toolkit:
       # toolkit needs to be set on per OS
       # see: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html#bare-metal-passthrough-with-default-configurations-on-centos
@@ -25,7 +25,7 @@ data:
       # gfd is no longer published a standalone helm chart or image and instead uses
       # the k8s-device-plugin image.
       enabled: true
-      version: v0.15.0-ubi8
+      version: v0.15.0-ubi8-d2iq.0
     dcgm:
       enabled: true
       version: 3.3.5-1-ubuntu22.04

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
@@ -33,7 +33,5 @@ data:
       enabled: true
       version: 3.3.5-3.4.1-ubuntu22.04
     validator:
-      version: v24.3.0
-      image:
-        repository: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/cloud-native/gpu-operator-validator
-        tag: v24.3.0-d2iq.0
+      version: v24.3.0-d2iq.0
+

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
@@ -37,6 +37,3 @@ data:
       version: 3.3.5-3.4.1-ubuntu22.04
     validator:
       version: v24.3.0
-      image:
-        repository: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/cloud-native/gpu-operator-validator
-        tag: v24.3.0-d2iq.0

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
@@ -5,9 +5,8 @@ metadata:
   namespace: ${releaseNamespace}
 data:
   values.yaml: |
-    image: 
-      registry: ghcr.io
-      repository: mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator
+    image:
+      repository: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator
       tag: v24.3.0-d2iq.0
     nfd:
       enabled: false

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
@@ -6,8 +6,7 @@ metadata:
 data:
   values.yaml: |
     image:
-      registry: ghcr.io
-      repository: mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator
+      repository: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/cloud-native/gpu-operator-validator
       tag: v24.3.0-d2iq.0
     nfd:
       enabled: false
@@ -38,3 +37,6 @@ data:
       version: 3.3.5-3.4.1-ubuntu22.04
     validator:
       version: v24.3.0
+      image:
+        repository: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/cloud-native/gpu-operator-validator
+        tag: v24.3.0-d2iq.0

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
@@ -34,4 +34,3 @@ data:
       version: 3.3.5-3.4.1-ubuntu22.04
     validator:
       version: v24.3.0-d2iq.0
-

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
@@ -36,4 +36,4 @@ data:
       enabled: true
       version: 3.3.5-3.4.1-ubuntu22.04
     validator:
-      version: v24.3.0
+      version: v24.3.0-d2iq.0

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: ${releaseNamespace}
 data:
   values.yaml: |
+    image: 
+      registry: ghcr.io
+      repository: mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator
+      tag: v24.3.0-d2iq.0
     nfd:
       enabled: false
     driver:

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
@@ -6,7 +6,8 @@ metadata:
 data:
   values.yaml: |
     image:
-      repository: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator
+      registry: ghcr.io
+      repository: mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator
       tag: v24.3.0-d2iq.0
     nfd:
       enabled: false

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/defaults/cm.yaml
@@ -5,9 +5,6 @@ metadata:
   namespace: ${releaseNamespace}
 data:
   values.yaml: |
-    image:
-      repository: ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator
-      tag: v24.3.0-d2iq.0
     nfd:
       enabled: false
     driver:

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/extra-images.txt
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/extra-images.txt
@@ -5,4 +5,4 @@ nvcr.io/nvidia/cloud-native/dcgm:{{ .Values.dcgm.version }}
 nvcr.io/nvidia/k8s/dcgm-exporter:{{ .Values.dcgmExporter.version }}
 nvcr.io/nvidia/k8s-device-plugin:{{ .Values.devicePlugin.version }}
 nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2
-
+ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator:v24.3.0-d2iq.0

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/extra-images.txt
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/extra-images.txt
@@ -3,5 +3,5 @@ ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/k8s/container-toolkit:{{ 
 ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/cloud-native/gpu-operator-validator:{{ .Values.validator.version }}
 nvcr.io/nvidia/cloud-native/dcgm:{{ .Values.dcgm.version }}
 nvcr.io/nvidia/k8s/dcgm-exporter:{{ .Values.dcgmExporter.version }}
-ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/k8s-device-plugin:{{ .Values.devicePlugin.version }}
 nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2
+ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/k8s-device-plugin:{{ .Values.devicePlugin.version }}

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/extra-images.txt
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/extra-images.txt
@@ -1,7 +1,8 @@
 nvcr.io/nvidia/k8s/container-toolkit:{{ regexReplaceAllLiteral "-.+$" .Values.toolkit.version "" }}-ubuntu20.04
 ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/k8s/container-toolkit:{{ regexReplaceAllLiteral "-.+$" .Values.toolkit.version "" }}-ubi8-d2iq.0
-nvcr.io/nvidia/cloud-native/gpu-operator-validator:{{ .Values.validator.version }}
+ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/cloud-native/gpu-operator-validator:{{ .Values.validator.version }}
 nvcr.io/nvidia/cloud-native/dcgm:{{ .Values.dcgm.version }}
 nvcr.io/nvidia/k8s/dcgm-exporter:{{ .Values.dcgmExporter.version }}
 ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/k8s-device-plugin:{{ .Values.devicePlugin.version }}
 nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2
+

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/extra-images.txt
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/extra-images.txt
@@ -5,3 +5,4 @@ nvcr.io/nvidia/cloud-native/dcgm:{{ .Values.dcgm.version }}
 nvcr.io/nvidia/k8s/dcgm-exporter:{{ .Values.dcgmExporter.version }}
 nvcr.io/nvidia/k8s-device-plugin:{{ .Values.devicePlugin.version }}
 nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2
+

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/extra-images.txt
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/extra-images.txt
@@ -3,5 +3,5 @@ ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/k8s/container-toolkit:{{ 
 nvcr.io/nvidia/cloud-native/gpu-operator-validator:{{ .Values.validator.version }}
 nvcr.io/nvidia/cloud-native/dcgm:{{ .Values.dcgm.version }}
 nvcr.io/nvidia/k8s/dcgm-exporter:{{ .Values.dcgmExporter.version }}
-nvcr.io/nvidia/k8s-device-plugin:{{ .Values.devicePlugin.version }}
+ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/k8s-device-plugin:{{ .Values.devicePlugin.version }}
 nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/extra-images.txt
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/extra-images.txt
@@ -5,4 +5,3 @@ nvcr.io/nvidia/cloud-native/dcgm:{{ .Values.dcgm.version }}
 nvcr.io/nvidia/k8s/dcgm-exporter:{{ .Values.dcgmExporter.version }}
 ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/k8s-device-plugin:{{ .Values.devicePlugin.version }}
 nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2
-

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/extra-images.txt
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/extra-images.txt
@@ -5,4 +5,3 @@ nvcr.io/nvidia/cloud-native/dcgm:{{ .Values.dcgm.version }}
 nvcr.io/nvidia/k8s/dcgm-exporter:{{ .Values.dcgmExporter.version }}
 nvcr.io/nvidia/k8s-device-plugin:{{ .Values.devicePlugin.version }}
 nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2
-ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/gpu-operator:v24.3.0-d2iq.0

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/nvidia.yaml
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/nvidia.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: helm.ngc.nvidia.com-nvidia
         namespace: kommander-flux
-      version: v24.3.0
+      version: v24.3.0-d2iq.0
   interval: 15s
   install:
     crds: CreateReplace

--- a/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/nvidia.yaml
+++ b/services/nvidia-gpu-operator/24.3.0-d2iq.0/helmrelease/nvidia.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: helm.ngc.nvidia.com-nvidia
         namespace: kommander-flux
-      version: v24.3.0-d2iq.0
+      version: v24.3.0
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:
Patch gpu-operator and gpu-operator-validator image with fixed CVE's

workflow link:
https://github.com/mesosphere/dkp-container-images/actions/runs/9894213737
https://github.com/mesosphere/dkp-container-images/actions/runs/9902973870

`sandhya.ravi@GT9X7CVF5F kommander-applications % trivy image ghcr.io/mesosphere/dkp-container-images/nvcr.io/nvidia/cloud-native/gpu-operator-validator:v24.3.0-d2iq.0  --vuln-type os --ignore-unfixed | grep Total
2024-07-16T16:32:13+05:30	INFO	Vulnerability scanning is enabled
2024-07-16T16:32:13+05:30	INFO	Secret scanning is enabled
2024-07-16T16:32:13+05:30	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-07-16T16:32:13+05:30	INFO	Please see also https://aquasecurity.github.io/trivy/v0.53/docs/scanner/secret#recommendation for faster secret detection
2024-07-16T16:32:21+05:30	INFO	Detected OS	family="redhat" version="8.9"
2024-07-16T16:32:21+05:30	INFO	[redhat] Detecting RHEL/CentOS vulnerabilities...	os_version="8" pkg_num=195
2024-07-16T16:32:22+05:30	WARN	Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.53/docs/scanner/vulnerability#severity-selection for details.
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)`

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-101394

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
