### PR TITLE
feat: add monitoring to cnpg and default harbor db

### DIFF
--- a/services/cloudnative-pg/0.23.0/defaults/cm.yaml
+++ b/services/cloudnative-pg/0.23.0/defaults/cm.yaml
@@ -6,4 +6,6 @@ metadata:
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-
-    ---
+    config:
+      data:
+        INHERITED_LABELS: "prometheus.kommander.d2iq.io/select"

--- a/services/harbor/1.16.0/defaults/database.yaml
+++ b/services/harbor/1.16.0/defaults/database.yaml
@@ -14,5 +14,9 @@ data:
         size: 10Gi
       initdb:
         database: harbor
+      monitoring:
+        enabled: true
+      additionalLabels:
+        prometheus.kommander.d2iq.io/select: "true"
     backups:
       enabled: false


### PR DESCRIPTION
**What problem does this PR solve?**:

- configure CloudNativePG Operator to pass labels used by NKP Prom instance to select monitors
- enable monitoring on harbor databases