### PR TITLE
feat: bump kubectl to 1.30.5 with cve fix

### DIFF
--- a/apptests/appscenarios/contants.go
+++ b/apptests/appscenarios/contants.go
@@ -21,5 +21,5 @@ const (
 
 	// Velero constants
 	kubetoolsImageRepository = "bitnami/kubectl"
-	kubetoolsImageTag        = "1.29.6"
+	kubetoolsImageTag        = "1.30.5"
 )

--- a/common/build/list-images-values.yaml
+++ b/common/build/list-images-values.yaml
@@ -1,3 +1,3 @@
 secretName: unused
 commonName: unused
-kubectlImage: bitnami/kubectl:1.29.6
+kubectlImage: bitnami/kubectl:1.30.5

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -574,7 +574,7 @@ resources:
       - url: https://github.com/NVIDIA/cuda-samples
         ref: v12.5
         license_path: LICENSE
-  - container_image: docker.io/bitnami/kubectl:1.29.6
+  - container_image: docker.io/bitnami/kubectl:1.30.5
     sources:
       - url: https://github.com/kubernetes/kubectl
         ref: v0${image_tag#1}

--- a/services/ai-navigator-app/0.2.5/defaults/cm.yaml
+++ b/services/ai-navigator-app/0.2.5/defaults/cm.yaml
@@ -112,4 +112,4 @@ data:
     tolerations: []
 
     affinity: {}
-    kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}
+    kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.30.5}

--- a/services/centralized-kubecost/0.37.5/defaults/cm.yaml
+++ b/services/centralized-kubecost/0.37.5/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
     ---
     hooks:
       clusterID:
-        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.30.5}"
         priorityClassName: dkp-high-priority
 
     cost-analyzer:

--- a/services/centralized-kubecost/0.37.5/post-install-jobs/post-install-jobs.yaml
+++ b/services/centralized-kubecost/0.37.5/post-install-jobs/post-install-jobs.yaml
@@ -42,7 +42,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.30.5}"
           command:
             - sh
             - -c

--- a/services/centralized-kubecost/0.37.5/release/release.yaml
+++ b/services/centralized-kubecost/0.37.5/release/release.yaml
@@ -73,7 +73,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.30.5}"
           command:
             - sh
             - "-c"

--- a/services/dex/2.14.0/defaults/cm.yaml
+++ b/services/dex/2.14.0/defaults/cm.yaml
@@ -7,7 +7,7 @@ data:
   values.yaml: |-
     ---
     priorityClassName: "dkp-critical-priority"
-    kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+    kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.30.5}"
     image: mesosphere/dex
     imageTag: v2.41.1-d2iq.1
     resources:

--- a/services/grafana-loki/0.79.4/grafana-loki-pre-install-jobs/pre-install.yaml
+++ b/services/grafana-loki/0.79.4/grafana-loki-pre-install-jobs/pre-install.yaml
@@ -46,7 +46,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: pre-install
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.30.5}"
           command:
             - sh
             - -c

--- a/services/istio/1.23.2/defaults/cm.yaml
+++ b/services/istio/1.23.2/defaults/cm.yaml
@@ -30,7 +30,7 @@ data:
           prometheus.kommander.d2iq.io/select: "true"
     global:
       image: ${kubetoolsImageRepository:=bitnami/kubectl}
-      tag: ${kubetoolsImageTag:=1.29.6}
+      tag: ${kubetoolsImageTag:=1.30.5}
       priorityClassName: "dkp-critical-priority"
     operator:
       # expose metrics for prometheus scraping

--- a/services/knative/1.10.5/defaults/cm.yaml
+++ b/services/knative/1.10.5/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
     global:
       priorityClassName: "dkp-high-priority"
       image: ${kubetoolsImageRepository:=bitnami/kubectl}
-      tag: ${kubetoolsImageTag:=1.29.6}
+      tag: ${kubetoolsImageTag:=1.30.5}
     eventing:
       enabled: false
     eventing-sources:

--- a/services/kommander/0.13.0/dynamic-helmreleases/cluster-observer/list-images-values.yaml
+++ b/services/kommander/0.13.0/dynamic-helmreleases/cluster-observer/list-images-values.yaml
@@ -1,2 +1,2 @@
 hooks:
-  kubectlImage: "bitnami/kubectl:1.29.6"
+  kubectlImage: "bitnami/kubectl:1.30.5"

--- a/services/kube-prometheus-stack/63.0.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/63.0.0/defaults/cm.yaml
@@ -22,7 +22,7 @@ data:
     mesosphereResources:
       create: true
       hooks:
-        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.30.5}"
       rules:
         # addon alert rules are defaulted to false to prevent potential misfires if addons
         # are disabled.

--- a/services/kubecost/0.37.6/defaults/cm.yaml
+++ b/services/kubecost/0.37.6/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
     ---
     hooks:
       clusterID:
-        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.30.5}"
         priorityClassName: dkp-high-priority
 
     cost-analyzer:

--- a/services/kubefed/0.10.5/defaults/cm.yaml
+++ b/services/kubefed/0.10.5/defaults/cm.yaml
@@ -35,7 +35,7 @@ data:
       postInstallJob:
         repository: bitnami
         image: kubectl
-        tag: 1.29.6
+        tag: 1.30.5
     webhook:
       annotations:
         secret.reloader.stakater.com/reload: "kubefed-root-ca"

--- a/services/kubetunnel/0.0.36/defaults/cm.yaml
+++ b/services/kubetunnel/0.0.36/defaults/cm.yaml
@@ -17,7 +17,7 @@ data:
     hooks:
       kubectlImage:
         repository: "${kubetoolsImageRepository:=bitnami/kubectl}"
-        tag: "${kubetoolsImageTag:=1.29.6}"
+        tag: "${kubetoolsImageTag:=1.30.5}"
     controller:
       manager:
         resources:

--- a/services/nkp-insights-management/1.2.2/defaults/cm.yaml
+++ b/services/nkp-insights-management/1.2.2/defaults/cm.yaml
@@ -34,7 +34,7 @@ data:
     insightsCRIngress:
       globalRateLimitAverageQPS: 100
       globalRateLimitBurst: 100
-    kubectlImage: bitnami/kubectl:1.29.6
+    kubectlImage: bitnami/kubectl:1.30.5
     managementCM:
       backendTokenTTL: 1h
       insightsTTL: 72h

--- a/services/nkp-insights/1.2.2/defaults/cm.yaml
+++ b/services/nkp-insights/1.2.2/defaults/cm.yaml
@@ -429,7 +429,7 @@ data:
             cpu: 100m
             memory: 512Mi
       schedule: '@every 35m'
-    kubectlImage: bitnami/kubectl:1.29.6
+    kubectlImage: bitnami/kubectl:1.30.5
     nova:
       baseEvaluationTimeout: 1m
       enabled: true

--- a/services/project-grafana-loki/0.79.4/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.79.4/defaults/cm.yaml
@@ -27,7 +27,7 @@ data:
     ####################################################################
 
     # this is used in object-bucket-claims overrides
-    kubectlImage: bitnami/kubectl:1.29.6
+    kubectlImage: bitnami/kubectl:1.30.5
 
     loki:
       ingesterFullname: loki-ingester

--- a/services/rook-ceph-cluster/1.14.5/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.14.5/defaults/cm.yaml
@@ -244,7 +244,7 @@ data:
           memory: "100Mi"
 
     # this is used in object-bucket-claims overrides
-    kubectlImage: bitnami/kubectl:1.29.6
+    kubectlImage: bitnami/kubectl:1.30.5
 
     #################################################################
     ## BEGIN NKP specific config overrides                         ##

--- a/services/rook-ceph-cluster/1.14.5/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.14.5/pre-install/ceph-crd-check.yaml
@@ -47,7 +47,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: pre-install
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.30.5}"
           command:
             - sh
             - -c
@@ -57,7 +57,7 @@ spec:
                 sleep 30
               done
         - name: pre-upgrade
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.30.5}"
           command:
             - sh
             - -c

--- a/services/thanos/15.7.23/jobs/jobs.yaml
+++ b/services/thanos/15.7.23/jobs/jobs.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.30.5}"
           command:
             - sh
             - "-c"

--- a/services/traefik/27.0.2/defaults/cm.yaml
+++ b/services/traefik/27.0.2/defaults/cm.yaml
@@ -39,7 +39,7 @@ data:
         app: traefik
       initContainers:
       - name: initialize-middleware
-        image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+        image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.30.5}"
         command:
           - bash
         args:

--- a/services/velero/7.1.4/defaults/cm.yaml
+++ b/services/velero/7.1.4/defaults/cm.yaml
@@ -56,4 +56,4 @@ data:
       image:
         # If we don't override the version here, upstream chart will pull an image dynamically based on k8s cluster version.
         # which makes it harder to build airgapped tar bundles. So to make bundle collection predictable, we override the tag here.
-        tag: "${kubetoolsImageTag:=1.29.6}"
+        tag: "${kubetoolsImageTag:=1.30.5}"


### PR DESCRIPTION
**What problem does this PR solve?**:
bump kubectl image in apps to 1.30.5

`sandhya.ravi@GT9X7CVF5F kommander-applications % trivy i docker.io/bitnami/kubectl:1.30.5
2024-09-30T12:20:15+05:30	INFO	Vulnerability scanning is enabled
2024-09-30T12:20:15+05:30	INFO	Secret scanning is enabled
2024-09-30T12:20:15+05:30	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-09-30T12:20:15+05:30	INFO	Please see also https://aquasecurity.github.io/trivy/v0.53/docs/scanner/secret#recommendation for faster secret detection
2024-09-30T12:20:18+05:30	INFO	Detected OS	family="debian" version="12.7"
2024-09-30T12:20:18+05:30	INFO	[debian] Detecting vulnerabilities...	os_version="12" pkg_num=127
2024-09-30T12:20:18+05:30	INFO	Number of language-specific files	num=5
2024-09-30T12:20:18+05:30	INFO	[gobinary] Detecting vulnerabilities...
2024-09-30T12:20:18+05:30	INFO	[bitnami] Detecting vulnerabilities...
2024-09-30T12:20:18+05:30	WARN	Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.53/docs/scanner/vulnerability#severity-selection for details.

docker.io/bitnami/kubectl:1.30.5 (debian 12.7)

Total: 123 (UNKNOWN: 0, LOW: 83, MEDIUM: 28, HIGH: 11, CRITICAL: 1)`

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-102768


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
