### PR TITLE
feat: Bump git operator to v0.11.0

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -164,11 +164,11 @@ resources:
     sources:
       - ref: ${image_tag}
         url: https://github.com/mesosphere/dkp-insights
-  - container_image: docker.io/mesosphere/git-operator:v0.10.0
+  - container_image: docker.io/mesosphere/git-operator:v0.11.0
     sources:
       - ref: ${image_tag}
         url: https://github.com/mesosphere/git-operator
-  - container_image: docker.io/mesosphere/gitwebserver:v0.10.0
+  - container_image: docker.io/mesosphere/gitwebserver:v0.11.0
     sources:
       - ref: ${image_tag}
         url: https://github.com/mesosphere/git-operator

--- a/services/git-operator/0.1.0/additional-images.txt
+++ b/services/git-operator/0.1.0/additional-images.txt
@@ -1,2 +1,2 @@
-docker.io/mesosphere/gitwebserver:v0.10.0
+docker.io/mesosphere/gitwebserver:v0.11.0
 nginxinc/nginx-unprivileged:1.25.4-alpine

--- a/services/git-operator/0.1.0/git-operator-manifests/all.yaml
+++ b/services/git-operator/0.1.0/git-operator-manifests/all.yaml
@@ -709,7 +709,7 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --namespace=${NAMESPACE:=git-operator-system}
-        image: docker.io/mesosphere/git-operator:v0.10.0
+        image: docker.io/mesosphere/git-operator:v0.11.0
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumping git operator to v0.11.0

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
