### PR TITLE
fix: patch and bump kubecost images to fix cve

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -571,7 +571,7 @@ resources:
   - container_image: ghcr.io/mesosphere/dkp-container-images/gcr.io/kubecost1/frontend:prod-1.108.1-d2iq.0
     sources:
       - url: https://github.com/opencost/opencost
-        ref: v1.108.1-d2iq.0
+        ref: v1.108.1
         license_path: LICENSE
   - container_image: registry.k8s.io/pause:3.10
     sources:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -568,10 +568,10 @@ resources:
       - url: https://github.com/opencost/opencost
         ref: v${image_tag#prod-}
         license_path: LICENSE
-  - container_image: gcr.io/kubecost1/frontend:prod-1.108.1
+  - container_image: ghcr.io/mesosphere/dkp-container-images/gcr.io/kubecost1/frontend:prod-1.108.1-d2iq.0
     sources:
       - url: https://github.com/opencost/opencost
-        ref: v1.108.1
+        ref: v1.108.1-d2iq.0
         license_path: LICENSE
   - container_image: registry.k8s.io/pause:3.10
     sources:

--- a/services/centralized-kubecost/0.37.7/defaults/cm.yaml
+++ b/services/centralized-kubecost/0.37.7/defaults/cm.yaml
@@ -13,6 +13,8 @@ data:
 
     cost-analyzer:
       fullnameOverride: "kommander-kubecost-cost-analyzer"
+      kubecostFrontend:
+        fullImageName: ghcr.io/mesosphere/dkp-container-images/gcr.io/kubecost1/frontend:prod-1.108.1-d2iq.0
       priority:
         enabled: true
         name: dkp-high-priority

--- a/services/kubecost/0.37.8/defaults/cm.yaml
+++ b/services/kubecost/0.37.8/defaults/cm.yaml
@@ -12,6 +12,8 @@ data:
         priorityClassName: dkp-high-priority
 
     cost-analyzer:
+      kubecostFrontend:
+        fullImageName: ghcr.io/mesosphere/dkp-container-images/gcr.io/kubecost1/frontend:prod-1.108.1-d2iq.0
       priority:
         enabled: true
         name: dkp-high-priority


### PR DESCRIPTION
**What problem does this PR solve?**:
patch and bump frontend image

workflow:
https://github.com/mesosphere/dkp-container-images/actions/runs/11930752381

**Which issue(s) does this PR fix?**:



**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
