### PR TITLE
fix: allow traefik-crds helmrelease overrides

### DIFF
--- a/services/traefik/34.1.0/crds/crds.yaml
+++ b/services/traefik/34.1.0/crds/crds.yaml
@@ -16,3 +16,6 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: traefik-crd-1.2.0-d2iq-defaults
+    - kind: ConfigMap
+      name: traefik-crd-overrides
+      optional: true


### PR DESCRIPTION
Add an optionnal overrides for the traefik-crds helm chart to be able to deploy additional crd if needed