### PR TITLE
fix: Bump image to ghcr.io/jimmidyson/configmap-reload:v0.14.0

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -77,7 +77,7 @@ resources:
       - license_path: LICENSE
         ref: v${image_tag}
         url: https://github.com/jaegertracing/jaeger-operator
-  - container_image: ghcr.io/jimmidyson/configmap-reload:v0.14.1
+  - container_image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
     sources:
       - license_path: LICENSE.txt
         ref: ${image_tag}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -77,7 +77,7 @@ resources:
       - license_path: LICENSE
         ref: v${image_tag}
         url: https://github.com/jaegertracing/jaeger-operator
-  - container_image: docker.io/jimmidyson/configmap-reload:v0.7.1
+  - container_image: docker.io/jimmidyson/configmap-reload:v0.14.0
     sources:
       - license_path: LICENSE.txt
         ref: ${image_tag}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -77,7 +77,7 @@ resources:
       - license_path: LICENSE
         ref: v${image_tag}
         url: https://github.com/jaegertracing/jaeger-operator
-  - container_image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+  - container_image: ghcr.io/jimmidyson/configmap-reload:v0.14.1
     sources:
       - license_path: LICENSE.txt
         ref: ${image_tag}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -77,7 +77,7 @@ resources:
       - license_path: LICENSE
         ref: v${image_tag}
         url: https://github.com/jaegertracing/jaeger-operator
-  - container_image: docker.io/jimmidyson/configmap-reload:v0.14.0
+  - container_image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
     sources:
       - license_path: LICENSE.txt
         ref: ${image_tag}

--- a/services/kubecost/0.37.6/defaults/cm.yaml
+++ b/services/kubecost/0.37.6/defaults/cm.yaml
@@ -47,7 +47,15 @@ data:
           priorityClassName: dkp-high-priority
         alertmanager:
           priorityClassName: dkp-high-priority
-
+      configmapReload:
+          prometheus:
+            image:
+              repository: ghcr.io/jimmidyson/configmap-reload
+              tag: v0.14.0
+          alertmanager:
+            image:
+              repository: ghcr.io/jimmidyson/configmap-reload
+              tag: v0.14.0
       grafana:
         priorityClassName: dkp-high-priority
         image:

--- a/services/kubecost/0.37.6/defaults/cm.yaml
+++ b/services/kubecost/0.37.6/defaults/cm.yaml
@@ -47,11 +47,11 @@ data:
           priorityClassName: dkp-high-priority
         alertmanager:
           priorityClassName: dkp-high-priority  
-       configmapReload:
-         prometheus:
-           image:
-             repository: ghcr.io/jimmidyson/configmap-reload
-             tag: v0.14.0
+        configmapReload:
+          prometheus:
+            image:
+              repository: ghcr.io/jimmidyson/configmap-reload
+              tag: v0.14.0
           alertmanager:
             image:
               repository: ghcr.io/jimmidyson/configmap-reload

--- a/services/kubecost/0.37.6/defaults/cm.yaml
+++ b/services/kubecost/0.37.6/defaults/cm.yaml
@@ -46,12 +46,12 @@ data:
         server:
           priorityClassName: dkp-high-priority
         alertmanager:
-          priorityClassName: dkp-high-priority
-      configmapReload:
-          prometheus:
-            image:
-              repository: ghcr.io/jimmidyson/configmap-reload
-              tag: v0.14.0
+          priorityClassName: dkp-high-priority  
+       configmapReload:
+         prometheus:
+           image:
+             repository: ghcr.io/jimmidyson/configmap-reload
+             tag: v0.14.0
           alertmanager:
             image:
               repository: ghcr.io/jimmidyson/configmap-reload


### PR DESCRIPTION
**What problem does this PR solve?**:

(pkg:docker/jimmidyson/configmap-reload@v0.7.1).                                                                                                                   Bump image to `ghcr.io/jimmidyson/configmap-reload:v0.14.0`
Referenced in:  ./services/kubecost/0.37.6/kubecost.yaml


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-102771


**Special notes for your reviewer**:
rajaramana.pedireddy@GP7YJYXV6F kommander-applications % trivy image ghcr.io/jimmidyson/configmap-reload:v0.14.0
2024-10-03T13:56:51+05:30	INFO	[db] Need to update DB
2024-10-03T13:56:51+05:30	INFO	[db] Downloading DB...	repository="ghcr.io/aquasecurity/trivy-db:2"
53.95 MiB / 53.95 MiB [------------------------------------------------------------------------------------] 100.00% 13.87 MiB p/s 4.1s
2024-10-03T13:56:57+05:30	INFO	[vuln] Vulnerability scanning is enabled
2024-10-03T13:56:57+05:30	INFO	[secret] Secret scanning is enabled
2024-10-03T13:56:57+05:30	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-10-03T13:56:57+05:30	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.55/docs/scanner/secret#recommendation for faster secret detection
2024-10-03T13:57:01+05:30	INFO	Detected OS	family="debian" version="11.10"
2024-10-03T13:57:01+05:30	INFO	[debian] Detecting vulnerabilities...	os_version="11" pkg_num=3
2024-10-03T13:57:01+05:30	INFO	Number of language-specific files	num=1
2024-10-03T13:57:01+05:30	INFO	[gobinary] Detecting vulnerabilities...

ghcr.io/jimmidyson/configmap-reload:v0.14.0 (debian 11.10)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)



