### PR TITLE
feat: bump new version postgres-exporter 0.16.0-debian-12-r3

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -540,7 +540,7 @@ resources:
         ref: controller-v1.11.2
         license_path: LICENSE
         directory: /images/kube-webhook-certgen/rootfs
-  - container_image: docker.io/bitnami/postgres-exporter:0.15.0-debian-12-r44
+  - container_image: docker.io/bitnami/postgres-exporter:0.16.0-debian-12-r3
     sources:
       - url: https://github.com/prometheus-community/postgres_exporter
         ref: v0.12.0

--- a/services/nkp-insights/1.3.4/defaults/cm.yaml
+++ b/services/nkp-insights/1.3.4/defaults/cm.yaml
@@ -418,7 +418,7 @@ data:
         image:
           registry: docker.io
           repository: bitnami/postgres-exporter
-          tag: 0.15.0-debian-12-r44
+          tag: 0.16.0-debian-12-r3
       primary:
         containerSecurityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Upgrades the following apps to use version 0.15.0-debian-12-r44 to 0.16.0-debian-12-r3

* postgres-exporter from 0.15.0-debian-12-r44 to 0.16.0-debian-12-r3
