### PR TITLE
feat: Bump AI Navigator chart to v0.2.8

### DIFF
--- a/services/ai-navigator-app/0.2.8/defaults/cm.yaml
+++ b/services/ai-navigator-app/0.2.8/defaults/cm.yaml
@@ -33,6 +33,8 @@ data:
       enabled: true
       primary:
         priorityClassName: dkp-high-priority
+        initdb:
+          scriptsConfigMap: ai-navigator-cluster-info-api-postgresql-initdb
       readReplicas:
         priorityClassName: dkp-high-priority
 

--- a/services/ai-navigator-app/0.2.8/helmrelease/helmrelease.yaml
+++ b/services/ai-navigator-app/0.2.8/helmrelease/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-ai-navigator-cluster-info-api-charts
         namespace: kommander-flux
-      version: 0.2.7
+      version: 0.2.8
   install:
     remediation:
       retries: 30


### PR DESCRIPTION
**What problem does this PR solve?**:
Upgrade the AI Navigator Cluster Info API to `0.2.8`, which includes a proper fix for the postgres migration issue.

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-104562


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
