### PR TITLE
feat: Bump kube-webhook-certgen to 1.4.4

### DIFF
--- a/apptests/testdata/cert-manager/acme-setup/deploy-ingress-nginx-v1.10.0.yaml
+++ b/apptests/testdata/cert-manager/acme-setup/deploy-ingress-nginx-v1.10.0.yaml
@@ -545,7 +545,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.0@sha256:44d1d0e9f19c63f58b380c5fddaca7cf22c7cee564adeff365225a5df5ef3334
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.4@sha256:44d1d0e9f19c63f58b380c5fddaca7cf22c7cee564adeff365225a5df5ef3334
         imagePullPolicy: IfNotPresent
         name: create
         securityContext:
@@ -598,7 +598,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.0@sha256:44d1d0e9f19c63f58b380c5fddaca7cf22c7cee564adeff365225a5df5ef3334
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.4@sha256:44d1d0e9f19c63f58b380c5fddaca7cf22c7cee564adeff365225a5df5ef3334
         imagePullPolicy: IfNotPresent
         name: patch
         securityContext:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -532,7 +532,7 @@ resources:
       - url: https://github.com/kubernetes/kubectl
         ref: v0${image_tag#1}
         license_path: LICENSE
-  - container_image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.3
+  - container_image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.4
     sources:
       - url: https://github.com/kubernetes/ingress-nginx
         ref: controller-v1.11.2

--- a/services/kube-prometheus-stack/65.5.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/65.5.0/defaults/cm.yaml
@@ -19,7 +19,7 @@ data:
           image:
             registry: registry.k8s.io
             repository: ingress-nginx/kube-webhook-certgen
-            tag: v1.4.3
+            tag: v1.4.4
             # Set SHA to empty so airgapped deployments work out of box.
             sha: ""
     mesosphereResources:


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumps webhook certgen version to 1.4.4

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-104606

**Special notes for your reviewer**:
arvinder.pal@GHH4XN27GC kommander-applications % git checkout webhook-certgen-1.4.4
branch 'webhook-certgen-1.4.4' set up to track 'origin/webhook-certgen-1.4.4'.
Switched to a new branch 'webhook-certgen-1.4.4'
arvinder.pal@GHH4XN27GC kommander-applications % trivy i registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.4
2024-12-10T18:28:30+05:30	INFO	[db] Need to update DB
2024-12-10T18:28:30+05:30	INFO	[db] Downloading DB...	repository="ghcr.io/aquasecurity/trivy-db:2"
57.28 MiB / 57.28 MiB [-----------------------------------------------------------------------] 100.00% 3.17 MiB p/s 18s
2024-12-10T18:28:50+05:30	INFO	[vuln] Vulnerability scanning is enabled
2024-12-10T18:28:50+05:30	INFO	[secret] Secret scanning is enabled
2024-12-10T18:28:50+05:30	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-12-10T18:28:50+05:30	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.55/docs/scanner/secret#recommendation for faster secret detection
2024-12-10T18:28:51+05:30	INFO	Detected OS	family="debian" version="12.7"
2024-12-10T18:28:51+05:30	INFO	[debian] Detecting vulnerabilities...	os_version="12" pkg_num=3
2024-12-10T18:28:51+05:30	INFO	Number of language-specific files	num=1
2024-12-10T18:28:51+05:30	INFO	[gobinary] Detecting vulnerabilities...

registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.4 (debian 12.7)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
