### PR TITLE
fix: Remove hardcoded image in for ai-navigator-cluster-info-agent

### DIFF
--- a/services/ai-navigator-cluster-info-agent/0.1.2/defaults/cm.yaml
+++ b/services/ai-navigator-cluster-info-agent/0.1.2/defaults/cm.yaml
@@ -16,12 +16,6 @@ data:
     # Default values for cluster-info-agent
     replicaCount: 1
 
-    image:
-      repository: mesosphere/ai-navigator-cluster-info-agent
-      pullPolicy: Always
-      # Overrides the image tag whose default is the chart appVersion.
-      tag: "v0.1.0"
-
     imagePullSecrets: []
     nameOverride: ""
     fullnameOverride: ""


### PR DESCRIPTION
**What problem does this PR solve?**:
Removes the hardcoded tag and use the default chart value, so we don't have to maintain that in both places.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
