### PR TITLE
fix: add license mapping for remaining images

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -1,9 +1,6 @@
 ignore:
   - ghcr.io/mesosphere/dkp-container-images/docker.io/mesosphere/grafana-plugins:v0.0.1-d2iq.0
-  - gcr.io/kubecost1/cost-model:prod-1.106.7
-  - ghcr.io/mesosphere/dkp-container-images/gcr.io/kubecost1/frontend:prod-1.106.7-d2iq.0
   - docker.io/mesosphere/trivy-bundles:0.53.0-20240726T101319Z
-  - gcr.io/google_containers/pause:3.2
 
 resources:
   - container_image: ghcr.io/mesosphere/dkp-container-images/cr.fluentbit.io/fluent/fluent-bit:2.2.3-d2iq.0
@@ -616,5 +613,20 @@ resources:
   - container_image: docker.io/library/busybox:1
     sources:
       - url: https://github.com/mirror/busybox
+        ref: master
+        license_path: LICENSE
+  - container_image: gcr.io/kubecost1/cost-model:prod-1.106.7
+    sources:
+      - url: https://github.com/opencost/opencost
+        ref: v${image_tag#prod-}
+        license_path: LICENSE
+  - container_image: ghcr.io/mesosphere/dkp-container-images/gcr.io/kubecost1/frontend:prod-1.106.7-d2iq.0
+    sources:
+      - url: https://github.com/opencost/opencost
+        ref: v1.106.7
+        license_path: LICENSE
+  - container_image: gcr.io/google_containers/pause:3.2
+    sources:
+      - url: https://github.com/kubernetes/kubernetes
         ref: master
         license_path: LICENSE


### PR DESCRIPTION
**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
