### PR TITLE
feat: bump kiwigrid/k8s-sidecar to 1.28.0

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -77,7 +77,7 @@ resources:
       - license_path: LICENSE.txt
         ref: ${image_tag}
         url: https://github.com/jimmidyson/configmap-reload
-  - container_image: docker.io/kiwigrid/k8s-sidecar:1.27.6
+  - container_image: docker.io/kiwigrid/k8s-sidecar:1.28.0
     sources:
       - license_path: LICENSE
         ref: ${image_tag}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -464,11 +464,6 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag%-distro}
         url: https://github.com/kiali/kiali
-  - container_image: docker.io/kiwigrid/k8s-sidecar:1.27.6
-    sources:
-      - license_path: LICENSE
-        ref: ${image_tag}
-        url: docker.io/kiwigrid/k8s-sidecar
   - container_image: quay.io/prometheus-operator/prometheus-config-reloader:v0.76.1
     sources:
       - license_path: LICENSE

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -81,7 +81,7 @@ resources:
     sources:
       - license_path: LICENSE
         ref: ${image_tag}
-        url: docker.io/kiwigrid/k8s-sidecar
+        url: https://github.com/kiwigrid/k8s-sidecar
   - container_image: docker.io/kubernetesui/dashboard-api:1.7.0
     sources:
       - license_path: LICENSE

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -77,6 +77,11 @@ resources:
       - license_path: LICENSE.txt
         ref: ${image_tag}
         url: https://github.com/jimmidyson/configmap-reload
+  - container_image: docker.io/kiwigrid/k8s-sidecar:1.27.6
+    sources:
+      - license_path: LICENSE
+        ref: ${image_tag}
+        url: https://github.com/kiwigrid/k8s-sidecar
   - container_image: docker.io/kubernetesui/dashboard-api:1.7.0
     sources:
       - license_path: LICENSE

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -77,11 +77,11 @@ resources:
       - license_path: LICENSE.txt
         ref: ${image_tag}
         url: https://github.com/jimmidyson/configmap-reload
-  - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/kiwigrid/k8s-sidecar:1.25.3-d2iq.1
+  - container_image: docker.io/kiwigrid/k8s-sidecar:1.27.6
     sources:
       - license_path: LICENSE
-        ref: ${image_tag%-d2iq.1}
-        url: https://github.com/kiwigrid/k8s-sidecar
+        ref: ${image_tag}
+        url: docker.io/kiwigrid/k8s-sidecar
   - container_image: docker.io/kubernetesui/dashboard-api:1.7.0
     sources:
       - license_path: LICENSE
@@ -464,11 +464,11 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag%-distro}
         url: https://github.com/kiali/kiali
-  - container_image: ghcr.io/mesosphere/dkp-container-images/quay.io/kiwigrid/k8s-sidecar:1.26.1-d2iq.1
+  - container_image: docker.io/kiwigrid/k8s-sidecar:1.27.6
     sources:
       - license_path: LICENSE
-        ref: ${image_tag%-d2iq.1}
-        url: https://github.com/kiwigrid/k8s-sidecar
+        ref: ${image_tag}
+        url: docker.io/kiwigrid/k8s-sidecar
   - container_image: quay.io/prometheus-operator/prometheus-config-reloader:v0.76.1
     sources:
       - license_path: LICENSE

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -77,11 +77,6 @@ resources:
       - license_path: LICENSE.txt
         ref: ${image_tag}
         url: https://github.com/jimmidyson/configmap-reload
-  - container_image: docker.io/kiwigrid/k8s-sidecar:1.27.6
-    sources:
-      - license_path: LICENSE
-        ref: ${image_tag}
-        url: https://github.com/kiwigrid/k8s-sidecar
   - container_image: docker.io/kubernetesui/dashboard-api:1.7.0
     sources:
       - license_path: LICENSE

--- a/services/centralized-grafana/63.0.0/defaults/cm.yaml
+++ b/services/centralized-grafana/63.0.0/defaults/cm.yaml
@@ -21,9 +21,9 @@ data:
         path: "/dkp/kommander/monitoring/grafana/metrics"
       sidecar:
         image:
-          registry: ghcr.io
-          repository: mesosphere/dkp-container-images/quay.io/kiwigrid/k8s-sidecar
-          tag: 1.26.1-d2iq.1
+          registry: docker.io
+          repository: kiwigrid/k8s-sidecar
+          tag: 1.27.6
         dashboards:
           enabled: true
           # label that the configmaps with dashboards are marked with

--- a/services/centralized-grafana/63.0.0/defaults/cm.yaml
+++ b/services/centralized-grafana/63.0.0/defaults/cm.yaml
@@ -23,7 +23,7 @@ data:
         image:
           registry: docker.io
           repository: kiwigrid/k8s-sidecar
-          tag: 1.27.6
+          tag: 1.28.0
         dashboards:
           enabled: true
           # label that the configmaps with dashboards are marked with

--- a/services/centralized-kubecost/0.37.6/defaults/cm.yaml
+++ b/services/centralized-kubecost/0.37.6/defaults/cm.yaml
@@ -72,8 +72,8 @@ data:
         # Grafana itself is not installed.
         sidecar:
           image:
-            repository: ghcr.io/mesosphere/dkp-container-images/docker.io/kiwigrid/k8s-sidecar
-            tag: 1.25.3-d2iq.0
+            repository: docker.io/kiwigrid/k8s-sidecar
+            tag: 1.27.6
           dashboards:
             enabled: true
             label: grafana_dashboard_kommander

--- a/services/centralized-kubecost/0.37.6/defaults/cm.yaml
+++ b/services/centralized-kubecost/0.37.6/defaults/cm.yaml
@@ -73,7 +73,7 @@ data:
         sidecar:
           image:
             repository: docker.io/kiwigrid/k8s-sidecar
-            tag: 1.27.6
+            tag: 1.28.0
           dashboards:
             enabled: true
             label: grafana_dashboard_kommander

--- a/services/grafana-logging/8.3.6/defaults/cm.yaml
+++ b/services/grafana-logging/8.3.6/defaults/cm.yaml
@@ -31,7 +31,7 @@ data:
       image:
         registry: docker.io
         repository: kiwigrid/k8s-sidecar
-        tag: 1.27.6
+        tag: 1.28.0
 
       dashboards:
         enabled: true

--- a/services/grafana-logging/8.3.6/defaults/cm.yaml
+++ b/services/grafana-logging/8.3.6/defaults/cm.yaml
@@ -29,9 +29,9 @@ data:
 
     sidecar:
       image:
-        registry: ghcr.io
-        repository: mesosphere/dkp-container-images/quay.io/kiwigrid/k8s-sidecar
-        tag: 1.26.1-d2iq.1
+        registry: docker.io
+        repository: kiwigrid/k8s-sidecar
+        tag: 1.27.6
 
       dashboards:
         enabled: true

--- a/services/kube-prometheus-stack/63.0.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/63.0.0/defaults/cm.yaml
@@ -355,9 +355,9 @@ data:
         pathType: ImplementationSpecific
       sidecar:
         image:
-          registry: ghcr.io
-          repository: mesosphere/dkp-container-images/quay.io/kiwigrid/k8s-sidecar
-          tag: 1.26.1-d2iq.1
+          registry: docker.io
+          repository: docker.io/kiwigrid/k8s-sidecar
+          tag: 1.27.6
         dashboards:
           enabled: true
           label: grafana_dashboard

--- a/services/kube-prometheus-stack/63.0.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/63.0.0/defaults/cm.yaml
@@ -357,7 +357,7 @@ data:
         image:
           registry: docker.io
           repository: kiwigrid/k8s-sidecar
-          tag: 1.27.6
+          tag: 1.28.0
         dashboards:
           enabled: true
           label: grafana_dashboard

--- a/services/kube-prometheus-stack/63.0.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/63.0.0/defaults/cm.yaml
@@ -356,7 +356,7 @@ data:
       sidecar:
         image:
           registry: docker.io
-          repository: docker.io/kiwigrid/k8s-sidecar
+          repository: kiwigrid/k8s-sidecar
           tag: 1.27.6
         dashboards:
           enabled: true

--- a/services/kubecost/0.37.7/defaults/cm.yaml
+++ b/services/kubecost/0.37.7/defaults/cm.yaml
@@ -120,8 +120,8 @@ data:
             check_for_updates: false
         sidecar:
           image:
-            repository: ghcr.io/mesosphere/dkp-container-images/docker.io/kiwigrid/k8s-sidecar
-            tag: 1.25.3-d2iq.1
+            repository: docker.io/kiwigrid/k8s-sidecar
+            tag: 1.27.6
 
       kubecostProductConfigs:
         grafanaURL: "/dkp/kubecost/grafana"

--- a/services/kubecost/0.37.7/defaults/cm.yaml
+++ b/services/kubecost/0.37.7/defaults/cm.yaml
@@ -121,7 +121,7 @@ data:
         sidecar:
           image:
             repository: docker.io/kiwigrid/k8s-sidecar
-            tag: 1.27.6
+            tag: 1.28.0
 
       kubecostProductConfigs:
         grafanaURL: "/dkp/kubecost/grafana"

--- a/services/project-grafana-logging/8.3.5/defaults/cm.yaml
+++ b/services/project-grafana-logging/8.3.5/defaults/cm.yaml
@@ -31,7 +31,7 @@ data:
       image:
         registry: docker.io
         repository: kiwigrid/k8s-sidecar
-        tag: 1.27.6
+        tag: 1.28.0
       dashboards:
         enabled: true
         label: project_grafana_logging_dashboard

--- a/services/project-grafana-logging/8.3.5/defaults/cm.yaml
+++ b/services/project-grafana-logging/8.3.5/defaults/cm.yaml
@@ -29,9 +29,9 @@ data:
 
     sidecar:
       image:
-        registry: ghcr.io
-        repository: mesosphere/dkp-container-images/quay.io/kiwigrid/k8s-sidecar
-        tag: 1.26.1-d2iq.1
+        registry: docker.io
+        repository: kiwigrid/k8s-sidecar
+        tag: 1.27.6
       dashboards:
         enabled: true
         label: project_grafana_logging_dashboard


### PR DESCRIPTION
**What problem does this PR solve?**:

bump kiwigrid/k8s-sidecar to 1.27.6

**Which issue(s) does this PR fix?**:

https://jira.nutanix.com/browse/NCN-102780



**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
