### PR TITLE
fix: third-party apps should use the qualified certification

### DIFF
--- a/services/cloudnative-pg/metadata.yaml
+++ b/services/cloudnative-pg/metadata.yaml
@@ -12,7 +12,6 @@ licensing:
   - Enterprise
 certifications:
   - qualified
-  - supported
   - airgapped
 overview: |-
   # Overview

--- a/services/harbor/metadata.yaml
+++ b/services/harbor/metadata.yaml
@@ -14,7 +14,6 @@ licensing:
   - Enterprise
 certifications:
   - qualified
-  - supported
   - airgapped
 overview: |-
   # Overview


### PR DESCRIPTION
**What problem does this PR solve?**:
Third-party applications should use 'qualified' instead of 'supported'.
Supported is now reserved for Nutanix supported apps - NKP Insights, NAI, etc. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-105258

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
CloudNativePG and Harbor applications will have a qualified badge and not a certified badge.
```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
