### PR TITLE
chore: remove deprecated gcr.io/kubebuilder/kube-rbac-proxy

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -371,11 +371,6 @@ resources:
       - license_path: LICENSE
         ref: knative-v1.10.0
         url: https://github.com/knative/serving
-  - container_image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-    sources:
-      - license_path: LICENSE
-        ref: ${image_tag}
-        url: https://github.com/brancz/kube-rbac-proxy
   - container_image: ghcr.io/fluxcd/helm-controller:v0.36.2
     sources:
       - license_path: LICENSE


### PR DESCRIPTION
**What problem does this PR solve?**:
chore: remove deprecated gcr.io/kubebuilder/kube-rbac-proxy from 2.7.3 branch

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-104599