### PR TITLE
fix: patched git-operator Nginx image in airgapped bundle

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -598,10 +598,10 @@ resources:
       - url: https://github.com/nginx/nginx
         ref: release-${image_tag%-alpine}
         license_path: docs/text/LICENSE
-  - container_image: docker.io/nginxinc/nginx-unprivileged:1.25.4-alpine
+  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.25.5-alpine-d2iq.0
     sources:
       - url: https://github.com/nginx/nginx
-        ref: release-${image_tag%-alpine}
+        ref: release-${image_tag%-alpine-d2iq.0}
         license_path: docs/text/LICENSE
   - container_image: bitnami/external-dns:0.14.2-debian-12-r7
     sources:

--- a/services/git-operator/0.1.0/additional-images.txt
+++ b/services/git-operator/0.1.0/additional-images.txt
@@ -1,2 +1,2 @@
 docker.io/mesosphere/gitwebserver:v0.11.0
-nginxinc/nginx-unprivileged:1.25.4-alpine
+ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.25.5-alpine-d2iq.0


### PR DESCRIPTION
**What problem does this PR solve?**:
https://nutanix.slack.com/archives/C06A78Y063B/p1722245168452669

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
