### PR TITLE
fix: list image shell missing cronjob

### DIFF
--- a/hack/list-images.sh
+++ b/hack/list-images.sh
@@ -129,7 +129,7 @@ done
 # These services use raw manifests rather than Helm charts so list the images directly from the manifests.
 # If more raw manifest services are added, then they should be added to the list of paths below.
 gojq --yaml-input --raw-output 'select(.kind | test("^(?:Deployment|Job|CronJob|StatefulSet|DaemonSet)$")) |
-                                .spec.template.spec |
+                                (.spec.template.spec // .spec.jobTemplate.spec.template.spec) |
                                 (select(.containers != null) | .containers[].image), (select(.initContainers != null) | .initContainers[].image)' \
 				./services/git-operator/*/git-operator-manifests/* \
                                 ./services/kommander-flux/*/templates/* \

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -527,6 +527,11 @@ resources:
       - url: https://github.com/NVIDIA/cuda-samples
         ref: v12.5
         license_path: LICENSE
+  - container_image: docker.io/bitnami/kubectl:1.29.6
+    sources:
+      - url: https://github.com/kubernetes/kubectl
+        ref: v0${image_tag#1}
+        license_path: LICENSE
   - container_image: docker.io/bitnami/kubectl:1.30.5
     sources:
       - url: https://github.com/kubernetes/kubectl


### PR DESCRIPTION
**What problem does this PR solve?**:
list-images.sh skips Cronjob images

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-105004

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

tested running the script and saw the missing `docker.io/bitnami/kubectl:1.29.6` image

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
