### PR TITLE
feat: bump velero v1.11.0

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -253,7 +253,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/rook/rook
-  - container_image: docker.io/velero/velero-plugin-for-aws:v1.10.1
+  - container_image: docker.io/velero/velero-plugin-for-aws:v1.11.0
     sources:
       - license_path: LICENSE
         ref: ${image_tag}

--- a/services/README.md
+++ b/services/README.md
@@ -1,1 +1,1 @@
-`/services/` directory contains one directory per platform service in which a HelmRelease resides for that specific platform service.
+`/services/` directory contains one directory per platform service in which a HelmRelease resides for that specific platform service

--- a/services/README.md
+++ b/services/README.md
@@ -1,1 +1,1 @@
-`/services/` directory contains one directory per platform service in which a HelmRelease resides for that specific platform service
+`/services/` directory contains one directory per platform service in which a HelmRelease resides for that specific platform service.

--- a/services/velero/7.2.2/defaults/cm.yaml
+++ b/services/velero/7.2.2/defaults/cm.yaml
@@ -51,7 +51,7 @@ data:
           servicemonitor.kommander.mesosphere.io/path: "metrics"
     initContainers:
       - name: velero-plugin-for-aws
-        image: velero/velero-plugin-for-aws:v1.10.1
+        image: velero/velero-plugin-for-aws:v1.11.0
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - mountPath: /target


### PR DESCRIPTION
**What problem does this PR solve?**:
Bump version v1.11.0

**Which issue(s) does this PR fix?**:
pkg:docker/velero/velero-plugin-for-aws@v1.10.1

trivy image docker.io/velero/velero-plugin-for-aws:v1.11.0
2024-11-19T14:01:03+05:30       INFO    [vuln] Vulnerability scanning is enabled
2024-11-19T14:01:03+05:30       INFO    [secret] Secret scanning is enabled
2024-11-19T14:01:03+05:30       INFO    [secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-11-19T14:01:03+05:30       INFO    [secret] Please see also https://aquasecurity.github.io/trivy/v0.57/docs/scanner/secret#recommendation for faster secret detection
2024-11-19T14:01:06+05:30       INFO    Number of language-specific files       num=2
2024-11-19T14:01:06+05:30       INFO    [gobinary] Detecting vulnerabilities...

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
