### PR TITLE
feat: consume centralized-grafana in primary kubecost

### DIFF
--- a/apptests/appscenarios/kubecost_test.go
+++ b/apptests/appscenarios/kubecost_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Kubecost Tests", Label("kubecost"), func() {
 			deploymentList = &appsv1.DeploymentList{}
 			err = k8sClient.List(ctx, deploymentList, listOptions)
 			Expect(err).To(BeNil())
-			Expect(deploymentList.Items).To(HaveLen(4), "Expected 4 deployments to be created - cost-analyzer, grafana, prometheus server and prometheus alertmanager")
+			Expect(deploymentList.Items).To(HaveLen(3), "Expected 3 components to be created - cost-analyzer, prometheus server and prometheus alertmanager")
 			Expect(err).To(BeNil())
 
 			for _, deployment := range deploymentList.Items {

--- a/services/kubecost/2.5.2/defaults/cm.yaml
+++ b/services/kubecost/2.5.2/defaults/cm.yaml
@@ -13,6 +13,7 @@ data:
 
       grafana:
         enabled: false # Cannot use grafana when federatedETL.agentOnly is true.
+        proxy: false
 
       # Installs custom CA certificates onto Kubecost pods
       updateCaTrust:
@@ -171,12 +172,6 @@ data:
   # Overrides for kubecost to run in primary mode (single cluster with no object storage)
   primary-values.yaml: |
     global:
-      grafana:
-        enabled: true
-        # TODO(takirala): Use kommander monitoring centralized-grafana instance
-        # once it is available.
-        # Or, maybe just add same datasource to it if possible ?
-
       notifications:
         alertmanager:
           # If true, allow kubecost to write to alertmanager
@@ -248,18 +243,18 @@ data:
 
     grafana:
       priorityClassName: dkp-high-priority
-      image:
-        repository: grafana/grafana
-        tag: 11.4.0
-        pullPolicy: IfNotPresent
       sidecar:
         dashboards:
           enabled: true
           label: grafana_dashboard_kommander
+          labelValue: 1
         datasources:
           enabled: true
           defaultDatasourceEnabled: false
           label: grafana_datasource_kommander
+
+    kubecostProductConfigs:
+      grafanaURL: "/dkp/kommander/monitoring/grafana"
 
   # Overrides for kubecost to create cosi resources.
   primary-cosi-values.yaml: |

--- a/services/kubecost/2.5.2/release/release.yaml
+++ b/services/kubecost/2.5.2/release/release.yaml
@@ -39,6 +39,21 @@ spec:
   postRenderers:
     - kustomize:
         patches:
+          - target:
+              version: v1
+              kind: ConfigMap
+              name: grafana-datasource
+            patch: |
+              - op: replace
+                path: /data/datasource.yaml
+                value: |-
+                  apiVersion: 1
+                  datasources:
+                  - access: proxy
+                    name: default-kubecost
+                    type: prometheus
+                    isDefault: false
+                    url: http://kubecost-prometheus-server.${releaseNamespace}.svc.cluster.local
           # The name of grafana datasource configmap is hardcoded in upstream chart. Use postRenderers to make the name specific to kubecost (no-op on attached clusters).
           - target:
               version: v1


### PR DESCRIPTION
**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
