### PR TITLE
chore: bump to latest cosi-bucket-kit

### DIFF
--- a/services/cosi-driver-nutanix/0.0.4/cosi-resources-nutanix.yaml
+++ b/services/cosi-driver-nutanix/0.0.4/cosi-resources-nutanix.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: 0.0.1-alpha.1
+      version: 0.0.1-alpha.3
   interval: 15s
   dependsOn:
     # This dependency is not honored during Upgrade, only during Install.

--- a/services/kubecost/2.5.2/cosi-storage/cosi-bucket.yaml
+++ b/services/kubecost/2.5.2/cosi-storage/cosi-bucket.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: 0.0.1-alpha.2
+      version: 0.0.1-alpha.3
   interval: 15s
   install:
     crds: CreateReplace

--- a/services/rook-ceph-cluster/1.16.2/objectbucketclaims/cosi-bucket.yaml
+++ b/services/rook-ceph-cluster/1.16.2/objectbucketclaims/cosi-bucket.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: 0.0.1-alpha.1
+      version: 0.0.1-alpha.3
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:

Bumping the cosi-bucket-kit chart to the latest version and be consistent across all apps.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
