### PR TITLE
fix: Update all Essential License name under the kommander applicatio…

### DIFF
--- a/services/ai-navigator-app/metadata.yaml
+++ b/services/ai-navigator-app/metadata.yaml
@@ -9,7 +9,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 overview: |-
   # Overview

--- a/services/ai-navigator-cluster-info-agent/metadata.yaml
+++ b/services/ai-navigator-cluster-info-agent/metadata.yaml
@@ -9,7 +9,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 overview: |-
   # Overview

--- a/services/cert-manager/metadata.yaml
+++ b/services/cert-manager/metadata.yaml
@@ -9,7 +9,7 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/chartmuseum/metadata.yaml
+++ b/services/chartmuseum/metadata.yaml
@@ -5,5 +5,5 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise

--- a/services/cloudnative-pg/metadata.yaml
+++ b/services/cloudnative-pg/metadata.yaml
@@ -8,7 +8,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/dex-k8s-authenticator/metadata.yaml
+++ b/services/dex-k8s-authenticator/metadata.yaml
@@ -9,5 +9,5 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise

--- a/services/dex/metadata.yaml
+++ b/services/dex/metadata.yaml
@@ -5,5 +5,5 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise

--- a/services/external-dns/metadata.yaml
+++ b/services/external-dns/metadata.yaml
@@ -11,7 +11,7 @@ certifications:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 overview: |-
   # External DNS

--- a/services/fluent-bit/metadata.yaml
+++ b/services/fluent-bit/metadata.yaml
@@ -11,7 +11,7 @@ certifications:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 overview: |-
   # Overview

--- a/services/gatekeeper/metadata.yaml
+++ b/services/gatekeeper/metadata.yaml
@@ -12,7 +12,7 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 overview: |-
   # Overview

--- a/services/git-operator/metadata.yaml
+++ b/services/git-operator/metadata.yaml
@@ -5,5 +5,5 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise

--- a/services/grafana-logging/metadata.yaml
+++ b/services/grafana-logging/metadata.yaml
@@ -10,7 +10,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/grafana-loki/metadata.yaml
+++ b/services/grafana-loki/metadata.yaml
@@ -10,7 +10,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/harbor/metadata.yaml
+++ b/services/harbor/metadata.yaml
@@ -10,7 +10,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/istio/metadata.yaml
+++ b/services/istio/metadata.yaml
@@ -12,7 +12,7 @@ certifications:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 overview: |-
   # Overview

--- a/services/jaeger/metadata.yaml
+++ b/services/jaeger/metadata.yaml
@@ -10,7 +10,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/kiali/metadata.yaml
+++ b/services/kiali/metadata.yaml
@@ -10,7 +10,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/knative/metadata.yaml
+++ b/services/knative/metadata.yaml
@@ -10,7 +10,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 overview: |-
   Knative components build on top of Kubernetes, abstracting away the complex details and enabling developers to focus on what matters. Built by codifying the best practices shared by successful real-world implementations, Knative solves the "boring but difficult" parts of deploying and managing cloud native services so you don't have to.

--- a/services/kommander-appmanagement/metadata.yaml
+++ b/services/kommander-appmanagement/metadata.yaml
@@ -5,5 +5,5 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise

--- a/services/kommander-flux/metadata.yaml
+++ b/services/kommander-flux/metadata.yaml
@@ -5,5 +5,5 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise

--- a/services/kommander-ui/metadata.yaml
+++ b/services/kommander-ui/metadata.yaml
@@ -7,5 +7,5 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise

--- a/services/kommander/metadata.yaml
+++ b/services/kommander/metadata.yaml
@@ -7,5 +7,5 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise

--- a/services/kube-oidc-proxy/metadata.yaml
+++ b/services/kube-oidc-proxy/metadata.yaml
@@ -12,7 +12,7 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/kube-prometheus-stack/metadata.yaml
+++ b/services/kube-prometheus-stack/metadata.yaml
@@ -8,7 +8,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/kubefed/metadata.yaml
+++ b/services/kubefed/metadata.yaml
@@ -5,5 +5,5 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise

--- a/services/kubernetes-dashboard/metadata.yaml
+++ b/services/kubernetes-dashboard/metadata.yaml
@@ -10,7 +10,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/kubetunnel/metadata.yaml
+++ b/services/kubetunnel/metadata.yaml
@@ -4,5 +4,5 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise

--- a/services/logging-operator/metadata.yaml
+++ b/services/logging-operator/metadata.yaml
@@ -11,7 +11,7 @@ certifications:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 overview: |-
   # Overview

--- a/services/nkp-pulse-management/metadata.yaml
+++ b/services/nkp-pulse-management/metadata.yaml
@@ -5,5 +5,5 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise

--- a/services/nkp-pulse-workspace/metadata.yaml
+++ b/services/nkp-pulse-workspace/metadata.yaml
@@ -5,5 +5,5 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise

--- a/services/nvidia-gpu-operator/metadata.yaml
+++ b/services/nvidia-gpu-operator/metadata.yaml
@@ -8,7 +8,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/prometheus-adapter/metadata.yaml
+++ b/services/prometheus-adapter/metadata.yaml
@@ -10,7 +10,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/reloader/metadata.yaml
+++ b/services/reloader/metadata.yaml
@@ -9,7 +9,7 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/rook-ceph-cluster/metadata.yaml
+++ b/services/rook-ceph-cluster/metadata.yaml
@@ -11,7 +11,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/rook-ceph/metadata.yaml
+++ b/services/rook-ceph/metadata.yaml
@@ -9,7 +9,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/traefik-forward-auth-mgmt/metadata.yaml
+++ b/services/traefik-forward-auth-mgmt/metadata.yaml
@@ -9,5 +9,5 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise

--- a/services/traefik-forward-auth/metadata.yaml
+++ b/services/traefik-forward-auth/metadata.yaml
@@ -11,7 +11,7 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/traefik/metadata.yaml
+++ b/services/traefik/metadata.yaml
@@ -12,7 +12,7 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified

--- a/services/velero/metadata.yaml
+++ b/services/velero/metadata.yaml
@@ -10,7 +10,7 @@ scope:
 licensing:
   - Pro
   - Ultimate
-  - Essentials
+  - Essential
   - Enterprise
 certifications:
   - qualified


### PR DESCRIPTION
Need to update the all kommander applications Essential license field from Essentials to Essential.

Example: https://github.com/mesosphere/kommander-applications/blob/main/services/grafana-logging/metadata.yaml#L13

JIRA: https://jira.nutanix.com/browse/NCN-105311