### PR TITLE
fix: bump curl to 8.9.1

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -500,7 +500,7 @@ resources:
       - url: https://github.com/NVIDIA/DCGM
         ref: v${image_tag%-1-ubuntu22.04}
         license_path: LICENSE
-  - container_image: docker.io/curlimages/curl:8.8.0
+  - container_image: docker.io/curlimages/curl:8.9.1
     sources:
       - url: https://github.com/curl/curl
         ref: curl-${image_tag//./_}

--- a/services/gatekeeper/3.17.0/defaults/cm.yaml
+++ b/services/gatekeeper/3.17.0/defaults/cm.yaml
@@ -26,7 +26,7 @@ data:
         priorityClassName: system-cluster-critical
         image:
           repository: curlimages/curl
-          tag: 8.8.0
+          tag: 8.9.1
     controllerManager:
       tlsMinVersion: 1.2
     upgradeCRDs:


### PR DESCRIPTION
**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
