### PR TITLE
chore: bump cosi-bucket-kit chart

### DIFF
--- a/services/kubecost/2.5.2/cosi-storage/cosi-bucket.yaml
+++ b/services/kubecost/2.5.2/cosi-storage/cosi-bucket.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: 0.0.1-alpha.0
+      version: 0.0.1-alpha.1
   interval: 15s
   install:
     crds: CreateReplace

--- a/services/kubecost/2.5.2/defaults/cm.yaml
+++ b/services/kubecost/2.5.2/defaults/cm.yaml
@@ -259,35 +259,37 @@ data:
   # Overrides for kubecost to create cosi resources.
   primary-cosi-values.yaml: |
     ---
-    # COSI related resources
-    bucketClasses: # Cluster scoped resource
-      - name: kubecost-cosi-storage
-        driverName: rook-ceph.ceph.objectstorage.k8s.io
-        deletionPolicy: Delete
-        parameters:
-          objectStoreUserSecretName: rook-ceph-object-user-dkp-object-store-cosi-admin
-          objectStoreUserSecretNamespace: ${releaseNamespace}
-    bucketAccessClasses: # Cluster scoped resource
-      - name: kubecost-cosi-storage
-        driverName: rook-ceph.ceph.objectstorage.k8s.io
-        authenticationType: KEY
-        parameters:
-          # This secret (backed by a ceph user) is created below in the driver config.
-          objectStoreUserSecretName: rook-ceph-object-user-dkp-object-store-cosi-admin
-          objectStoreUserSecretNamespace: ${releaseNamespace}
-    bucketClaims: # Namespace scoped resource
-      - name: kubecost-cosi-storage
-        namespace: ${releaseNamespace}
-        bucketClassName: kubecost-cosi-storage
-        protocols:
-          - s3
-    bucketAccesses: # Namespace scoped resource
-      - name: kubecost-cosi-storage
-        namespace: ${releaseNamespace}
-        bucketAccessClassName: kubecost-cosi-storage
-        bucketClaimName: kubecost-cosi-storage
-        protocol: s3
-        credentialsSecretName: federated-store
+    cosiBucketKit:
+      enabled: true
+      # COSI related resources
+      bucketClasses: # Cluster scoped resource
+        - name: kubecost-cosi-storage
+          driverName: rook-ceph.ceph.objectstorage.k8s.io
+          deletionPolicy: Delete
+          parameters:
+            objectStoreUserSecretName: rook-ceph-object-user-dkp-object-store-cosi-admin
+            objectStoreUserSecretNamespace: ${releaseNamespace}
+      bucketAccessClasses: # Cluster scoped resource
+        - name: kubecost-cosi-storage
+          driverName: rook-ceph.ceph.objectstorage.k8s.io
+          authenticationType: KEY
+          parameters:
+            # This secret (backed by a ceph user) is created below in the driver config.
+            objectStoreUserSecretName: rook-ceph-object-user-dkp-object-store-cosi-admin
+            objectStoreUserSecretNamespace: ${releaseNamespace}
+      bucketClaims: # Namespace scoped resource
+        - name: kubecost-cosi-storage
+          namespace: ${releaseNamespace}
+          bucketClassName: kubecost-cosi-storage
+          protocols:
+            - s3
+      bucketAccesses: # Namespace scoped resource
+        - name: kubecost-cosi-storage
+          namespace: ${releaseNamespace}
+          bucketAccessClassName: kubecost-cosi-storage
+          bucketClaimName: kubecost-cosi-storage
+          protocol: s3
+          credentialsSecretName: federated-store
   # Overrides for kubecost to run in primary mode for multi cluster setup with object storage.
   primary-object-storage-ready-values.yaml: |
     ---


### PR DESCRIPTION
**What problem does this PR solve?**:

Bumps cosi-bucket-kit chart consumed by kubecost to latest version

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
