### PR TITLE
chore: remove old k8s version bloodhound validation

### DIFF
--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -1,11 +1,6 @@
 # Kubernetes versions
 # (e.g. 1.23.0 - has to match versions in https://github.com/yannh/kubernetes-json-schema)
 k8s_versions:
-  - 1.23.6
-  - 1.24.6
-  - 1.25.4
-  - 1.26.6
-  - 1.27.6
   - 1.28.7
   - 1.29.6
   - 1.30.1


### PR DESCRIPTION
**What problem does this PR solve?**:
We don't need to validate pre 1.28 k8s versions compatibility.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
