### PR TITLE
fix: Use only alphanumeric characters for harbor valkey password

### DIFF
--- a/services/harbor/1.16.0/pre-install/pre-install-jobs.yaml
+++ b/services/harbor/1.16.0/pre-install/pre-install-jobs.yaml
@@ -25,7 +25,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "create"]
+    verbs: ["get", "list", "create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -89,8 +89,9 @@ spec:
                 exit 0
               fi
 
-              kubectl create secret generic -n ncr-system "$SECRET_NAME" -oyaml --dry-run=client --save-config \
-                --from-literal=HARBOR_ADMIN_PASSWORD=$(tr -dc 'A-Za-z0-9!?%=' < /dev/urandom | head -c 20) | kubectl apply -f -
+              kubectl create secret generic -n ncr-system "$SECRET_NAME" -oyaml --dry-run=client \
+                --from-literal=HARBOR_ADMIN_PASSWORD=$(tr -dc 'A-Za-z0-9!?%=' < /dev/urandom | head -c 20) | \
+                kubectl apply --server-side -f -
         - name: generate-valkey-password
           image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.30.5}"
           command:
@@ -112,5 +113,6 @@ spec:
                 exit 0
               fi
 
-              kubectl create secret generic -n ncr-system "$SECRET_NAME" -oyaml --dry-run=client --save-config \
-                --from-literal=REDIS_PASSWORD=$(tr -dc 'A-Za-z0-9!?%=' < /dev/urandom | head -c 20) | kubectl apply -f -
+              kubectl create secret generic -n ncr-system "$SECRET_NAME" -oyaml --dry-run=client \
+                --from-literal=REDIS_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 20) | \
+                kubectl apply --server-side -f -


### PR DESCRIPTION
Harbor helm chart does not adequately URL escape special characters in redis (valkey) password leading to harbor core not being able to connect to redis. This PR limits the characters usable for password generation so the connection URLs are guaranteed to be valid.