### PR TITLE
chore: bump kubetunnel to v0.0.34

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -229,19 +229,19 @@ resources:
     sources:
       - ref: ${image_tag}
         url: https://github.com/mesosphere/kubeaddons-extrasteps
-  - container_image: docker.io/mesosphere/kubetunnel-controller:v0.0.33
+  - container_image: docker.io/mesosphere/kubetunnel-controller:v0.0.34
     sources:
       - ref: ${image_tag}
         url: https://github.com/mesosphere/kubetunnel
-  - container_image: docker.io/mesosphere/kubetunnel-kubeconfig-webhook:v0.0.33
+  - container_image: docker.io/mesosphere/kubetunnel-kubeconfig-webhook:v0.0.34
     sources:
       - ref: ${image_tag}
         url: https://github.com/mesosphere/kubetunnel
-  - container_image: docker.io/mesosphere/kubetunnel-reverse-proxy:v0.0.33
+  - container_image: docker.io/mesosphere/kubetunnel-reverse-proxy:v0.0.34
     sources:
       - ref: ${image_tag}
         url: https://github.com/mesosphere/kubetunnel
-  - container_image: docker.io/mesosphere/kubetunnel-webhook:v0.0.33
+  - container_image: docker.io/mesosphere/kubetunnel-webhook:v0.0.34
     sources:
       - ref: ${image_tag}
         url: https://github.com/mesosphere/kubetunnel

--- a/services/kubetunnel/0.0.34/kubetunnel.yaml
+++ b/services/kubetunnel/0.0.34/kubetunnel.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-kubetunnel-charts
         namespace: kommander-flux
-      version: v0.0.33
+      version: v0.0.34
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:
bump kubetunnel to v0.0.34

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
