### PR TITLE
build: Fix how S3 URL is constructed

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ git_operator_version := env("GIT_OPERATOR_VERSION", "latest")
 
 s3_path := "dkp" / git_tag
 s3_bucket := "downloads.mesosphere.io"
-s3_uri := "s3://" / s3_bucket / s3_path
+s3_uri := "s3://" + s3_bucket / s3_path
 s3_acl := "bucket-owner-full-control"
 archive_name := "kommander-applications-" + git_tag+ ".tar.gz"
 published_url := "https://downloads.d2iq.com" / s3_path / archive_name


### PR DESCRIPTION
**What problem does this PR solve?**:
Right now it creates `s3:///foobar`, let's make it `s3://foobar`.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
