### PR TITLE
feat: bump kube-oidc-proxy 1.0.9

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -425,7 +425,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/cert-manager/cert-manager
-  - container_image: ghcr.io/mesosphere/dkp-container-images/kube-oidc-proxy:1.0.7
+  - container_image: ghcr.io/mesosphere/dkp-container-images/kube-oidc-proxy:1.0.9
     sources:
       - license_path: LICENSE
         ref: v${image_tag}

--- a/services/kube-oidc-proxy/0.3.5/defaults/cm.yaml
+++ b/services/kube-oidc-proxy/0.3.5/defaults/cm.yaml
@@ -10,7 +10,7 @@ data:
     # See: https://github.com/mesosphere/dkp-container-images/tree/main/kube-oidc-proxy
     image:
       repository: ghcr.io/mesosphere/dkp-container-images/kube-oidc-proxy
-      tag: 1.0.7
+      tag: 1.0.9
     priorityClassName: "dkp-critical-priority"
     deploymentAnnotations:
       # Config changes and certificate rotation by cert-manager need a reload


### PR DESCRIPTION

Upgrades the following apps to use version 1.0.7 to 1.0.9
* kube-oidc-procy from version  1.0.7 to 1.0.9
<!--
kube-oidc-proxy 1.0.9
-->
