### PR TITLE
chore: Post release bumps

### DIFF
--- a/upgrade-matrix.yaml
+++ b/upgrade-matrix.yaml
@@ -3,57 +3,69 @@ upgrades:
       to: v2.6.3-dev
       k8sversion: "1.26"
     - from: v2.6.0
-      to: v2.7.3-dev
+      to: v2.7.4-dev
       k8sversion: "1.26"
     - from: v2.6.1
       to: v2.6.3-dev
       k8sversion: "1.26"
     - from: v2.6.1
-      to: v2.7.3-dev
+      to: v2.7.4-dev
       k8sversion: "1.26"
     - from: v2.6.2
       to: v2.6.3-dev
       k8sversion: "1.26"
     - from: v2.6.2
-      to: v2.7.3-dev
+      to: v2.7.4-dev
       k8sversion: "1.26"
     - from: v2.6.3-dev
-      to: v2.7.3-dev
+      to: v2.7.4-dev
       k8sversion: "1.26"
     - from: v2.7.0
-      to: v2.7.3-dev
+      to: v2.7.4-dev
       k8sversion: "1.27"
     - from: v2.7.0
-      to: v2.8.2-dev
+      to: v2.8.3-dev
       k8sversion: "1.27"
     - from: v2.7.1
-      to: v2.7.3-dev
+      to: v2.7.4-dev
       k8sversion: "1.27"
     - from: v2.7.1
-      to: v2.8.2-dev
+      to: v2.8.3-dev
       k8sversion: "1.27"
     - from: v2.7.2
-      to: v2.7.3-dev
+      to: v2.7.4-dev
       k8sversion: "1.27"
     - from: v2.7.2
-      to: v2.8.2-dev
+      to: v2.8.3-dev
       k8sversion: "1.27"
-    - from: v2.7.3-dev
-      to: v2.8.2-dev
+    - from: v2.7.3
+      to: v2.7.4-dev
+      k8sversion: "1.27"
+    - from: v2.7.3
+      to: v2.8.3-dev
+      k8sversion: "1.27"
+    - from: v2.7.4-dev
+      to: v2.8.3-dev
       k8sversion: "1.27"
     - from: v2.8.0
-      to: v2.8.2-dev
+      to: v2.8.3-dev
       k8sversion: "1.28"
     - from: v2.8.0
       to: v2.12.2-dev
       k8sversion: "1.28"
     - from: v2.8.1
-      to: v2.8.2-dev
+      to: v2.8.3-dev
       k8sversion: "1.28"
     - from: v2.8.1
       to: v2.12.2-dev
       k8sversion: "1.28"
-    - from: v2.8.2-dev
+    - from: v2.8.2
+      to: v2.8.3-dev
+      k8sversion: "1.28"
+    - from: v2.8.2
+      to: v2.12.2-dev
+      k8sversion: "1.28"
+    - from: v2.8.3-dev
       to: v2.12.2-dev
       k8sversion: "1.28"
     - from: v2.12.0
@@ -71,3 +83,6 @@ upgrades:
     - from: v2.12.2-dev
       to: v2.13.0-dev
       k8sversion: "1.29"
+    - from: v2.13.0-dev
+      to: v2.14.0-dev
+      k8sversion: "1.30"


### PR DESCRIPTION
Post-release bumps are PRs created by [gh-dkp](https://github.com/mesosphere/gh-dkp/)
to adjust repositories after releases.
