### PR TITLE
fix: docker client fix

### DIFF
--- a/apptests/kind/kind.go
+++ b/apptests/kind/kind.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/cmd"
@@ -98,14 +99,14 @@ func (c *Cluster) RunScript(ctx context.Context, nodeName, script string) error 
 	default:
 	}
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return err
 	}
 	defer apiClient.Close()
 
 	rst, err := apiClient.ContainerExecCreate(context.Background(), nodeName,
-		types.ExecConfig{
+		container.ExecOptions{
 			AttachStdout: true,
 			AttachStderr: true,
 			Cmd:          []string{script},


### PR DESCRIPTION
**What problem does this PR solve?**:
fix the below error
`Error response from daemon: client version 1.46 is too new. Maximum supported API version is 1.45`

**Which issue(s) does this PR fix?**:
https://nutanix.slack.com/archives/C06KX3DPA9K/p1727705385264839


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
