### PR TITLE
feat: Fix Traefik rewrite for api url

### DIFF
--- a/services/traefik/27.0.2/defaults/cm.yaml
+++ b/services/traefik/27.0.2/defaults/cm.yaml
@@ -135,8 +135,8 @@ data:
               plugin:
                 plugin-rewritebody:
                   rewrites:
-                    - regex: "/api"
-                      replacement: "/dkp/traefik/api"
+                    - regex: apiUrl:\"/api\"
+                      replacement: apiUrl:"/dkp/traefik/api"
             EOF
     resources:
       limits:


### PR DESCRIPTION
**What problem does this PR solve?**:

Work around for Traefik issue: https://github.com/traefik/traefik/issues/5853

URLs with `api` later in the URL are also being rewritten resulting in a 404.

As a workaround, pin the match to the beginning of the URL by matching the label too:

```
      rewrites:
      - regex: apiUrl:\"/api\"
        replacement: apiUrl:"/dkp/traefik/api"
```

See Slack: https://nutanix.slack.com/archives/C067BPT2MQ9/p1719940306056019

**Which issue(s) does this PR fix?**:

https://jira.nutanix.com/browse/NCN-101671

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
