### PR TITLE
feat: Update upgrade-matrix.yaml in post-upgrade based on env variable

### DIFF
--- a/hack/release/cmd/postrelease/postrelease.go
+++ b/hack/release/cmd/postrelease/postrelease.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/appversion"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/chartversion"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/upgradematrix"
 	"github.com/spf13/cobra"
 )
 
@@ -54,6 +55,14 @@ func init() { //nolint:gochecknoinits // Initializing cobra application.
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Updated Kommander chart version to %s", chartVersion)
+
+			if err := upgradematrix.UpdateUpgradeMatrix(
+				cmd.Context(),
+				kommanderApplicationsRepo,
+			); err != nil {
+				return err
+			}
+
 			return nil
 		},
 	}

--- a/hack/release/pkg/upgradematrix/upgradematrix.go
+++ b/hack/release/pkg/upgradematrix/upgradematrix.go
@@ -1,0 +1,44 @@
+package upgradematrix
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	upgradeMatrixEnv  = "NKP_RELEASE_AUTOMATION_UPGRADE_MATRIX"
+	upgradeMatrixFile = "upgrade-matrix.yaml"
+)
+
+var ErrIncorrectFormat = errors.New("upgrade matrix does not appear to be in the correct format, unable to update upgrade-matrix.yaml")
+
+// UpdateUpgradeMatrix updates the upgrade-matrix.yaml file in the kommander-applications repository with the contents \
+// of the upgradeMatrixEnv environment variable.
+func UpdateUpgradeMatrix(ctx context.Context, kommanderApplicationsRepo string) error {
+	// Get the upgrade matrix environment variable
+	upgradeMatrix := os.Getenv(upgradeMatrixEnv)
+	if upgradeMatrix == "" {
+		log.Printf("upgrade matrix environment variable %s is empty, unable to update upgrade-matrix.yaml", upgradeMatrixEnv)
+		return nil
+	}
+
+	// Check that upgradeMatrix appears to be correct
+	if !strings.HasPrefix(upgradeMatrix, "upgrades:") {
+		return ErrIncorrectFormat
+	}
+
+	// Write the upgrade matrix to the file
+	err := os.WriteFile(filepath.Join(kommanderApplicationsRepo, upgradeMatrixFile), []byte(upgradeMatrix), 0644)
+	if err != nil {
+		log.Print("cannot write upgrade-matrix.yaml")
+		return err
+	}
+
+	log.Print("Updated upgrade matrix")
+
+	return nil
+}

--- a/hack/release/pkg/upgradematrix/upgradematrix_test.go
+++ b/hack/release/pkg/upgradematrix/upgradematrix_test.go
@@ -38,6 +38,7 @@ func TestUpdateUpgradeMatrix(t *testing.T) {
 
 	// Expected update value
 	err = os.Setenv(upgradeMatrixEnv, expectedContent)
+	require.NoError(t, err)
 
 	err = UpdateUpgradeMatrix(context.Background(), dir)
 	require.NoError(t, err)
@@ -59,6 +60,7 @@ func TestUpdateUpgradeMatrixNoEnv(t *testing.T) {
 
 	// Ensure that the environment variable is empty
 	err = os.Setenv(upgradeMatrixEnv, "")
+	require.NoError(t, err)
 
 	err = UpdateUpgradeMatrix(context.Background(), dir)
 	require.NoError(t, err)

--- a/hack/release/pkg/upgradematrix/upgradematrix_test.go
+++ b/hack/release/pkg/upgradematrix/upgradematrix_test.go
@@ -1,0 +1,81 @@
+package upgradematrix
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testFile = `upgrades:
+  - from: v1.2.3
+    to: v4.5.6
+    k8s_version: "1.34"
+`
+
+const expectedContent = `upgrades:
+  - from: v2.8.0
+    to: v2.8.2-dev
+    k8s_version: "1.28"
+  - from: v2.8.1
+    to: v2.8.2-dev
+    k8s_version: "1.28"
+  - from: v2.8.2-dev
+    to: v2.12.0-dev
+    k8s_version: "1.28"
+`
+
+func TestUpdateUpgradeMatrix(t *testing.T) {
+	dir := fetchRepo(t)
+
+	// Replace the existing file with known test data
+	err := os.WriteFile(filepath.Join(dir, "upgrade-matrix.yaml"), []byte(testFile), 0644)
+	require.NoError(t, err)
+
+	// Expected update value
+	err = os.Setenv(upgradeMatrixEnv, expectedContent)
+
+	err = UpdateUpgradeMatrix(context.Background(), dir)
+	require.NoError(t, err)
+
+	// Check that the file has been regenerated
+	fileContent, err := os.ReadFile(filepath.Join(dir, "upgrade-matrix.yaml"))
+	require.NoError(t, err)
+
+	require.Equal(t, string(fileContent), expectedContent)
+	require.NotContains(t, string(fileContent), testFile)
+}
+
+func TestUpdateUpgradeMatrixNoEnv(t *testing.T) {
+	dir := fetchRepo(t)
+
+	// Replace the existing file with known test data
+	err := os.WriteFile(filepath.Join(dir, "upgrade-matrix.yaml"), []byte(testFile), 0644)
+	require.NoError(t, err)
+
+	// Ensure that the environment variable is empty
+	err = os.Setenv(upgradeMatrixEnv, "")
+
+	err = UpdateUpgradeMatrix(context.Background(), dir)
+	require.NoError(t, err)
+
+	// Check that the file has *not* been regenerated
+	fileContent, err := os.ReadFile(filepath.Join(dir, "upgrade-matrix.yaml"))
+	require.NoError(t, err)
+
+	require.Equal(t, string(fileContent), testFile)
+}
+
+func fetchRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	cmd := exec.Command("git", "clone", strings.Repeat("../", 4), dir)
+	require.NoError(t, cmd.Run())
+
+	return dir
+}


### PR DESCRIPTION
**What problem does this PR solve?**:

Updates `upgrade-matrix.yaml` in post-release with the value from an environment variable. The variable is set in `gh-dkp`

https://github.com/mesosphere/gh-dkp/pull/492 needs to be merged first.


**Which issue(s) does this PR fix?**:

https://jira.nutanix.com/browse/NCN-100509

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

Test manually with:

```
export NKP_RELEASE_AUTOMATION_UPGRADE_MATRIX="upgrades:"
go run . post-release --version v2.21.31 --repo /Users/luke.ogg/Projects/kommander-applications
```


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
