### PR TITLE
fix(kiali): Override to use distroless kiali image

### DIFF
--- a/services/kiali/1.87.0/defaults/cm.yaml
+++ b/services/kiali/1.87.0/defaults/cm.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   values.yaml: |
     priorityClassName: dkp-high-priority
+    allowAdHocKialiImage: true
     cr:
       create: true
       namespace: ${releaseNamespace}
@@ -35,6 +36,7 @@ data:
             use_grpc: true
         deployment:
           priority_class_name: dkp-high-priority
+          image_version: v1.87.0-distro
           accessible_namespaces:
           - '**'
           ingress:


### PR DESCRIPTION
**What problem does this PR solve?**:
We must override the kiali image to the distroless image (to resolve CVEs)
Relevant: https://github.com/kiali/kiali/issues/6580

Tested on the daily cluster

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-102082

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
