### PR TITLE
feat: bump kube-state-metrics to v2.13.0

### DIFF
--- a/apptests/appscenarios/kubecost_test.go
+++ b/apptests/appscenarios/kubecost_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Kubecost Tests", Label("kubecost"), func() {
 			deploymentList = &appsv1.DeploymentList{}
 			err = k8sClient.List(ctx, deploymentList, listOptions)
 			Expect(err).To(BeNil())
-			Expect(deploymentList.Items).To(HaveLen(5))
+			Expect(deploymentList.Items).To(HaveLen(4))
 			Expect(err).To(BeNil())
 
 			for _, deployment := range deploymentList.Items {

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -527,11 +527,6 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/thanos-io/thanos
-  - container_image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v1.9.8
-    sources:
-      - license_path: LICENSE
-        ref: ${image_tag}
-        url: https://github.com/kubernetes/kube-state-metrics
   - container_image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
     sources:
       - license_path: LICENSE

--- a/services/kube-prometheus-stack/63.0.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/63.0.0/defaults/cm.yaml
@@ -450,6 +450,9 @@ data:
       enabled: true
     kube-state-metrics:
       priorityClassName: "dkp-critical-priority"
+      image:
+        repository: kube-state-metrics/kube-state-metrics
+        tag: v2.13.0
       metricLabelsAllowlist:
         - pods=[*]
         - namespaces=[*]

--- a/services/kubecost/0.37.6/defaults/cm.yaml
+++ b/services/kubecost/0.37.6/defaults/cm.yaml
@@ -42,10 +42,9 @@ data:
 
       prometheus:
         kube-state-metrics:
-          image:
-            repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
-            tag: v2.13.0
-          priorityClassName: dkp-high-priority
+          enabled: false
+        kube-state-metrics:
+          disabled: true
         server:
           priorityClassName: dkp-high-priority
         alertmanager:

--- a/services/kubecost/0.37.6/defaults/cm.yaml
+++ b/services/kubecost/0.37.6/defaults/cm.yaml
@@ -41,9 +41,9 @@ data:
         enabled: false
 
       prometheus:
-        kube-state-metrics:
+        kubeStateMetrics:
           enabled: false
-        kube-state-metrics:
+        kubeStateMetrics:
           disabled: true
         server:
           priorityClassName: dkp-high-priority

--- a/services/kubecost/0.37.6/defaults/cm.yaml
+++ b/services/kubecost/0.37.6/defaults/cm.yaml
@@ -42,6 +42,9 @@ data:
 
       prometheus:
         kube-state-metrics:
+          image:
+            repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
+            tag: v2.13.0
           priorityClassName: dkp-high-priority
         server:
           priorityClassName: dkp-high-priority

--- a/services/kubecost/0.37.6/defaults/cm.yaml
+++ b/services/kubecost/0.37.6/defaults/cm.yaml
@@ -43,7 +43,7 @@ data:
       prometheus:
         kubeStateMetrics:
           enabled: false
-        kubeStateMetrics:
+        kube-state-metrics:
           disabled: true
         server:
           priorityClassName: dkp-high-priority


### PR DESCRIPTION
**What problem does this PR solve?**:
update kube-state-metrics to v2.13.0

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-102773


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
