### PR TITLE
feat: bump new version docker.io/grafana/loki:3.3.2

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -24,7 +24,7 @@ resources:
         notice_path: NOTICE.md
         ref: v${image_tag}
         url: https://github.com/grafana/grafana
-  - container_image: docker.io/grafana/loki:2.9.10
+  - container_image: docker.io/grafana/loki:3.3.2
     sources:
       - license_path: LICENSE
         ref: v${image_tag}

--- a/services/grafana-loki/0.79.5/defaults/cm.yaml
+++ b/services/grafana-loki/0.79.5/defaults/cm.yaml
@@ -6,7 +6,9 @@ metadata:
 data:
   values.yaml: |
     loki:
-      image: docker.io/grafana/loki:3.3.2
+      image:
+      repository: docker.io/grafana/loki
+      tag: 3.3.2
       ingesterFullname: loki-ingester
       annotations:
         secret.reloader.stakater.com/reload: dkp-loki

--- a/services/grafana-loki/0.79.5/defaults/cm.yaml
+++ b/services/grafana-loki/0.79.5/defaults/cm.yaml
@@ -7,8 +7,8 @@ data:
   values.yaml: |
     loki:
       image:
-      repository: docker.io/grafana/loki
-      tag: 3.3.2
+        repository: docker.io/grafana/loki
+        tag: 3.3.2
       ingesterFullname: loki-ingester
       annotations:
         secret.reloader.stakater.com/reload: dkp-loki

--- a/services/grafana-loki/0.79.5/defaults/cm.yaml
+++ b/services/grafana-loki/0.79.5/defaults/cm.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   values.yaml: |
     loki:
+      image: docker.io/grafana/loki:3.3.2
       ingesterFullname: loki-ingester
       annotations:
         secret.reloader.stakater.com/reload: dkp-loki

--- a/services/project-grafana-loki/0.79.5/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.79.5/defaults/cm.yaml
@@ -30,6 +30,9 @@ data:
     kubectlImage: bitnami/kubectl:1.31.4
 
     loki:
+      image:
+        repository: docker.io/grafana/loki
+        tag: 3.3.2
       ingesterFullname: loki-ingester
       annotations:
         secret.reloader.stakater.com/reload: proj-loki-${releaseNamespace}


### PR DESCRIPTION
Update  lokiversion 2.9.10: 3.3.2

* loki version 2.9.10:3.3.2