### PR TITLE
fix: update cosi & harbor metadata fields

### DIFF
--- a/services/cosi-driver-nutanix/metadata.yaml
+++ b/services/cosi-driver-nutanix/metadata.yaml
@@ -1,7 +1,7 @@
 displayName: COSI Driver For Nutanix
 description: Seamlessly manage provisioning of object storage resources on Nutanix platforms within Kubernetes environments adhering to COSI standard.
-category: []
-dependencies: []
+category:
+  - general
 type: platform
 scope:
   - workspace

--- a/services/harbor/metadata.yaml
+++ b/services/harbor/metadata.yaml
@@ -1,7 +1,7 @@
 displayName: Harbor
 description: A cloud native registry for storing, signing, and scanning container images.
-category: []
-dependencies: []
+category:
+  - general
 requiredDependencies:
   - cloudnative-pg
 type: platform


### PR DESCRIPTION
**What problem does this PR solve?**:
The category and the dependency field of metadata yaml of the cosi driver nutanix app and harbor app was set to empty array. However, we do not need dependency fields for either of the app and category needs to be general. Hence removing dependency field and adding category.
Slack Discussion Thread :- https://nutanix.slack.com/archives/C06A78Y063B/p1738775586636359?thread_ts=1738773226.964009&cid=C06A78Y063B

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-105574

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
