### PR TITLE
fix: add airgapped certification to istio, jaeger, and kiali

### DIFF
--- a/services/istio/metadata.yaml
+++ b/services/istio/metadata.yaml
@@ -9,6 +9,7 @@ scope:
   - workspace
 certifications:
   - qualified
+  - airgapped
 licensing:
   - Pro
   - Ultimate

--- a/services/jaeger/metadata.yaml
+++ b/services/jaeger/metadata.yaml
@@ -14,6 +14,7 @@ licensing:
   - Enterprise
 certifications:
   - qualified
+  - airgapped
 overview: |-
   # Overview
   Jaeger is open source software for tracing transactions between distributed services. It is used for monitoring and troubleshooting complex microservices environments. Jaeger uses distributed tracing to follow the path of a request through different microservices.

--- a/services/kiali/metadata.yaml
+++ b/services/kiali/metadata.yaml
@@ -14,6 +14,7 @@ licensing:
   - Enterprise
 certifications:
   - qualified
+  - airgapped
 overview: |-
   # Overview
   Kiali is a management console for an Istio-based service mesh. It provides dashboards, observability, and lets you operate your mesh with robust configuration and validation capabilities. It shows the structure of your service mesh by inferring traffic topology and displays the health of your mesh. To use Kiali, Prometheus, Istio, and Jaeger need to be deployed.


### PR DESCRIPTION
**What problem does this PR solve?**:
Istio, Jaeger, and Kiali are available in airgapped environments.
Link to discussion - https://nutanix.slack.com/archives/C068HGFS19B/p1737181472843889

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-105312

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
Istio, Jaeger, and Kiali will have a badge indicating they are available in airgapped environments.
```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
