### PR TITLE
feat: use ghcr.io/mesosphere images for cosi

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -597,7 +597,12 @@ resources:
       - url: https://github.com/ceph/ceph-cosi
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v20250117-a29e5f6
+  - container_image: ghcr.io/mesosphere/dkp-container-images/objectstorage-controller:v20250110-a29e5f6
+    sources:
+      - url: https://github.com/kubernetes-sigs/container-object-storage-interface
+        ref: main
+        license_path: LICENSE
+  - container_image: ghcr.io/mesosphere/dkp-container-images/objectstorage-sidecar:v20250123-a0e4046
     sources:
       - url: https://github.com/kubernetes-sigs/container-object-storage-interface
         ref: main

--- a/services/cosi-driver-nutanix/0.0.4/defaults/cm.yaml
+++ b/services/cosi-driver-nutanix/0.0.4/defaults/cm.yaml
@@ -8,12 +8,17 @@ data:
   values.yaml: |-
     cosiController:
       enabled: false # This should be deployed during k8s cluster creation by konvoy.
+      image:
+        registry: ghcr.io
+        repository: mesosphere/dkp-container-images/objectstorage-controller
+        tag: v20250110-a29e5f6
+        pullPolicy: IfNotPresent
     objectstorageProvisionerSidecar:
       image:
-        registry: gcr.io
+        registry: ghcr.io
         # keep this in sync with the sidecar that is deployed in CephCOSIDriver to avoid duplicate images in airgapped bundle.
-        repository: k8s-staging-sig-storage/objectstorage-sidecar
-        tag: v20250117-a29e5f6
+        repository: mesosphere/dkp-container-images/objectstorage-sidecar
+        tag: v20250123-a0e4046
         pullPolicy: IfNotPresent
     image:
       registry: ghcr.io

--- a/services/cosi-driver-nutanix/0.0.4/extra-images.txt
+++ b/services/cosi-driver-nutanix/0.0.4/extra-images.txt
@@ -1,2 +1,1 @@
-# We disable controller by default, but a user can enable it if they want.
 ghcr.io/mesosphere/dkp-container-images/objectstorage-controller:v20250110-a29e5f6

--- a/services/cosi-driver-nutanix/0.0.4/extra-images.txt
+++ b/services/cosi-driver-nutanix/0.0.4/extra-images.txt
@@ -1,0 +1,2 @@
+# We disable controller by default, but a user can enable it if they want.
+ghcr.io/mesosphere/dkp-container-images/objectstorage-controller:v20250110-a29e5f6

--- a/services/rook-ceph-cluster/1.16.2/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.16.2/defaults/cm.yaml
@@ -305,6 +305,7 @@ data:
             namespace: ${releaseNamespace}
             spec:
               deploymentStrategy: Auto
+              objectProvisionerImage: ghcr.io/mesosphere/dkp-container-images/objectstorage-sidecar:v20250123-a0e4046
           adminuser:
             enabled: true
             name: cosi-admin

--- a/services/rook-ceph-cluster/1.16.2/objectbucketclaims/extra-images.txt
+++ b/services/rook-ceph-cluster/1.16.2/objectbucketclaims/extra-images.txt
@@ -1,2 +1,2 @@
 quay.io/ceph/cosi:v0.1.2
-gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v20250117-a29e5f6
+ghcr.io/mesosphere/dkp-container-images/objectstorage-sidecar:v20250123-a0e4046


### PR DESCRIPTION
**What problem does this PR solve?**:

See the warning at https://console.cloud.google.com/gcr/images/k8s-staging-sig-storage/GLOBAL/objectstorage-controller:v20221027-v0.1.1-8-g300019f/details 

> Container Registry is deprecated and scheduled for shutdown. Artifact Registry now [hosts images for the gcr.io domain by default ](https://cloud.google.com/artifact-registry/docs/transition/gcr-on-ar) in projects without previous Container Registry usage. After March 18, 2025, Container Registry will be shut down. To learn more about your options to upgrade to Artifact Registry, see Prepare for Container Registry shutdown.

Depends on https://github.com/mesosphere/dkp-container-images/pull/14 

The nutanix cosi app now bundles the cosi controller image. (this is used by kommander airgapped kind suite)

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
