### PR TITLE
feat: Add Pro Apps autodeploy list

### DIFF
--- a/services/kommander/0.12.0/defaults/cm.yaml
+++ b/services/kommander/0.12.0/defaults/cm.yaml
@@ -76,6 +76,18 @@ data:
       - "prometheus-thanos-traefik"
       - "thanos"
       - "nkp-insights-management"
+      defaultProApps:
+      - "ai-navigator-app"
+      - "grafana-logging"
+      - "grafana-loki"
+      - "kube-prometheus-stack"
+      - "kubernetes-dashboard"
+      - "kubetunnel"
+      - "logging-operator"
+      - "prometheus-adapter"
+      - "rook-ceph"
+      - "rook-ceph-cluster"
+      - "velero"
     kommander-ui:
       enabled: false
     capimate:


### PR DESCRIPTION
**What problem does this PR solve?**:

Adds a list of Apps which need to be deployed for Nutanix infra only when upgrading from `Starter` to `Pro`/`Essentials` licenses.

For non-Nutanix infra, this set of apps is configured and installed by Kommander CLI.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://jira.nutanix.com/browse/NCN-101939

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
