### PR TITLE
build(gha): Flux update fixes

### DIFF
--- a/.github/workflows/flux-update-scheduled-check.yml
+++ b/.github/workflows/flux-update-scheduled-check.yml
@@ -22,6 +22,17 @@ jobs:
           path: kommander
           token: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
 
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_committer_email: ci-mergebot@d2iq.com
+          git_committer_name: d2iq-mergebot
+          git_commit_gpgsign: true
+          git_config_global: true
+
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY }}


### PR DESCRIPTION
**What problem does this PR solve?**:
Fixed up a few things in the automated flux bump workflow. Working test run https://github.com/mesosphere/kommander-applications/actions/runs/11060715919 which produced PR https://github.com/mesosphere/kommander-applications/pull/2664 (closed since I was triggering it against this branch so an extra commit was on there)

If the branch already exists then it should exit gracefully as a success instead of looking like a failed run.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-102720

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
