### PR TITLE
fix: make git-operator images appear in the airgapped bundle

### DIFF
--- a/hack/list-images.sh
+++ b/hack/list-images.sh
@@ -131,9 +131,12 @@ done
 gojq --yaml-input --raw-output 'select(.kind | test("^(?:Deployment|Job|CronJob|StatefulSet|DaemonSet)$")) |
                                 .spec.template.spec |
                                 (select(.containers != null) | .containers[].image), (select(.initContainers != null) | .initContainers[].image)' \
+				./services/git-operator/*/git-operator-manifests/* \
                                 ./services/kommander-flux/*/templates/* \
                                 ./services/kube-prometheus-stack/*/etcd-metrics-proxy/* \
                                 >>"${IMAGES_FILE}"
+
+cat ./services/git-operator/*/additional-images.txt  >>"${IMAGES_FILE}"
 
 # Ensure that all images are fully qualified to ensure uniqueness of images in the image bundle.
 sed --expression='s|^docker.io/||' \

--- a/justfile
+++ b/justfile
@@ -11,6 +11,11 @@ release-oci tag tmp_dir=`mktemp --directory`:
     rsync --info=name --archive --recursive --files-from={{ include_file }} --exclude-from={{ exclude_file }} {{ justfile_directory() }} {{ tmp_dir }}
     cd {{ tmp_dir }} && echo "${DOCKER_PASSWORD}" | oras push --password-stdin --username "${DOCKER_USERNAME}" --verbose {{ registry }}/{{ repository }}:{{ tag }} .
 
-git-operator-fetch-manifests tmp_dir=`mktemp --directory` service_version=`ls services/git-operator/ | grep -E "v?[[:digit:]]\.[[:digit:]]\.[[:digit:]]"`:
+service_version:=`ls services/git-operator/ | grep -E "v?[[:digit:]]\.[[:digit:]]\.[[:digit:]]"`
+service_dir:=justfile_directory() / "services/git-operator" / service_version
+
+git-operator-fetch-manifests tmp_dir=`mktemp --directory`:
     flux pull artifact oci://docker.io/mesosphere/git-operator-manifests:{{ git_operator_version }} --output {{ tmp_dir }}
-    kustomize build {{ tmp_dir }}/default > {{ justfile_directory() }}/services/git-operator/{{ service_version }}/git-operator-manifests/all.yaml
+    # HACK: strip SHA off git-operator image
+    kustomize build {{ tmp_dir }}/default | sed -r 's/(image\: docker\.io\/mesosphere\/git-operator\:v[0-9]+\.[0-9]+.[0-9]+)\@sha256\:.*?$/\1/g' >{{ service_dir }}/git-operator-manifests/all.yaml
+    [ -z "$(git diff --name-only services/git-operator)" ] || echo -e '\n\n\nWARNING: Git Operator manifests have changed!\nEdit {{ service_dir }}/additional-images.txt to ensure additional images are up to date.\n\n'

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -1,8 +1,10 @@
 ignore:
-  - ghcr.io/mesosphere/git-operator:v0.2.0
+  - docker.io/mesosphere/git-operator:v0.8.3
+  - docker.io/mesosphere/gitwebserver:v0.8.3
   - ghcr.io/mesosphere/dkp-container-images/docker.io/mesosphere/grafana-plugins:v0.0.1-d2iq.0
   - docker.io/mesosphere/kommander2-kubetools
   - docker.io/nginxinc/nginx-unprivileged:1.24.0-alpine
+  - docker.io/nginxinc/nginx-unprivileged:1.25.4-alpine
   - docker.io/bitnami/external-dns:0.14.2-debian-12-r1
   - docker.io/bitnami/postgresql:11.22.0-debian-11-r4
   - docker.io/bitnami/postgresql:15.2.0-debian-11-r21
@@ -375,6 +377,11 @@ resources:
         ref: knative-v1.10.0
         url: https://github.com/knative/serving
   - container_image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+    sources:
+      - license_path: LICENSE
+        ref: ${image_tag}
+        url: https://github.com/brancz/kube-rbac-proxy
+  - container_image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
     sources:
       - license_path: LICENSE
         ref: ${image_tag}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -1,6 +1,4 @@
 ignore:
-  - docker.io/mesosphere/git-operator:v0.8.3
-  - docker.io/mesosphere/gitwebserver:v0.8.3
   - ghcr.io/mesosphere/dkp-container-images/docker.io/mesosphere/grafana-plugins:v0.0.1-d2iq.0
   - docker.io/mesosphere/kommander2-kubetools
   - docker.io/nginxinc/nginx-unprivileged:1.24.0-alpine
@@ -230,6 +228,14 @@ resources:
     sources:
       - ref: ${image_tag}
         url: https://github.com/mesosphere/dkp-insights
+  - container_image: docker.io/mesosphere/git-operator:v0.8.3
+    sources:
+      - ref: ${image_tag}
+        url: https://github.com/mesosphere/git-operator
+  - container_image: docker.io/mesosphere/gitwebserver:v0.8.3
+    sources:
+      - ref: ${image_tag}
+        url: https://github.com/mesosphere/git-operator
   - container_image: docker.io/mesosphere/karma:v0.88-d2iq-server-name.2
     sources:
       - license_path: LICENSE

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -381,7 +381,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/brancz/kube-rbac-proxy
-  - container_image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+  - container_image: docker.io/kubebuilder/kube-rbac-proxy:v0.16.0
     sources:
       - license_path: LICENSE
         ref: ${image_tag}

--- a/services/git-operator/0.1.0/additional-images.txt
+++ b/services/git-operator/0.1.0/additional-images.txt
@@ -1,0 +1,2 @@
+docker.io/mesosphere/gitwebserver:v0.8.3
+nginxinc/nginx-unprivileged:1.25.4-alpine

--- a/services/git-operator/0.1.0/git-operator-manifests/all.yaml
+++ b/services/git-operator/0.1.0/git-operator-manifests/all.yaml
@@ -699,7 +699,7 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --namespace=${NAMESPACE:=git-operator-system}
-        image: docker.io/mesosphere/git-operator:v0.8.3@sha256:3a4c42890549394bbe3842d99c7bf143334c19dc6e8d13413cd796c219aead8e
+        image: docker.io/mesosphere/git-operator:v0.8.3
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
**What problem does this PR solve?**:
Makes the airgapped installation (incl. airgapped validation tests) work with Git Operator.

**Which issue(s) does this PR fix?**:
A temporary solution to https://jira.nutanix.com/browse/NCN-101519

**Special notes for your reviewer**:
The local docker registry used in Kommander airgapped validation tests (and probably some other docker registry) exhibits a weird behaviour where it fails to provide an image when the image ref uses the `image:tag@sha256...` syntax; this is why this PR strips the SHA part in `git-operator` manifests.
 
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
