### PR TITLE
docs: highlights kubecost v2 breaking change

### DIFF
--- a/services/kubecost/metadata.yaml
+++ b/services/kubecost/metadata.yaml
@@ -17,6 +17,11 @@ overview: |-
 
   Today, Kubecost empowers more than 1,000 teams across companies of all sizes to monitor and reduce costs, while balancing cost, performance, and reliability. Kubecost is tightly integrated with the open source cloud native ecosystem and built for engineers and developers first, making it easy to drive adoption within your organization.
 
+  ## Kubecost V2 Breaking Changes  
+  Kubecost V2 now requires S3-compatible object storage to persist long-term data. If you do not enable rook-ceph-cluster AppDeployment in NKP, you would need to provide the endpoint to your own S3-compatible storage in order to use Kubecost. **Otherwise, Kubecost will not be able to start.**
+  
+  If you want to use external S3-compatible storage providers, see https://docs.kubecost.com/install-and-configure/install/multi-cluster/long-term-storage-configuration.
+
   ## Key Features
   ### Cost Allocation
   Breakdown costs for accurate showbacks, chargebacks, and ongoing monitoring.

--- a/services/kubecost/metadata.yaml
+++ b/services/kubecost/metadata.yaml
@@ -17,10 +17,14 @@ overview: |-
 
   Today, Kubecost empowers more than 1,000 teams across companies of all sizes to monitor and reduce costs, while balancing cost, performance, and reliability. Kubecost is tightly integrated with the open source cloud native ecosystem and built for engineers and developers first, making it easy to drive adoption within your organization.
 
-  ## Kubecost V2 Breaking Changes  
-  Kubecost V2 now requires S3-compatible object storage to persist long-term data. If you do not enable rook-ceph-cluster AppDeployment in NKP, you would need to provide the endpoint to your own S3-compatible storage in order to use Kubecost. **Otherwise, Kubecost will not be able to start.**
-  
-  If you want to use external S3-compatible storage providers, see https://docs.kubecost.com/install-and-configure/install/multi-cluster/long-term-storage-configuration.
+  ## Notes
+  Kubecost requires S3-compatible object storage to persist long-term data.
+
+  Please ensure your S3-compatible object storage provider is deployed and has enough storage available.
+
+  To use the default S3-compatible object storage available in NKP (rook-ceph), ensure that the rook-ceph and rook-ceph-cluster applications are enabled in the workspace, and that the rook-ceph-cluster is configured with sufficient storage space.
+
+  For more information on configuring Kubecost to use other S3-compatible storage providers, see: https://docs.kubecost.com/install-and-configure/install/multi-cluster/long-term-storage-configuration.
 
   ## Key Features
   ### Cost Allocation


### PR DESCRIPTION
**What problem does this PR solve?**:
currently kubecost metadata overview doesn't include kubecost v2 breaking change

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-105479

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
