### PR TITLE
feat: update the alert-manager to v0.28.0

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -458,7 +458,7 @@ resources:
         notice_path: NOTICE
         ref: ${image_tag}
         url: https://github.com/prometheus-operator/prometheus-operator
-  - container_image: quay.io/prometheus/alertmanager:v0.27.0
+  - container_image: quay.io/prometheus/alertmanager:v0.28.0
     sources:
       - license_path: LICENSE
         notice_path: NOTICE

--- a/services/kube-prometheus-stack/67.6.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/67.6.0/defaults/cm.yaml
@@ -332,6 +332,10 @@ data:
         pathType: ImplementationSpecific
       alertmanagerSpec:
         priorityClassName: "dkp-critical-priority"
+        image:
+          registry: quay.io
+          repository: prometheus/alertmanager
+          tag: v0.28.0
         logLevel: warn
         resources:
           limits:

--- a/services/kubecost/2.5.2/defaults/cm.yaml
+++ b/services/kubecost/2.5.2/defaults/cm.yaml
@@ -118,6 +118,9 @@ data:
           enabled: true
       alertmanager:
         fullnameOverride: "kubecost-prometheus-alertmanager"
+        image:
+          repository: quay.io/prometheus/alertmanager
+          tag: v0.28.0
         priorityClassName: dkp-high-priority
         enabled: true
         resources:


### PR DESCRIPTION
Upgrades the following apps to use version alert-manager to v0.28.0:
* alert-manager to v0.28.0
<!--
kapps:sandy/alert-manager-cve-fix
-->


