### PR TITLE
chore: update cloudnative-pg metadata

### DIFF
--- a/services/cloudnative-pg/metadata.yaml
+++ b/services/cloudnative-pg/metadata.yaml
@@ -1,7 +1,7 @@
 displayName: CloudNativePG
 description: Seamlessly manage PostgreSQL databases within Kubernetes environments.
-category: []
-dependencies: []
+category:
+  - general
 type: platform
 scope:
   - workspace


### PR DESCRIPTION
**What problem does this PR solve?**:

The metadata yaml file for cloudnative-pg app has dependencies and category fields set to an empty array. The dependency field should be removed and category should be set as "general" if it is not categorized. 
Setting dependencies field as empty array [], causes UI to render empty name (see screenshot in the [ticket](https://jira.nutanix.com/browse/NCN-105607)), a bug in kommander-ui which is being tracked [here](https://jira.nutanix.com/browse/NCN-105575) . 
For now, as we do for all other k-apps metadata, if the cloudnative-pg app has no dependencies it can be safely removed from the metadata yaml file. 


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-105607

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
