### PR TITLE
build: Adjust the release automation to handle ghcr

### DIFF
--- a/hack/release/pkg/extraimages/extraimages.go
+++ b/hack/release/pkg/extraimages/extraimages.go
@@ -30,7 +30,7 @@ func UpdateExtraImagesVersions(kommanderApplicationsRepo, chartVersion string) e
 
 	if err := os.WriteFile(
 		matches[0],
-		[]byte(fmt.Sprintf("mesosphere/kommander-applications-server:%s\n", chartVersion)),
+		[]byte(fmt.Sprintf("ghcr.io/mesosphere/kommander-applications-server:%s\n", chartVersion)),
 		0o644,
 	); err != nil {
 		return fmt.Errorf("error while updating extra-images file: %w", err)

--- a/hack/release/pkg/extraimages/extraimages_test.go
+++ b/hack/release/pkg/extraimages/extraimages_test.go
@@ -29,5 +29,5 @@ func TestUpdateExtraImages(t *testing.T) {
 	assert.Len(t, afterUpgradeFile, 1)
 	contentes, err := os.ReadFile(afterUpgradeFile[0])
 	require.NoError(t, err)
-	assert.Equal(t, "mesosphere/kommander-applications-server:v1.2.3\n", string(contentes))
+	assert.Equal(t, "ghcr.io/mesosphere/kommander-applications-server:v1.2.3\n", string(contentes))
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
The release automation has to be adjusted too:
https://github.com/mesosphere/kommander-applications/commit/199536d025c3124eefcd96ad903f77787d69a171#diff-320fd277251bdefe63fc147281f3cec45d88932c9e31bfcf17f8658b2ad03e97R1

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
