### PR TITLE
fix: Unprivileged/CVE fix

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -590,12 +590,12 @@ resources:
       - url: https://github.com/prometheus-community/postgres_exporter
         ref: v0.12.0
         license_path: LICENSE
-  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.27.1-alpine-d2iq.0
+  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.27-alpine-d2iq.0
     sources:
       - url: https://github.com/nginx/nginx
         ref: release-${image_tag%-alpine-d2iq.0}
         license_path: docs/text/LICENSE
-  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.27.1-alpine-d2iq.0
+  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.27-alpine-d2iq.0
     sources:
       - url: https://github.com/nginx/nginx
         ref: release-${image_tag%-alpine-d2iq.0}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -590,12 +590,12 @@ resources:
       - url: https://github.com/prometheus-community/postgres_exporter
         ref: v0.12.0
         license_path: LICENSE
-  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.25.5-alpine-d2iq.0
+  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.27.1-alpine-d2iq.0
     sources:
       - url: https://github.com/nginx/nginx
         ref: release-${image_tag%-alpine-d2iq.0}
         license_path: docs/text/LICENSE
-  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.25.5-alpine-d2iq.0
+  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.27.1-alpine-d2iq.0
     sources:
       - url: https://github.com/nginx/nginx
         ref: release-${image_tag%-alpine-d2iq.0}

--- a/services/git-operator/0.1.0/git-operator-manifests/all.yaml
+++ b/services/git-operator/0.1.0/git-operator-manifests/all.yaml
@@ -955,7 +955,7 @@ spec:
         app.kubernetes.io/name: git-operator
     spec:
       containers:
-      - image: ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.27.1-alpine-d2iq.0
+      - image: ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.27-alpine-d2iq.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/services/git-operator/0.1.0/git-operator-manifests/all.yaml
+++ b/services/git-operator/0.1.0/git-operator-manifests/all.yaml
@@ -955,7 +955,7 @@ spec:
         app.kubernetes.io/name: git-operator
     spec:
       containers:
-      - image: ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.27.1-alpine-d2iq.0
+      - image: ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.25.5-alpine-d2iq.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/services/git-operator/0.1.0/git-operator-manifests/all.yaml
+++ b/services/git-operator/0.1.0/git-operator-manifests/all.yaml
@@ -955,7 +955,7 @@ spec:
         app.kubernetes.io/name: git-operator
     spec:
       containers:
-      - image: ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.25.5-alpine-d2iq.0
+      - image: ghcr.io/mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged:1.27.1-alpine-d2iq.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/services/grafana-loki/0.79.2/defaults/cm.yaml
+++ b/services/grafana-loki/0.79.2/defaults/cm.yaml
@@ -188,7 +188,7 @@ data:
         # As of 0.48.4, chart maintainers are still using 1.19-alpine.
         registry: ghcr.io
         repository: mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged
-        tag: 1.27.1-alpine-d2iq.0
+        tag: 1.27-alpine-d2iq.0
       nginxConfig:
         httpSnippet: |-
           client_max_body_size 10M;

--- a/services/grafana-loki/0.79.2/defaults/cm.yaml
+++ b/services/grafana-loki/0.79.2/defaults/cm.yaml
@@ -188,7 +188,7 @@ data:
         # As of 0.48.4, chart maintainers are still using 1.19-alpine.
         registry: ghcr.io
         repository: mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged
-        tag: 1.25.5-alpine-d2iq.0
+        tag: 1.27.1-alpine-d2iq.0
       nginxConfig:
         httpSnippet: |-
           client_max_body_size 10M;

--- a/services/project-grafana-loki/0.79.2/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.79.2/defaults/cm.yaml
@@ -196,7 +196,7 @@ data:
         # As of 0.48.4, chart maintainers are still using 1.19-alpine.
         registry: ghcr.io
         repository: mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged
-        tag: 1.27.1-alpine-d2iq.0
+        tag: 1.27-alpine-d2iq.0
       verboseLogging: false
       nginxConfig:
         httpSnippet: |-

--- a/services/project-grafana-loki/0.79.2/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.79.2/defaults/cm.yaml
@@ -196,7 +196,7 @@ data:
         # As of 0.48.4, chart maintainers are still using 1.19-alpine.
         registry: ghcr.io
         repository: mesosphere/dkp-container-images/docker.io/nginxinc/nginx-unprivileged
-        tag: 1.25.5-alpine-d2iq.0
+        tag: 1.27.1-alpine-d2iq.0
       verboseLogging: false
       nginxConfig:
         httpSnippet: |-


### PR DESCRIPTION
What problem does this PR solve?:
update and nginx-unprivileged image with fixed CVE's

trivy i nginxinc/nginx-unprivileged:1.27.1-alpine
2024-09-09T11:20:55Z    INFO    Vulnerability scanning is enabled
2024-09-09T11:20:55Z    INFO    Secret scanning is enabled
2024-09-09T11:20:55Z    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-09-09T11:20:55Z    INFO    Please see also https://aquasecurity.github.io/trivy/dev/docs/scanner/secret#recommendation for faster secret detection
2024-09-09T11:20:56Z    INFO    Detected OS     family="alpine" version="3.20.3"
2024-09-09T11:20:56Z    INFO    [alpine] Detecting vulnerabilities...   os_version="3.20" repository="3.20" pkg_num=66
2024-09-09T11:20:56Z    INFO    Number of language-specific files       num=0nginxinc/nginx-unprivileged:1.27.1-alpine (alpine 3.20.3)Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

Which issue(s) does this PR fix?:
https://jira.nutanix.com/browse/NCN-102436