### PR TITLE
fix: missing certifications for knative and ai navigator apps

### DIFF
--- a/services/ai-navigator-app/metadata.yaml
+++ b/services/ai-navigator-app/metadata.yaml
@@ -6,6 +6,8 @@ type: platform
 allowMultipleInstances: false
 scope:
   - workspace
+certifications:
+  - supported
 licensing:
   - Pro
   - Ultimate

--- a/services/ai-navigator-cluster-info-agent/metadata.yaml
+++ b/services/ai-navigator-cluster-info-agent/metadata.yaml
@@ -6,6 +6,8 @@ type: platform
 allowMultipleInstances: false
 scope:
   - workspace
+certifications:
+  - supported
 licensing:
   - Pro
   - Ultimate

--- a/services/knative/metadata.yaml
+++ b/services/knative/metadata.yaml
@@ -7,6 +7,9 @@ category:
 type: catalog
 scope:
   - workspace
+certifications:
+  - qualified
+  - airgapped
 licensing:
   - Pro
   - Ultimate


### PR DESCRIPTION
**What problem does this PR solve?**:
We are missing certifications for Knative and AI Navigator apps.
Confirmed with product what these should be. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-105577

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
Knative application will display a Nutanix Qualified and Air-Gapped badge. AI Navigator applications will display a Nutanix Supported badge.
```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
