### PR TITLE
feat(traefik): Increase default registry entrypoint read timeout

### DIFF
--- a/services/traefik/34.1.0/defaults/traefik.yaml
+++ b/services/traefik/34.1.0/defaults/traefik.yaml
@@ -207,4 +207,3 @@ data:
           respondingTimeouts:
             # Increased read timeout to handle pushing of large images to OCI registry.
             readTimeout: 10m
-

--- a/services/traefik/34.1.0/defaults/traefik.yaml
+++ b/services/traefik/34.1.0/defaults/traefik.yaml
@@ -203,3 +203,8 @@ data:
           default: true
         exposedPort: 5000
         protocol: TCP
+        transport:
+          respondingTimeouts:
+            # Increased read timeout to handle pushing of large images to OCI registry.
+            readTimeout: 10m
+


### PR DESCRIPTION
This allows for pushing of large blobs to image registry which would
otherwise timeout.
