### PR TITLE
fix(kubernetes-dashboard): Make deployable on gke

### DIFF
--- a/services/kubernetes-dashboard/7.5.0/defaults/cm.yaml
+++ b/services/kubernetes-dashboard/7.5.0/defaults/cm.yaml
@@ -12,45 +12,6 @@ data:
       priorityClassName: dkp-high-priority
       image:
         pullPolicy: Always
-      api:
-        containers:
-          args:
-            - --namespace=${releaseNamespace}
-          resources:
-            requests:
-              cpu: 100m
-              memory: 200Mi
-            limits:
-              cpu: 500m
-              memory: 1000Mi
-      auth:
-        containers:
-          resources:
-            requests:
-              cpu: 100m
-              memory: 200Mi
-            limits:
-              cpu: 250m
-              memory: 400Mi
-      web:
-        containers:
-          resources:
-            requests:
-              cpu: 100m
-              memory: 200Mi
-            limits:
-              cpu: 500m
-              memory: 1000Mi
-      metricsScraper:
-        enabled: true
-        containers:
-          resources:
-            requests:
-              cpu: 100m
-              memory: 200Mi
-            limits:
-              cpu: 250m
-              memory: 400Mi
       ingress:
         enabled: true
         ingressClassName: kommander-traefik
@@ -60,3 +21,42 @@ data:
           traefik.ingress.kubernetes.io/router.middlewares: "kommander-stripprefixes@kubernetescrd,kommander-forwardauth-full@kubernetescrd"
         path: /dkp/kubernetes
         hosts: ~
+    api:
+      containers:
+        args:
+          - --namespace=${releaseNamespace}
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+          limits:
+            cpu: 500m
+            memory: 1000Mi
+    auth:
+      containers:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+          limits:
+            cpu: 250m
+            memory: 400Mi
+    web:
+      containers:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+          limits:
+            cpu: 500m
+            memory: 1000Mi
+    metricsScraper:
+      enabled: true
+      containers:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+          limits:
+            cpu: 250m
+            memory: 400Mi

--- a/services/kubernetes-dashboard/7.5.0/defaults/cm.yaml
+++ b/services/kubernetes-dashboard/7.5.0/defaults/cm.yaml
@@ -60,3 +60,7 @@ data:
           limits:
             cpu: 250m
             memory: 400Mi
+    kong:
+      admin:
+        tls:
+          enabled: false


### PR DESCRIPTION
**What problem does this PR solve?**:
awsgke e2e tests are failing on kubernetes-dashboard failing to come up ready. Trying to see how to fix it.
Also, found a few indentation errors in values.yaml

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-101453

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
