### PR TITLE
feat: updated app metadata

### DIFF
--- a/services/cert-manager/metadata.yaml
+++ b/services/cert-manager/metadata.yaml
@@ -12,8 +12,7 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 overview: |-
   # Overview

--- a/services/external-dns/metadata.yaml
+++ b/services/external-dns/metadata.yaml
@@ -6,8 +6,7 @@ type: platform
 scope:
   - workspace
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 licensing:
   - Pro

--- a/services/fluent-bit/metadata.yaml
+++ b/services/fluent-bit/metadata.yaml
@@ -6,8 +6,7 @@ type: platform
 scope:
   - workspace
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 licensing:
   - Pro

--- a/services/gatekeeper/metadata.yaml
+++ b/services/gatekeeper/metadata.yaml
@@ -6,8 +6,7 @@ type: platform
 scope:
   - workspace
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 licensing:
   - Starter

--- a/services/grafana-logging/metadata.yaml
+++ b/services/grafana-logging/metadata.yaml
@@ -13,7 +13,6 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
   - supported
   - airgapped
 overview: |-

--- a/services/grafana-loki/metadata.yaml
+++ b/services/grafana-loki/metadata.yaml
@@ -13,7 +13,6 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
   - supported
   - airgapped
 overview: |-

--- a/services/istio/metadata.yaml
+++ b/services/istio/metadata.yaml
@@ -8,7 +8,6 @@ type: platform
 scope:
   - workspace
 certifications:
-  - certified
   - supported
 licensing:
   - Pro

--- a/services/jaeger/metadata.yaml
+++ b/services/jaeger/metadata.yaml
@@ -13,8 +13,7 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
-  - supported
+  - qualified
 overview: |-
   # Overview
   Jaeger is open source software for tracing transactions between distributed services. It is used for monitoring and troubleshooting complex microservices environments. Jaeger uses distributed tracing to follow the path of a request through different microservices.

--- a/services/kiali/metadata.yaml
+++ b/services/kiali/metadata.yaml
@@ -13,8 +13,7 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
-  - supported
+  - qualified
 overview: |-
   # Overview
   Kiali is a management console for an Istio-based service mesh. It provides dashboards, observability, and lets you operate your mesh with robust configuration and validation capabilities. It shows the structure of your service mesh by inferring traffic topology and displays the health of your mesh. To use Kiali, Prometheus, Istio, and Jaeger need to be deployed.

--- a/services/kube-oidc-proxy/metadata.yaml
+++ b/services/kube-oidc-proxy/metadata.yaml
@@ -15,8 +15,7 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 overview: |-
   # Overview

--- a/services/kube-prometheus-stack/metadata.yaml
+++ b/services/kube-prometheus-stack/metadata.yaml
@@ -11,8 +11,7 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 overview: |-
   # Overview

--- a/services/kubecost/metadata.yaml
+++ b/services/kubecost/metadata.yaml
@@ -2,15 +2,14 @@ displayName: Kubecost
 description: Provides real-time cost visibility and insights for teams using Kubernetes, helping organizations continuously reduce cloud costs.
 category:
   - monitoring
-type: partner
+type: platform
 scope:
   - workspace
 licensing:
   - Ultimate
   - Enterprise
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 overview: |-
   # Overview

--- a/services/kubernetes-dashboard/metadata.yaml
+++ b/services/kubernetes-dashboard/metadata.yaml
@@ -13,8 +13,7 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 overview: |-
   # Overview

--- a/services/logging-operator/metadata.yaml
+++ b/services/logging-operator/metadata.yaml
@@ -6,8 +6,7 @@ type: platform
 scope:
   - workspace
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 licensing:
   - Pro

--- a/services/nkp-insights/metadata.yaml
+++ b/services/nkp-insights/metadata.yaml
@@ -12,7 +12,6 @@ requiredDependencies:
   - rook-ceph-cluster
 certifications:
   - airgapped
-  - certified
   - supported
 type: platform
 allowMultipleInstances: false

--- a/services/nvidia-gpu-operator/metadata.yaml
+++ b/services/nvidia-gpu-operator/metadata.yaml
@@ -11,8 +11,7 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 overview: |-
   # Overview

--- a/services/project-grafana-logging/metadata.yaml
+++ b/services/project-grafana-logging/metadata.yaml
@@ -11,8 +11,7 @@ licensing:
   - Ultimate
   - Enterprise
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 overview: |-
   # Overview

--- a/services/project-grafana-loki/metadata.yaml
+++ b/services/project-grafana-loki/metadata.yaml
@@ -13,8 +13,7 @@ licensing:
   - Ultimate
   - Enterprise
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 overview: |-
   # Overview

--- a/services/project-logging/metadata.yaml
+++ b/services/project-logging/metadata.yaml
@@ -11,8 +11,7 @@ licensing:
   - Ultimate
   - Enterprise
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 overview: |-
   # Overview

--- a/services/prometheus-adapter/metadata.yaml
+++ b/services/prometheus-adapter/metadata.yaml
@@ -13,8 +13,7 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 overview: |-
   # Overview

--- a/services/reloader/metadata.yaml
+++ b/services/reloader/metadata.yaml
@@ -12,8 +12,7 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 overview: |-
   # Overview

--- a/services/rook-ceph-cluster/metadata.yaml
+++ b/services/rook-ceph-cluster/metadata.yaml
@@ -14,8 +14,7 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 overview: |-
   # Overview

--- a/services/rook-ceph/metadata.yaml
+++ b/services/rook-ceph/metadata.yaml
@@ -12,8 +12,7 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
-  - supported
+  - qualified
   - airgapped
 overview: |-
   # Overview

--- a/services/traefik-forward-auth/metadata.yaml
+++ b/services/traefik-forward-auth/metadata.yaml
@@ -14,7 +14,6 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
   - supported
   - airgapped
 overview: |-

--- a/services/traefik/metadata.yaml
+++ b/services/traefik/metadata.yaml
@@ -15,7 +15,6 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
   - supported
   - airgapped
 overview: |-

--- a/services/velero/metadata.yaml
+++ b/services/velero/metadata.yaml
@@ -13,7 +13,6 @@ licensing:
   - Essentials
   - Enterprise
 certifications:
-  - certified
   - supported
   - airgapped
 overview: |-


### PR DESCRIPTION
Kubecost is now a platform application.
Certified should be removed.
Supported should be replaced with Qualified.

**What problem does this PR solve?**:
Requested changes for 2.14:
- Certified badges will be removed in the UI
- Supported -> Qualified for third-party apps
- Nutanix apps should keep supported ( I think we only have nkp insights here but let me know if I missed any)
- Partner applications should not be used. Kubecost should become a platform application due to this.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-104856

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
Kubecost has been updated to a platform application. 
The term "Certified" has been removed. 
The term "Supported" has been replaced with "Qualified".
```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
