### PR TITLE
ci(automerge): Update/fix automerge workflow

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -9,12 +9,6 @@ on:
       - edited
       - ready_for_review
       - reopened
-      - unlocked
-    branches:
-      - main
-      - 'release/*'
-    paths:
-      - 'services/**/*'
   check_suite:
     types:
       - completed
@@ -24,15 +18,15 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-    - name: Enable auto-merge for automated chart bump PRs
+    - name: Enable auto-merge for automated chart bump PRs or label
       id: automerge
       if: |
-        startsWith(github.head_ref, 'chartbump/')
+        (startsWith(github.head_ref, 'chartbump/') || contains(github.event.pull_request.labels.*.name, 'auto-merge'))
         && contains(github.event.pull_request.labels.*.name, 'ready-for-review')
         && !contains(github.event.pull_request.labels.*.name, 'do-not-merge')
         && !contains(github.event.pull_request.labels.*.name, 'do-not-merge/testing')
-        && !contains(github.event.pull_request.labels.*.name, 'let-me-merge-it')
+        && !contains(github.event.pull_request.labels.*.name, 'let-me-merge-it'))
       run: gh pr merge --auto --squash "$PR_URL"
       env:
         PR_URL: ${{ github.event.pull_request.html_url }}
-        GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What problem does this PR solve?**:
seeing if this fixes automerge to trigger the workflow successfully for chartbump prs and prs labeled with `auto-merge`

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
