### PR TITLE
feat: publish kapps server to ghcr

### DIFF
--- a/just/test.just
+++ b/just/test.just
@@ -10,7 +10,7 @@ _run_server: (release-server "false")
     --publish 12345:12345 \
     --detach \
     --user 1000:1000 \
-    {{ server_docker_repository }}:{{ git_tag }}
+    {{ server_repository }}:{{ git_tag }}
 
 _kill_server:
     docker kill {{ test_container_name }}

--- a/justfile
+++ b/justfile
@@ -2,13 +2,13 @@ set dotenv-load
 
 git_tag := env_var_or_default("GIT_TAG", "v0.0.0")
 
-registry := "docker.io"
+registry := "ghcr.io"
 org_name := "mesosphere"
 repository := org_name / "kommander-applications"
 include_file := justfile_directory() / ".include-airgapped"
 exclude_file := justfile_directory() / ".exclude-airgapped"
 git_operator_version := env("GIT_OPERATOR_VERSION", "latest")
-server_docker_repository := registry / org_name / "kommander-applications-server"
+server_repository := registry / org_name / "kommander-applications-server"
 
 s3_path := "dkp" / git_tag
 s3_bucket := "downloads.mesosphere.io"
@@ -39,9 +39,9 @@ release-oci publish="true" tmp_dir=`mktemp --directory`: (_prepare-files-for-a-b
 
 release-server publish="true" tmp_dir=`mktemp --directory`: (_prepare-git-repository tmp_dir)
     cp -r {{ tmp_dir }} ./server/data/
-    cd ./server && docker buildx build . --tag {{ server_docker_repository }}:{{ git_tag }}
+    cd ./server && docker buildx build . --tag {{ server_repository }}:{{ git_tag }}
     rm -rf ./server/data/
-    if {{ publish }}; then docker push {{ server_docker_repository }}:{{ git_tag }}; fi
+    if {{ publish }}; then docker push {{ server_repository }}:{{ git_tag }}; fi
 
 service_version:=`ls services/git-operator/ | grep -E "v?[[:digit:]]\.[[:digit:]]\.[[:digit:]]"`
 service_dir:=justfile_directory() / "services/git-operator" / service_version


### PR DESCRIPTION
**What problem does this PR solve?**:

Publish open source code images to ghcr instead of docker registry

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
