### PR TITLE
ci: use explicit name when publishing s3 blobs

### DIFF
--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ release publish="true" tmp_dir=`mktemp --directory`: (_prepare-archive tmp_dir) 
     #!/usr/bin/env bash
     set -euox pipefail
     if {{ publish }}; then
-      aws s3 cp --acl {{ s3_acl }} {{ archive_name }} {{ s3_uri }}
+      aws s3 cp --acl {{ s3_acl }} {{ archive_name }} {{ s3_uri }}/{{ archive_name }}
       echo "Published to {{ published_url }}"
     else
       echo "Skipping publish"


### PR DESCRIPTION
**What problem does this PR solve?**:

Follow up of https://github.com/mesosphere/kommander-applications/pull/2710

Above change corrupted how we publish artifacts cuz i see:

```bash
 ❯ curl -L https://downloads.d2iq.com/dkp/v2.13.0-dev.2 --output local.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  449k  100  449k    0     0  1414k      0 --:--:-- --:--:-- --:--:-- 1413k
 ❯ tar -tvf local.tar.gz
drwxr-xr-x runner/runner     0 2024-10-14 18:30 ./
drwxr-xr-x runner/runner     0 2024-10-14 18:29 ./charts/
drwxr-xr-x runner/runner     0 2024-10-14 18:29 ./charts/kommander-operator/
-rw-r--r-- runner/runner   168 2024-10-14 18:29 ./charts/kommander-operator/Chart.yaml
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
