### PR TITLE
docs: removing old dkp references

### DIFF
--- a/services/velero/metadata.yaml
+++ b/services/velero/metadata.yaml
@@ -23,7 +23,6 @@ overview: |-
   Velero offers key data protection features, such as scheduled backups, retention schedules, and pre- or post-backup hooks for custom actions. The tool can help protect data stored in persistent volumes and makes your entire Kubernetes cluster more resilient.
 
   ## Dependency on Rook Ceph Cluster
-  In previous versions of DKP (2.3.x), Velero was configured to deploy a standalone MinIO upon demand. In NKP 2.4.x and above, MinIO is replaced with Rook Ceph Cluster as the default Backend.
   If you plan to use Velero with Ceph, you must explicitly install Rook Ceph Cluster to use Velero (E.g.: on-prem clusters). It is recommended to use a storage backend that is outside your NKP cluster for production environments (so that the availability of backups is detached from cluster availability).
   If you plan to use Velero with any other S3 provider (E.g.: Amazon S3, Azure Storage Service, or Google Cloud Storage etc.,) then you don't need to install Rook Ceph Cluster.
 


### PR DESCRIPTION
**What problem does this PR solve?**:

There is an old reference to a now-unsupported version of DKP.
This removes that.

**Which issue(s) does this PR fix?**:
N/A

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
solely text on the application details page.

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
