### PR TITLE
feat: bump kube-webhook-certgen to 1.4.3

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -582,7 +582,7 @@ resources:
   - container_image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.3
     sources:
       - url: https://github.com/kubernetes/ingress-nginx
-        ref:  controller-v1.4.3
+        ref: ${image_tag}
         license_path: LICENSE
         directory: /images/kube-webhook-certgen/rootfs
   - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/bitnami/postgres-exporter:0.12.0-debian-11-r77-d2iq.0

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -582,7 +582,7 @@ resources:
   - container_image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.3
     sources:
       - url: https://github.com/kubernetes/ingress-nginx
-        ref:  controller-v1.5.2
+        ref:  controller-v1.4.3
         license_path: LICENSE
         directory: /images/kube-webhook-certgen/rootfs
   - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/bitnami/postgres-exporter:0.12.0-debian-11-r77-d2iq.0

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -582,7 +582,7 @@ resources:
   - container_image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.3
     sources:
       - url: https://github.com/kubernetes/ingress-nginx
-        ref: ${image_tag}
+        ref: controller-v1.11.2
         license_path: LICENSE
         directory: /images/kube-webhook-certgen/rootfs
   - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/bitnami/postgres-exporter:0.12.0-debian-11-r77-d2iq.0

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -579,7 +579,7 @@ resources:
       - url: https://github.com/kubernetes/kubectl
         ref: v0${image_tag#1}
         license_path: LICENSE
-  - container_image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
+  - container_image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.3
     sources:
       - url: https://github.com/kubernetes/ingress-nginx
         ref:  controller-v1.5.2

--- a/services/kube-prometheus-stack/63.0.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/63.0.0/defaults/cm.yaml
@@ -8,9 +8,6 @@ data:
     ---
     commonLabels:
       prometheus.kommander.d2iq.io/select: "true"
-    patch:
-      enabled: true
-
     prometheusOperator:
       priorityClassName: "dkp-critical-priority"
       logLevel: warn

--- a/services/kube-prometheus-stack/63.0.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/63.0.0/defaults/cm.yaml
@@ -8,6 +8,9 @@ data:
     ---
     commonLabels:
       prometheus.kommander.d2iq.io/select: "true"
+    patch:
+      enabled: true
+
     prometheusOperator:
       priorityClassName: "dkp-critical-priority"
       logLevel: warn
@@ -17,6 +20,9 @@ data:
         patch:
           priorityClassName: "dkp-critical-priority"
           image:
+            registry: registry.k8s.io
+            repository: ingress-nginx/kube-webhook-certgen
+            tag: v1.4.3
             # Set SHA to empty so airgapped deployments work out of box.
             sha: ""
     mesosphereResources:


### PR DESCRIPTION
**What problem does this PR solve?**:
bump kube-webhook-certgen to 1.4.3 with cve fix

`sandhya.ravi@GT9X7CVF5F kommander-applications % trivy i registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.3
2024-10-03T00:20:37+05:30	INFO	Vulnerability scanning is enabled
2024-10-03T00:20:37+05:30	INFO	Secret scanning is enabled
2024-10-03T00:20:37+05:30	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-10-03T00:20:37+05:30	INFO	Please see also https://aquasecurity.github.io/trivy/v0.53/docs/scanner/secret#recommendation for faster secret detection
2024-10-03T00:20:39+05:30	INFO	Detected OS	family="debian" version="12.6"
2024-10-03T00:20:39+05:30	INFO	[debian] Detecting vulnerabilities...	os_version="12" pkg_num=3
2024-10-03T00:20:39+05:30	INFO	Number of language-specific files	num=1
2024-10-03T00:20:39+05:30	INFO	[gobinary] Detecting vulnerabilities...
2024-10-03T00:20:39+05:30	WARN	Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.53/docs/scanner/vulnerability#severity-selection for details.

registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.3 (debian 12.6)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)`

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-102769


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
