### PR TITLE
feat: Bump docker.io/fluent/fluent-bit cve fix

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -18,11 +18,6 @@ resources:
       - license_path: LICENSE
         ref: v${image_tag%-debian-12-r1}
         url: https://github.com/thanos-io/thanos
-  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/fluent/fluent-bit:2.2.3-d2iq.1
-    sources:
-      - license_path: LICENSE
-        ref: v${image_tag%-d2iq.1}
-        url: https://github.com/fluent/fluent-bit
   - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/grafana/grafana:10.3.3-d2iq.0
     sources:
       - license_path: LICENSE

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -18,10 +18,10 @@ resources:
       - license_path: LICENSE
         ref: v${image_tag%-debian-12-r1}
         url: https://github.com/thanos-io/thanos
-  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/fluent/fluent-bit:3.1.9
+  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/fluent/fluent-bit:2.2.3-d2iq.1
     sources:
       - license_path: LICENSE
-        ref: v${image_tag%}
+        ref: v${image_tag%-d2iq.1}
         url: https://github.com/fluent/fluent-bit
   - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/grafana/grafana:10.3.3-d2iq.0
     sources:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -18,10 +18,10 @@ resources:
       - license_path: LICENSE
         ref: v${image_tag%-debian-12-r1}
         url: https://github.com/thanos-io/thanos
-  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/fluent/fluent-bit:2.2.3-d2iq.0
+  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/fluent/fluent-bit:3.1.9
     sources:
       - license_path: LICENSE
-        ref: v${image_tag%-d2iq.0}
+        ref: v${image_tag%}
         url: https://github.com/fluent/fluent-bit
   - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/grafana/grafana:10.3.3-d2iq.0
     sources:

--- a/services/logging-operator/4.2.5/defaults/cm.yaml
+++ b/services/logging-operator/4.2.5/defaults/cm.yaml
@@ -112,7 +112,7 @@ data:
         # Explicitly specify the version here. This should be updated when logging-operator is upgraded.
         # Also, update the image in fluent-bit configuration if the image is upgraded here.
         repository: ghcr.io/mesosphere/dkp-container-images/docker.io/fluent/fluent-bit
-        tag: 2.2.3-d2iq.0
+        tag: 3.1.9
       resources:
        limits:
          memory: 750Mi

--- a/services/logging-operator/4.2.5/defaults/cm.yaml
+++ b/services/logging-operator/4.2.5/defaults/cm.yaml
@@ -111,7 +111,7 @@ data:
       image:
         # Explicitly specify the version here. This should be updated when logging-operator is upgraded.
         # Also, update the image in fluent-bit configuration if the image is upgraded here.
-        repository: ghcr.io/mesosphere/dkp-container-images/docker.io/fluent/fluent-bit
+        repository: ghcr.io/mesosphere/dkp-container-images/cr.fluentbit.io/fluent/fluent-bit
         tag: 2.2.3-d2iq.1
       resources:
        limits:

--- a/services/logging-operator/4.2.5/defaults/cm.yaml
+++ b/services/logging-operator/4.2.5/defaults/cm.yaml
@@ -112,7 +112,7 @@ data:
         # Explicitly specify the version here. This should be updated when logging-operator is upgraded.
         # Also, update the image in fluent-bit configuration if the image is upgraded here.
         repository: ghcr.io/mesosphere/dkp-container-images/docker.io/fluent/fluent-bit
-        tag: 3.1.9
+        tag: 2.2.3-d2iq.1
       resources:
        limits:
          memory: 750Mi


### PR DESCRIPTION
**What problem does this PR solve?**:
Bump docker.io/fluent/fluent-bit to 2.2.3-d2iq.1 CVE fix

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-102779


