### PR TITLE
feat: bump new version dcgm-exporter:4.0.0-4.0.1-ubuntu22.04

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -380,7 +380,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag%-ubi8}
         url: https://github.com/NVIDIA/nvidia-container-toolkit
-  - container_image: nvcr.io/nvidia/k8s/dcgm-exporter:4.0.0-4.0.1-ubuntu22.04 
+  - container_image: nvcr.io/nvidia/k8s/dcgm-exporter:4.0.0-4.0.1-ubuntu22.04
     sources:
       - license_path: LICENSE
         ref: ${image_tag%-ubuntu22.04}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -380,7 +380,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag%-ubi8}
         url: https://github.com/NVIDIA/nvidia-container-toolkit
-  - container_image: nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04
+  - container_image: nvcr.io/nvidia/k8s/dcgm-exporter:4.0.0-4.0.1-ubuntu22.04 
     sources:
       - license_path: LICENSE
         ref: ${image_tag%-ubuntu22.04}

--- a/services/nvidia-gpu-operator/24.9.2/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.9.2/defaults/cm.yaml
@@ -32,7 +32,7 @@ data:
       version: 3.3.9-1-ubuntu22.04
     dcgmExporter:
       enabled: true
-      version: 3.3.9-3.6.1-ubuntu22.04
+      version: 4.0.0-4.0.1-ubuntu22.04
     validator:
       repository: nvcr.io/nvidia/cloud-native
       version: v24.9.2


### PR DESCRIPTION
Upgrades the following apps to use version 3.6.1 to 4.0.1

* dcgm-exporter from version 3.6.1 to 4.0.1