### PR TITLE
feat: bump bloodhound to validate against 1.32.0

### DIFF
--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -5,6 +5,7 @@ k8s_versions:
   - 1.29.9
   - 1.30.5
   - 1.31.1
+  - 1.32.9
 
 # paths to load (in that order)
 paths:

--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -5,7 +5,7 @@ k8s_versions:
   - 1.29.9
   - 1.30.5
   - 1.31.1
-  - 1.32.9
+  - 1.32.0
 
 # paths to load (in that order)
 paths:

--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -1,8 +1,6 @@
 # Kubernetes versions
 # (e.g. 1.23.0 - has to match versions in https://github.com/yannh/kubernetes-json-schema)
 k8s_versions:
-  - 1.28.7
-  - 1.29.9
   - 1.30.5
   - 1.31.1
   - 1.32.0


### PR DESCRIPTION
**What problem does this PR solve?**:
bumping 1.32.0 in commander-application for checking incompatible resources

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-103535

