### PR TITLE
fix: ensure ipv4 for kong

### DIFF
--- a/services/kubernetes-dashboard/7.10.0/defaults/cm.yaml
+++ b/services/kubernetes-dashboard/7.10.0/defaults/cm.yaml
@@ -69,3 +69,10 @@ data:
       admin:
         tls:
           enabled: false
+      # ensure it's using ipv4
+      proxy:
+        addresses:
+          - 0.0.0.0
+      status:
+        addresses:
+          - 0.0.0.0


### PR DESCRIPTION
**What problem does this PR solve?**:
k8s dashboard doesn't start when ipv6 is disabled

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-105116

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
