### PR TITLE
feat: Add extra image of kommander applications server

### DIFF
--- a/hack/release/cmd/postrelease/postrelease.go
+++ b/hack/release/cmd/postrelease/postrelease.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/appversion"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/chartversion"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/extraimages"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/upgradematrix"
 	"github.com/spf13/cobra"
 )
@@ -60,6 +61,10 @@ func init() { //nolint:gochecknoinits // Initializing cobra application.
 				cmd.Context(),
 				kommanderApplicationsRepo,
 			); err != nil {
+				return err
+			}
+
+			if err := extraimages.UpdateExtraImagesVersions(kommanderApplicationsRepo, chartVersion.Original()); err != nil {
 				return err
 			}
 

--- a/hack/release/cmd/prerelease/prerelease.go
+++ b/hack/release/cmd/prerelease/prerelease.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/chartversion"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/extraimages"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/updatecapimate"
 	"github.com/spf13/cobra"
 )
@@ -40,6 +41,12 @@ func init() { //nolint:gochecknoinits // Initializing cobra application.
 				return err
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Updated CAPIMate version to %s", chartVersionString)
+
+			if err := extraimages.UpdateExtraImagesVersions(kommanderApplicationsRepo, chartVersionString); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Updated kommander extra images to %s", chartVersionString)
 			return nil
 		},
 	}

--- a/hack/release/pkg/extraimages/extraimages.go
+++ b/hack/release/pkg/extraimages/extraimages.go
@@ -1,0 +1,40 @@
+package extraimages
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/constants"
+)
+
+func UpdateExtraImagesVersions(kommanderApplicationsRepo, chartVersion string) error {
+	path := filepath.Join(
+		kommanderApplicationsRepo,
+		constants.KommanderAppPath,
+		"*",
+		"extra-images.txt",
+	)
+
+	matches, err := filepath.Glob(path)
+	if err != nil {
+		return err
+	}
+
+	if len(matches) == 0 {
+		return fmt.Errorf("no matches found for extra images path, (verify the kommander-applications repo path is correct): %s", path)
+	}
+	if len(matches) > 1 {
+		return fmt.Errorf("found > 1 match for extra images path (there should only be one match): %s", path)
+	}
+
+	if err := os.WriteFile(
+		matches[0],
+		[]byte(fmt.Sprintf("mesosphere/kommander-applications-server:%s\n", chartVersion)),
+		0o644,
+	); err != nil {
+		return fmt.Errorf("error while updating extra-images file: %w", err)
+	}
+
+	return nil
+}

--- a/hack/release/pkg/extraimages/extraimages_test.go
+++ b/hack/release/pkg/extraimages/extraimages_test.go
@@ -1,0 +1,32 @@
+package extraimages
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	cp "github.com/otiai10/copy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const rootDir = "../../../../"
+
+func TestUpdateExtraImages(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	err := cp.Copy(rootDir, tmpDir)
+	require.NoError(t, err)
+
+	err = UpdateExtraImagesVersions(tmpDir, "v1.2.3")
+	assert.NoError(t, err)
+
+	afterUpgradeFile, err := filepath.Glob(filepath.Join(
+		tmpDir, "services/kommander/*/extra-images.txt",
+	))
+
+	assert.Len(t, afterUpgradeFile, 1)
+	contentes, err := os.ReadFile(afterUpgradeFile[0])
+	require.NoError(t, err)
+	assert.Equal(t, "mesosphere/kommander-applications-server:v1.2.3\n", string(contentes))
+}

--- a/hack/release/pkg/extraimages/extraimages_test.go
+++ b/hack/release/pkg/extraimages/extraimages_test.go
@@ -24,6 +24,7 @@ func TestUpdateExtraImages(t *testing.T) {
 	afterUpgradeFile, err := filepath.Glob(filepath.Join(
 		tmpDir, "services/kommander/*/extra-images.txt",
 	))
+	assert.NoError(t, err)
 
 	assert.Len(t, afterUpgradeFile, 1)
 	contentes, err := os.ReadFile(afterUpgradeFile[0])

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -222,6 +222,10 @@ resources:
     sources:
       - ref: v${image_tag}
         url: https://github.com/mesosphere/kommander-ui
+  - container_image: docker.io/mesosphere/kommander-applications-server:${kommander}
+    sources:
+      - ref: ${image_tag}
+        url: https://github.com/mesosphere/kommander-applications
   - container_image: docker.io/mesosphere/kubeaddons-addon-initializer:v0.7.3
     sources:
       - ref: ${image_tag}

--- a/services/kommander/0.13.0/extra-images.txt
+++ b/services/kommander/0.13.0/extra-images.txt
@@ -1,0 +1,1 @@
+mesosphere/kommander-applications-server:v2.13.0-dev


### PR DESCRIPTION
**What problem does this PR solve?**:
We need to make sure that the newly created kommander applications server image is in the airgapped bundle.

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-102822


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
