### PR TITLE
feat: Update upgrade-matrix.yaml in post-upgrade

### DIFF
--- a/hack/release/cmd/postrelease/postrelease.go
+++ b/hack/release/cmd/postrelease/postrelease.go
@@ -2,6 +2,7 @@ package postrelease
 
 import (
 	"fmt"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/upgradematrix"
 	"log"
 	"os"
 
@@ -54,6 +55,16 @@ func init() { //nolint:gochecknoinits // Initializing cobra application.
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Updated Kommander chart version to %s", chartVersion)
+
+			if err := upgradematrix.UpdateUpgradeMatrix(
+				cmd.Context(),
+				kommanderApplicationsRepo,
+			); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Updated upgrade matrix")
+
 			return nil
 		},
 	}

--- a/hack/release/cmd/postrelease/postrelease.go
+++ b/hack/release/cmd/postrelease/postrelease.go
@@ -2,13 +2,13 @@ package postrelease
 
 import (
 	"fmt"
-	"github.com/mesosphere/kommander-applications/hack/release/pkg/upgradematrix"
 	"log"
 	"os"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/appversion"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/chartversion"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/upgradematrix"
 	"github.com/spf13/cobra"
 )
 

--- a/hack/release/pkg/upgradematrix/upgradematrix.go
+++ b/hack/release/pkg/upgradematrix/upgradematrix.go
@@ -1,0 +1,32 @@
+package upgradematrix
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func UpdateUpgradeMatrix(ctx context.Context, kommanderApplicationsRepo string) error {
+	cmd := exec.CommandContext(ctx,
+		"bash",
+		"-c",
+		"gh dkp generate upgrade-matrix --json | yq -p json -o yaml",
+	)
+	cmd.Dir = kommanderApplicationsRepo
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("gh dkp generate upgrade-matrix command failed: %s", string(output))
+		return err
+	}
+
+	err = os.WriteFile(filepath.Join(kommanderApplicationsRepo, "upgrade-matrix.yaml"), output, 0644)
+	if err != nil {
+		log.Print("cannot write upgrade-matrix.yaml")
+		return err
+	}
+
+	return nil
+}

--- a/hack/release/pkg/upgradematrix/upgradematrix.go
+++ b/hack/release/pkg/upgradematrix/upgradematrix.go
@@ -2,11 +2,15 @@ package upgradematrix
 
 import (
 	"context"
+	"errors"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
+
+var ErrDKPNotFound = errors.New("gh dkp command not found")
 
 func UpdateUpgradeMatrix(ctx context.Context, kommanderApplicationsRepo string) error {
 	cmd := exec.CommandContext(ctx,
@@ -20,6 +24,11 @@ func UpdateUpgradeMatrix(ctx context.Context, kommanderApplicationsRepo string) 
 	if err != nil {
 		log.Printf("gh dkp generate upgrade-matrix command failed: %s", string(output))
 		return err
+	}
+
+	// Check output to determine if dkp extension is installed
+	if strings.Contains(string(output), "unknown command \"dkp") {
+		return ErrDKPNotFound
 	}
 
 	err = os.WriteFile(filepath.Join(kommanderApplicationsRepo, "upgrade-matrix.yaml"), output, 0644)

--- a/hack/release/pkg/upgradematrix/upgradematrix_test.go
+++ b/hack/release/pkg/upgradematrix/upgradematrix_test.go
@@ -30,7 +30,6 @@ func TestUpdateUpgradeMatrix(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check that the file has been regenerated
-	// Read the file and compare it to the expected content
 	fileContent, err := os.ReadFile(filepath.Join(dir, "upgrade-matrix.yaml"))
 	require.NoError(t, err)
 

--- a/hack/release/pkg/upgradematrix/upgradematrix_test.go
+++ b/hack/release/pkg/upgradematrix/upgradematrix_test.go
@@ -2,6 +2,7 @@ package upgradematrix
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,6 +28,9 @@ func TestUpdateUpgradeMatrix(t *testing.T) {
 	require.NoError(t, err)
 
 	err = UpdateUpgradeMatrix(context.Background(), dir)
+	if errors.Is(err, ErrDKPNotFound) {
+		t.Skip("Skipping test as gh dkp not installed.")
+	}
 	require.NoError(t, err)
 
 	// Check that the file has been regenerated

--- a/hack/release/pkg/upgradematrix/upgradematrix_test.go
+++ b/hack/release/pkg/upgradematrix/upgradematrix_test.go
@@ -1,0 +1,49 @@
+package upgradematrix
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testFile = `upgrades:
+  - from: v1.2.3
+    to: v4.5.6
+    k8s_version: "1.34"`
+
+const expectedContent = `upgrades:
+  - from:`
+
+func TestUpdateUpgradeMatrix(t *testing.T) {
+	dir := fetchRepo(t)
+
+	// Replace the file with test data
+	err := os.WriteFile(filepath.Join(dir, "upgrade-matrix.yaml"), []byte(testFile), 0644)
+	require.NoError(t, err)
+
+	err = UpdateUpgradeMatrix(context.Background(), dir)
+	require.NoError(t, err)
+
+	// Check that the file has been regenerated
+	// Read the file and compare it to the expected content
+	fileContent, err := os.ReadFile(filepath.Join(dir, "upgrade-matrix.yaml"))
+	require.NoError(t, err)
+
+	require.Contains(t, string(fileContent), expectedContent)
+	require.NotContains(t, string(fileContent), testFile)
+}
+
+func fetchRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	cmd := exec.Command("git", "clone", strings.Repeat("../", 4), dir)
+	require.NoError(t, cmd.Run())
+
+	return dir
+}


### PR DESCRIPTION
**What problem does this PR solve?**:

Update `upgrade-matrix.yaml` in post release.


**Which issue(s) does this PR fix?**:

https://jira.nutanix.com/browse/NCN-100509

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

Test manually with `go run . post-release --version v1.2.3 --repo <path to kommander-applications>` in `hack/release` with `gh-dkp` installed.


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
