### PR TITLE
fix: kubecost patched image with fixed CVEs

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -1,7 +1,7 @@
 ignore:
   - ghcr.io/mesosphere/dkp-container-images/docker.io/mesosphere/grafana-plugins:v0.0.1-d2iq.0
   - gcr.io/kubecost1/cost-model:prod-1.106.7
-  - gcr.io/kubecost1/frontend:prod-1.106.7
+  - ghcr.io/mesosphere/dkp-container-images/gcr.io/kubecost1/frontend:prod-1.106.7-d2iq.0
   - docker.io/mesosphere/trivy-bundles:0.49.1-20240301T193636Z
   - gcr.io/google_containers/pause:3.2
 

--- a/services/centralized-kubecost/0.37.4/defaults/cm.yaml
+++ b/services/centralized-kubecost/0.37.4/defaults/cm.yaml
@@ -14,7 +14,7 @@ data:
     cost-analyzer:
       fullnameOverride: "kommander-kubecost-cost-analyzer"
       kubecostFrontend:
-        image: ghcr.io/mesosphere/dkp-container-images/gcr.io/kubecost1/frontend
+        fullImageName: ghcr.io/mesosphere/dkp-container-images/gcr.io/kubecost1/frontend:prod-1.106.7-d2iq.0
       priority:
         enabled: true
         name: dkp-high-priority

--- a/services/centralized-kubecost/0.37.4/defaults/cm.yaml
+++ b/services/centralized-kubecost/0.37.4/defaults/cm.yaml
@@ -13,7 +13,8 @@ data:
 
     cost-analyzer:
       fullnameOverride: "kommander-kubecost-cost-analyzer"
-
+      kubecostFrontend:
+        image: ghcr.io/mesosphere/dkp-container-images/gcr.io/kubecost1/frontend
       priority:
         enabled: true
         name: dkp-high-priority

--- a/services/kubecost/0.37.4/defaults/cm.yaml
+++ b/services/kubecost/0.37.4/defaults/cm.yaml
@@ -13,7 +13,7 @@ data:
 
     cost-analyzer:
       kubecostFrontend:
-        fullImageName:: ghcr.io/mesosphere/dkp-container-images/gcr.io/kubecost1/frontend:prod-1.106.7-d2iq.0
+        fullImageName: ghcr.io/mesosphere/dkp-container-images/gcr.io/kubecost1/frontend:prod-1.106.7-d2iq.0
       priority:
         enabled: true
         name: dkp-high-priority

--- a/services/kubecost/0.37.4/defaults/cm.yaml
+++ b/services/kubecost/0.37.4/defaults/cm.yaml
@@ -12,10 +12,12 @@ data:
         priorityClassName: dkp-high-priority
 
     cost-analyzer:
+      kubecostFrontend:
+        image: ghcr.io/mesosphere/dkp-container-images/gcr.io/kubecost1/frontend
       priority:
         enabled: true
         name: dkp-high-priority
-
+        
       global:
         prometheus:
           enabled: true

--- a/services/kubecost/0.37.4/defaults/cm.yaml
+++ b/services/kubecost/0.37.4/defaults/cm.yaml
@@ -13,11 +13,11 @@ data:
 
     cost-analyzer:
       kubecostFrontend:
-        image: ghcr.io/mesosphere/dkp-container-images/gcr.io/kubecost1/frontend
+        fullImageName:: ghcr.io/mesosphere/dkp-container-images/gcr.io/kubecost1/frontend:prod-1.106.7-d2iq.0
       priority:
         enabled: true
         name: dkp-high-priority
-        
+
       global:
         prometheus:
           enabled: true


### PR DESCRIPTION
**What problem does this PR solve?**:
Patch kubecost image with fixed CVE's

workflow link:
https://github.com/mesosphere/dkp-container-images/actions/runs/9833998335

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-101394

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
