### PR TITLE
fix(kiali): Override to use distroless kiali image

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -465,7 +465,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/kiali/kiali-operator
-  - container_image: quay.io/kiali/kiali:v1.87.0-distro
+  - container_image: quay.io/kiali/kiali:v1.88.0-distro
     sources:
       - license_path: LICENSE
         ref: ${image_tag%-distro}

--- a/services/kiali/1.88.0/defaults/cm.yaml
+++ b/services/kiali/1.88.0/defaults/cm.yaml
@@ -36,7 +36,7 @@ data:
             use_grpc: true
         deployment:
           priority_class_name: dkp-high-priority
-          image_version: v1.87.0-distro
+          image_version: v1.88.0-distro
           accessible_namespaces:
           - '**'
           ingress:

--- a/services/kiali/1.88.0/defaults/cm.yaml
+++ b/services/kiali/1.88.0/defaults/cm.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   values.yaml: |
     priorityClassName: dkp-high-priority
+    allowAdHocKialiImage: true
     cr:
       create: true
       namespace: ${releaseNamespace}
@@ -35,6 +36,7 @@ data:
             use_grpc: true
         deployment:
           priority_class_name: dkp-high-priority
+          image_version: v1.87.0-distro
           accessible_namespaces:
           - '**'
           ingress:

--- a/services/kiali/1.88.0/extra-images.txt
+++ b/services/kiali/1.88.0/extra-images.txt
@@ -1,1 +1,1 @@
-quay.io/kiali/kiali:v1.87.0-distro
+quay.io/kiali/kiali:v1.88.0-distro

--- a/services/kiali/1.88.0/kiali.yaml
+++ b/services/kiali/1.88.0/kiali.yaml
@@ -44,7 +44,7 @@ data:
   dashboardLink: "/dkp/kiali"
   docsLink: "https://istio.io/docs/tasks/telemetry/kiali/"
   # Chart version matches app version
-  version: "1.87.0"
+  version: "1.88.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
(cherry picked from commit b810b70599ea60cfd7e5ed27fcf63a0740d9f414)

**What problem does this PR solve?**:
backports https://github.com/mesosphere/kommander-applications/pull/2573

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-102082

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
