### PR TITLE
fix: jaegertracing/all-in-one cve fix

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -66,7 +66,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/istio/proxy
-  - container_image: docker.io/jaegertracing/all-in-one:1.52.0
+  - container_image: docker.io/jaegertracing/all-in-one:1.61.0
     sources:
       - license_path: LICENSE
         notice_path: NOTICE

--- a/services/jaeger/2.56.0/defaults/cm.yaml
+++ b/services/jaeger/2.56.0/defaults/cm.yaml
@@ -10,7 +10,7 @@ data:
       spec:
         strategy: allInOne
         allInOne:
-          image: jaegertracing/all-in-one:1.52.0
+          image: jaegertracing/all-in-one:1.61.0
           options:
             query:
               base-path: /dkp/jaeger


### PR DESCRIPTION
**What problem does this PR solve?**:
 jaegertracing/all-in-one cve fix

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-102770


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
