### PR TITLE
feat: send slack notifications on success and failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,3 +70,66 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global  user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           devbox run -- just release-server
+
+  send_message:
+    runs-on:
+      - self-hosted
+      - small
+    needs:
+      - "release"
+    if: ${{ always() }}
+    steps:
+      - name: Send slack message if any of the release jobs failed
+        if: ${{contains(needs.*.result, 'failure') }}
+        uses: slackapi/slack-github-action@v1.27.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NTNX_NCNDKPSHIPIT }}
+        with:
+          payload: |
+            {
+              "text": "${{github.repository}} release ${{ github.ref_name }} failed",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":github: :x: ${{github.repository}} release ${{ github.ref_name }} failed",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Rerun the failed job(s) at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+      - name: Send slack message when all release jobs completed successfully
+        if: ${{ !contains(needs.*.result, 'failure') && !endsWith(github.ref_name, '-dev') }} # No need to send a message on daily releases.
+        uses: slackapi/slack-github-action@v1.27.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NTNX_NCNDKPSHIPIT }}
+        with:
+          payload: |
+            {
+              "text": "${{github.repository}} release ${{ github.ref_name }} succeeded",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":github: :heavy_check_mark: ${{github.repository}} - Release ${{ github.ref_name }} successful :rocket:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
**What problem does this PR solve?**:

Triggers slack notifications when release is failed as well as successful (for non `-dev` releases)

Which issue(s) does this PR fix?:

[jira.nutanix.com/browse/NCN-103687](https://jira.nutanix.com/browse/NCN-103687)


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
