### PR TITLE
fix: the list-images regex

### DIFF
--- a/hack/list-images.sh
+++ b/hack/list-images.sh
@@ -139,7 +139,7 @@ gojq --yaml-input --raw-output 'select(.kind | test("^(?:Deployment|Job|CronJob|
 # Ensure that all images are fully qualified to ensure uniqueness of images in the image bundle.
 sed --expression='s|^docker.io/||' \
     --expression='s|\(^[^/]\+$\)|library/\1|' \
-    --expression='s|\(^[^/]\+/[^/]\+$\)|docker.io/\1|' \
+    --expression='/^registry\.k8s\.io\//b; s|\(^[^/]\+/[^/]\+$\)|docker.io/\1|' \
     --expression='s|\(^[^:]\+:\?$\)|\1:latest|' \
     --expression='/^[[:space:]]*$/d' \
     --expression='/ai-navigator-/d' \


### PR DESCRIPTION
**What problem does this PR solve?**:
 err="failed to read image descriptor for "docker.io/registry.k8s.io/pause:3.10" from registry: GET https://index.docker.io/v2/registry.k8s.io/pause/manifests/3.10: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:registry.k8s.io/pause Type:repository]]"

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
