### PR TITLE
feat: Add chartmuseum ingress

### DIFF
--- a/services/chartmuseum/3.10.2/ingress.yaml
+++ b/services/chartmuseum/3.10.2/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: kommander-traefik
+    traefik.ingress.kubernetes.io/router.middlewares: "kommander-stripprefixes@kubernetescrd"
+    traefik.ingress.kubernetes.io/router.tls: "true"
+  labels:
+    app: helm-mirror
+  name: kommander-helm-mirror
+  namespace: kommander
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: chartmuseum
+            port:
+              number: 8080
+        path: /dkp/kommander/helm-mirror
+        pathType: Prefix

--- a/services/chartmuseum/3.10.2/kustomization.yaml
+++ b/services/chartmuseum/3.10.2/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - chartmuseum.yaml
+  - ingress.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:
It looks like chartmuseum manifests only existed in the k-cli:

https://github.com/mesosphere/kommander-cli/blob/main/pkg/chartmuseum/manifests/ingress.yaml

Let's move it here so we can deploy a fully functional chartmuseum without the cli.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
