### PR TITLE
chore: Exclude NKP-Pulse from Airgapped builds.

### DIFF
--- a/.exclude-airgapped
+++ b/.exclude-airgapped
@@ -1,3 +1,6 @@
 common/helm-repositories/ai-navigator-repos.yaml
 services/ai-navigator-app
 services/ai-navigator-cluster-info-agent
+common/helm-repositories/nkp-pulse-repos.yaml
+services/nkp-pulse-management
+services/nkp-pulse-workspace

--- a/common/helm-repositories/kustomization.yaml
+++ b/common/helm-repositories/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - kubefed.yaml
   - kubetunnel.yaml
   - mesosphere-repos.yaml
+  - nkp-pulse-repos.yaml
   - nvidia.yaml
   - prometheus-community.yaml
   - reloader.yaml

--- a/common/helm-repositories/mesosphere-repos.yaml
+++ b/common/helm-repositories/mesosphere-repos.yaml
@@ -50,4 +50,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/dkp-insights-charts-attached}"
-

--- a/common/helm-repositories/mesosphere-repos.yaml
+++ b/common/helm-repositories/mesosphere-repos.yaml
@@ -50,13 +50,4 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/dkp-insights-charts-attached}"
----
-apiVersion: source.toolkit.fluxcd.io/v1beta2
-kind: HelmRepository
-metadata:
-  name: mesosphere.github.io-nkp-pulse-charts
-  namespace: kommander-flux
-spec:
-  interval: 10m
-  timeout: 1m
-  url: "${helmMirrorURL:=https://mesosphere.github.io/nkp-pulse}"
+

--- a/common/helm-repositories/nkp-pulse-repos.yaml
+++ b/common/helm-repositories/nkp-pulse-repos.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: mesosphere.github.io-nkp-pulse-charts
+  namespace: kommander-flux
+spec:
+  interval: 10m
+  timeout: 1m
+  url: "${helmMirrorURL:=https://mesosphere.github.io/nkp-pulse}"
+

--- a/common/helm-repositories/nkp-pulse-repos.yaml
+++ b/common/helm-repositories/nkp-pulse-repos.yaml
@@ -8,4 +8,3 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/nkp-pulse}"
-

--- a/justfile
+++ b/justfile
@@ -67,6 +67,7 @@ _cleanup:
 _prepare-files-for-a-bundle output_dir:
     rsync --quiet --archive --recursive --files-from={{ include_file }} --exclude-from={{ exclude_file }} {{ justfile_directory() }} {{ output_dir }}
     yq 'del(.resources[] | select(. == "ai-navigator-repos.yaml"))' --inplace {{ output_dir }}/common/helm-repositories/kustomization.yaml
+    yq 'del(.resources[] | select(. == "nkp-pulse-repos.yaml"))' --inplace {{ output_dir }}/common/helm-repositories/kustomization.yaml
 
 
 import 'just/test.just'


### PR DESCRIPTION
**What problem does this PR solve?**:

NKP-Pulse shouldn't be included in air-gapped builds (similar to AI-Navigator).
This PR follows up on #2957 to exclude NKP-Pulse from airgapped builds.

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-103329


**Special notes for your reviewer**:
Corresponding PRs:
- https://github.com/mesosphere/kommander/pull/5379


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**

<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
