### PR TITLE
feat: add prom rules for harbor deployed cluster

### DIFF
--- a/services/harbor/1.16.0/defaults/database.yaml
+++ b/services/harbor/1.16.0/defaults/database.yaml
@@ -18,5 +18,6 @@ data:
         enabled: true
       additionalLabels:
         prometheus.kommander.d2iq.io/select: "true"
+        release: kube-prometheus-stack
     backups:
       enabled: false


### PR DESCRIPTION
**What problem does this PR solve?**:

we need a second labels to add the harbor db prometheusrules to our prom instance