### PR TITLE
fix: add the missing append

### DIFF
--- a/hack/list-images.sh
+++ b/hack/list-images.sh
@@ -130,22 +130,21 @@ done
 
 # These services use raw manifests rather than Helm charts so list the images directly from the manifests.
 # If more raw manifest services are added, then they should be added to the list of paths below.
-gojq --yaml-input --raw-output 'select(.kind | test("^(?:Deployment|Job|CronJob|StatefulSet|DaemonSet)$")) |
-                                (.spec.template.spec // .spec.jobTemplate.spec.template.spec) |
-                                (select(.containers != null) | .containers[].image), (select(.initContainers != null) | .initContainers[].image)' \
-                                ./services/kommander-flux/*/templates/* \
-                                ./services/kube-prometheus-stack/*/etcd-metrics-proxy/* \
-                                >>"${IMAGES_FILE}"
-
-# process git operator separately
-gojq --yaml-input --raw-output 'select(.kind | test("^(?:Deployment|Job|StatefulSet|DaemonSet)$")) |
-                                .spec.template.spec |
-                                (select(.containers != null) | .containers[].image), (select(.initContainers != null) | .initContainers[].image)' \
-				./services/git-operator/*/git-operator-manifests/* \
-                                >>"${IMAGES_FILE}"
-# we patch the cronjob image in this kustomization
-gojq --yaml-input --raw-output 'select(.kind | test("^(?:Kustomization)$")) | .images | map("\(.name):\(.newTag)") | .[]' \
-        ./services/git-operator/*/kustomization.yaml >>"${IMAGES_FILE}"
+{
+  gojq --yaml-input --raw-output 'select(.kind | test("^(?:Deployment|Job|CronJob|StatefulSet|DaemonSet)$")) |
+                                  (.spec.template.spec // .spec.jobTemplate.spec.template.spec) |
+                                  (select(.containers != null) | .containers[].image), (select(.initContainers != null) | .initContainers[].image)' \
+                                  ./services/kommander-flux/*/templates/* \
+                                  ./services/kube-prometheus-stack/*/etcd-metrics-proxy/* \
+  # process git operator separately
+  gojq --yaml-input --raw-output 'select(.kind | test("^(?:Deployment|Job|StatefulSet|DaemonSet)$")) |
+                                  .spec.template.spec |
+                                  (select(.containers != null) | .containers[].image), (select(.initContainers != null) | .initContainers[].image)' \
+  				./services/git-operator/*/git-operator-manifests/* \
+  # we patch the cronjob image in this kustomization
+  gojq --yaml-input --raw-output 'select(.kind | test("^(?:Kustomization)$")) | .images | map("\(.name):\(.newTag)") | .[]' \
+          ./services/git-operator/*/kustomization.yaml
+} >>"${IMAGES_FILE}"
 
 # Ensure that all images are fully qualified to ensure uniqueness of images in the image bundle.
 sed --expression='s|^docker.io/||' \

--- a/hack/list-images.sh
+++ b/hack/list-images.sh
@@ -145,7 +145,7 @@ gojq --yaml-input --raw-output 'select(.kind | test("^(?:Deployment|Job|Stateful
                                 >>"${IMAGES_FILE}"
 # we patch the cronjob image in this kustomization
 gojq --yaml-input --raw-output 'select(.kind | test("^(?:Kustomization)$")) | .images | map("\(.name):\(.newTag)") | .[]' \
-        ./services/git-operator/*/kustomization.yaml
+        ./services/git-operator/*/kustomization.yaml >>"${IMAGES_FILE}"
 
 # Ensure that all images are fully qualified to ensure uniqueness of images in the image bundle.
 sed --expression='s|^docker.io/||' \


### PR DESCRIPTION
**What problem does this PR solve?**:
the gojq line that parse git operator patch image was missing the append

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
