### PR TITLE
feat: install ceph cosi on attached clusters

### DIFF
--- a/services/rook-ceph-cluster/1.16.2/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.16.2/defaults/cm.yaml
@@ -278,7 +278,7 @@ data:
     #################################################################
     ## END of dkp specific config overrides                        ##
     #################################################################
-  kommander-namespace-cosi-values.yaml: |
+  cosi-bucket-kit-values.yaml: |
     # COSI related resources corresponding to cosi-bucket-kit chart from mesosphere/charts stable repo.
     cosiBucketKit:
       enabled: true

--- a/services/rook-ceph-cluster/1.16.2/objectbucketclaims/cosi-bucket.yaml
+++ b/services/rook-ceph-cluster/1.16.2/objectbucketclaims/cosi-bucket.yaml
@@ -27,7 +27,7 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: rook-ceph-cluster-1.16.2-d2iq-defaults
-      valuesKey: ${releaseNamespace}-namespace-cosi-values.yaml # This will ensure attached clusters do install cosi drivers by default.
+      valuesKey: cosi-bucket-kit-values.yaml
       optional: true
     - kind: ConfigMap
       name: rook-ceph-cluster-overrides


### PR DESCRIPTION
**What problem does this PR solve?**:

Insights requires ceph cosi driver on workload clusters. This change updates ceph config to always default to installing ceph cosi driver.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
