### PR TITLE
feat: kube-rbac-proxy bump to 0.18.2

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -298,11 +298,6 @@ resources:
       - license_path: LICENSE
         ref: knative-${image_tag}
         url: https://github.com/knative-extensions/net-istio
-  - container_image: quay.io/brancz/kube-rbac-proxy:v0.18.1
-    sources:
-      - license_path: LICENSE
-        ref: ${image_tag}
-        url: https://github.com/brancz/kube-rbac-proxy
   - container_image: quay.io/brancz/kube-rbac-proxy:v0.18.2
     sources:
       - license_path: LICENSE


### PR DESCRIPTION
**What problem does this PR solve?**:

Bumps kube-rbac-proxy version to 0.18.2
**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-104608

