### PR TITLE
fix: kiali-operator version bump 1.89.6

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -465,7 +465,7 @@ resources:
       - license_path: LICENSE
         ref: v${image_tag}
         url: https://github.com/TremoloSecurity/kube-oidc-proxy
-  - container_image: quay.io/kiali/kiali-operator:v1.89.2
+  - container_image: quay.io/kiali/kiali-operator:v1.89.6
     sources:
       - license_path: LICENSE
         ref: ${image_tag}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -465,7 +465,7 @@ resources:
       - license_path: LICENSE
         ref: v${image_tag}
         url: https://github.com/TremoloSecurity/kube-oidc-proxy
-  - container_image: quay.io/kiali/kiali-operator:v1.89.6
+  - container_image: quay.io/kiali/kiali-operator:v1.89.2
     sources:
       - license_path: LICENSE
         ref: ${image_tag}

--- a/services/kiali/1.89.6/defaults/cm.yaml
+++ b/services/kiali/1.89.6/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
     priorityClassName: dkp-high-priority
     image:
       repo: quay.io/kiali/kiali-operator
-      tag: v1.89.6
+      tag: v1.89.2
     allowAdHocKialiImage: true
     cr:
       create: true

--- a/services/kiali/1.89.6/defaults/cm.yaml
+++ b/services/kiali/1.89.6/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kiali-1.89.2-d2iq-defaults
+  name: kiali-1.89.6-d2iq-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kiali/1.89.6/defaults/cm.yaml
+++ b/services/kiali/1.89.6/defaults/cm.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kiali-1.89.2-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    priorityClassName: dkp-high-priority
+    image:
+      repo: quay.io/kiali/kiali-operator
+      tag: v1.89.6
+    allowAdHocKialiImage: true
+    cr:
+      create: true
+      namespace: ${releaseNamespace}
+      spec:
+        istio_namespace: istio-system
+        auth:
+          strategy: header
+        server:
+          web_root: /dkp/kiali
+        external_services:
+          istio:
+            component_status:
+              components:
+              - app_label: "istiod"
+                is_core: true
+                is_proxy: false
+              - app_label: "istio-ingressgateway"
+                is_core: true
+                is_proxy: true
+          grafana:
+            enabled: false
+          prometheus:
+            health_check_url: http://kube-prometheus-stack-prometheus.${workspaceNamespace}.svc.cluster.local:9090/-/healthy
+            url: http://kube-prometheus-stack-prometheus.${workspaceNamespace}.svc.cluster.local:9090
+          tracing:
+            in_cluster_url: http://jaeger-jaeger-operator-jaeger-query.istio-system.svc.cluster.local:16685
+            use_grpc: true
+        deployment:
+          priority_class_name: dkp-high-priority
+          image_version: v1.88.0-distro
+          accessible_namespaces:
+          - '**'
+          ingress:
+            enabled: true
+            class_name: ""
+            override_yaml:
+              metadata:
+                annotations:
+                  kubernetes.io/ingress.class: kommander-traefik
+                  traefik.ingress.kubernetes.io/router.tls: "true"
+                  traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth-full@kubernetescrd"
+              spec:
+                rules:
+                - http:
+                    paths:
+                    - path: /dkp/kiali
+                      pathType: Prefix
+                      backend:
+                        service:
+                          name: kiali
+                          port:
+                            number: 20001

--- a/services/kiali/1.89.6/defaults/cm.yaml
+++ b/services/kiali/1.89.6/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kiali-1.89.6-d2iq-defaults
+  name: kiali-1.89.2-d2iq-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kiali/1.89.6/defaults/kustomization.yaml
+++ b/services/kiali/1.89.6/defaults/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml

--- a/services/kiali/1.89.6/extra-images.txt
+++ b/services/kiali/1.89.6/extra-images.txt
@@ -1,0 +1,1 @@
+quay.io/kiali/kiali:v1.88.0-distro

--- a/services/kiali/1.89.6/kiali.yaml
+++ b/services/kiali/1.89.6/kiali.yaml
@@ -1,0 +1,88 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: kiali
+  namespace: ${releaseNamespace}
+spec:
+  dependsOn:
+    # Istio is a hard dependency for Kiali
+    # https://kiali.io/documentation/latest/architecture/
+    - name: istio
+      namespace: ${releaseNamespace}
+  chart:
+    spec:
+      chart: kiali-operator
+      sourceRef:
+        kind: HelmRepository
+        name: kiali-org
+        namespace: kommander-flux
+      version: 1.89.0
+  interval: 15s
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+  releaseName: kiali
+  valuesFrom:
+    - kind: ConfigMap
+      name: kiali-1.89.2-d2iq-defaults
+  targetNamespace: istio-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kiali-app-dashboard-info
+  namespace: ${releaseNamespace}
+  labels:
+    "kommander.d2iq.io/application": "kiali"
+data:
+  name: "Kiali"
+  dashboardLink: "/dkp/kiali"
+  docsLink: "https://istio.io/docs/tasks/telemetry/kiali/"
+  # Chart version matches app version
+  version: "1.88.0"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dkp-kiali-view
+rules:
+  - nonResourceURLs:
+      - /dkp/kiali
+      - /dkp/kiali/*
+    verbs:
+      - get
+      - head
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dkp-kiali-edit
+rules:
+  - nonResourceURLs:
+      - /dkp/kiali
+      - /dkp/kiali/*
+    verbs:
+      - get
+      - head
+      - post
+      - put
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dkp-kiali-admin
+rules:
+  - nonResourceURLs:
+      - /dkp/kiali
+      - /dkp/kiali/*
+    verbs:
+      - get
+      - head
+      - post
+      - put
+      - delete

--- a/services/kiali/1.89.6/kiali.yaml
+++ b/services/kiali/1.89.6/kiali.yaml
@@ -29,7 +29,7 @@ spec:
   releaseName: kiali
   valuesFrom:
     - kind: ConfigMap
-      name: kiali-1.89.2-d2iq-defaults
+      name: kiali-1.89.6-d2iq-defaults
   targetNamespace: istio-system
 ---
 apiVersion: v1

--- a/services/kiali/1.89.6/kiali.yaml
+++ b/services/kiali/1.89.6/kiali.yaml
@@ -16,7 +16,7 @@ spec:
         kind: HelmRepository
         name: kiali-org
         namespace: kommander-flux
-      version: 1.89.6
+      version: 1.89.2
   interval: 15s
   install:
     crds: CreateReplace

--- a/services/kiali/1.89.6/kiali.yaml
+++ b/services/kiali/1.89.6/kiali.yaml
@@ -16,7 +16,7 @@ spec:
         kind: HelmRepository
         name: kiali-org
         namespace: kommander-flux
-      version: 1.89.0
+      version: 1.89.6
   interval: 15s
   install:
     crds: CreateReplace

--- a/services/kiali/1.89.6/kiali.yaml
+++ b/services/kiali/1.89.6/kiali.yaml
@@ -16,7 +16,7 @@ spec:
         kind: HelmRepository
         name: kiali-org
         namespace: kommander-flux
-      version: 1.89.2
+      version: 1.89.0
   interval: 15s
   install:
     crds: CreateReplace

--- a/services/kiali/1.89.6/kustomization.yaml
+++ b/services/kiali/1.89.6/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kiali.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumps kiali-operator version  to 1.89.6

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-102772


**Special notes for your reviewer**:
arvinder.pal@GHH4XN27GC kommander-applications % trivy image quay.io/kiali/kiali-operator:v1.89.6                
2024-10-03T14:46:02+05:30	INFO	[vuln] Vulnerability scanning is enabled
2024-10-03T14:46:02+05:30	INFO	[secret] Secret scanning is enabled
2024-10-03T14:46:02+05:30	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-10-03T14:46:02+05:30	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.55/docs/scanner/secret#recommendation for faster secret detection
2024-10-03T14:46:08+05:30	INFO	Detected OS	family="redhat" version="8.10"
2024-10-03T14:46:08+05:30	INFO	[redhat] Detecting RHEL/CentOS vulnerabilities...	os_version="8" pkg_num=204
2024-10-03T14:46:08+05:30	INFO	Number of language-specific files	num=2
2024-10-03T14:46:08+05:30	INFO	[gobinary] Detecting vulnerabilities...
2024-10-03T14:46:08+05:30	INFO	[python-pkg] Detecting vulnerabilities...
2024-10-03T14:46:08+05:30	WARN	Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.55/docs/scanner/vulnerability#severity-selection for details.

quay.io/kiali/kiali-operator:v1.89.6 (redhat 8.10)

Total: 216 (UNKNOWN: 0, LOW: 191, MEDIUM: 25, HIGH: 0, CRITICAL: 0)


