### PR TITLE
revert: feat: use ghcr.io/mesosphere images for cosi (#3058)

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -597,12 +597,7 @@ resources:
       - url: https://github.com/ceph/ceph-cosi
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: ghcr.io/mesosphere/dkp-container-images/objectstorage-controller:v20250110-a29e5f6
-    sources:
-      - url: https://github.com/kubernetes-sigs/container-object-storage-interface
-        ref: main
-        license_path: LICENSE
-  - container_image: ghcr.io/mesosphere/dkp-container-images/objectstorage-sidecar:v20250123-a0e4046
+  - container_image: gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v20250117-a29e5f6
     sources:
       - url: https://github.com/kubernetes-sigs/container-object-storage-interface
         ref: main

--- a/services/cosi-driver-nutanix/0.0.4/defaults/cm.yaml
+++ b/services/cosi-driver-nutanix/0.0.4/defaults/cm.yaml
@@ -8,17 +8,12 @@ data:
   values.yaml: |-
     cosiController:
       enabled: false # This should be deployed during k8s cluster creation by konvoy.
-      image:
-        registry: ghcr.io
-        repository: mesosphere/dkp-container-images/objectstorage-controller
-        tag: v20250110-a29e5f6
-        pullPolicy: IfNotPresent
     objectstorageProvisionerSidecar:
       image:
-        registry: ghcr.io
+        registry: gcr.io
         # keep this in sync with the sidecar that is deployed in CephCOSIDriver to avoid duplicate images in airgapped bundle.
-        repository: mesosphere/dkp-container-images/objectstorage-sidecar
-        tag: v20250123-a0e4046
+        repository: k8s-staging-sig-storage/objectstorage-sidecar
+        tag: v20250117-a29e5f6
         pullPolicy: IfNotPresent
     image:
       registry: ghcr.io

--- a/services/cosi-driver-nutanix/0.0.4/extra-images.txt
+++ b/services/cosi-driver-nutanix/0.0.4/extra-images.txt
@@ -1,1 +1,0 @@
-ghcr.io/mesosphere/dkp-container-images/objectstorage-controller:v20250110-a29e5f6

--- a/services/rook-ceph-cluster/1.16.2/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.16.2/defaults/cm.yaml
@@ -305,7 +305,6 @@ data:
             namespace: ${releaseNamespace}
             spec:
               deploymentStrategy: Auto
-              objectProvisionerImage: ghcr.io/mesosphere/dkp-container-images/objectstorage-sidecar:v20250123-a0e4046
           adminuser:
             enabled: true
             name: cosi-admin

--- a/services/rook-ceph-cluster/1.16.2/objectbucketclaims/extra-images.txt
+++ b/services/rook-ceph-cluster/1.16.2/objectbucketclaims/extra-images.txt
@@ -1,2 +1,2 @@
 quay.io/ceph/cosi:v0.1.2
-ghcr.io/mesosphere/dkp-container-images/objectstorage-sidecar:v20250123-a0e4046
+gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v20250117-a29e5f6


### PR DESCRIPTION
This reverts commit 5035c4e50d6b7c64c25a5182ecdaf691b3d420da.

**What problem does this PR solve?**:

The new images broke some of the kubecost tests. I will get to debugging the faiures later, but temporarily reverting to upstream images meanwhile.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
