### PR TITLE
feat: Fix issue with Kubernetes dashboard in other namespaces

### DIFF
--- a/services/kubernetes-dashboard/7.5.0/defaults/cm.yaml
+++ b/services/kubernetes-dashboard/7.5.0/defaults/cm.yaml
@@ -18,7 +18,7 @@ data:
         annotations:
           kubernetes.io/ingress.class: kommander-traefik
           traefik.ingress.kubernetes.io/router.tls: "true"
-          traefik.ingress.kubernetes.io/router.middlewares: "kommander-stripprefixes@kubernetescrd,kommander-forwardauth-full@kubernetescrd"
+          traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth-full@kubernetescrd"
         path: /dkp/kubernetes
         hosts: ~
     api:


### PR DESCRIPTION
**What problem does this PR solve?**:

Fis regression with ingress to handle other namespaces. This was causing issues in the workload clusters.

**Which issue(s) does this PR fix?**:

https://jira.nutanix.com/browse/NCN-101835

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
