### PR TITLE
chore: add priorityclass for new pods

### DIFF
--- a/services/cloudnative-pg/0.23.0/defaults/cm.yaml
+++ b/services/cloudnative-pg/0.23.0/defaults/cm.yaml
@@ -9,3 +9,4 @@ data:
     config:
       data:
         INHERITED_LABELS: "prometheus.kommander.d2iq.io/select"
+    priorityClassName: dkp-critical-priority

--- a/services/kubecost/2.5.2/defaults/cm.yaml
+++ b/services/kubecost/2.5.2/defaults/cm.yaml
@@ -39,6 +39,9 @@ data:
 
     kubecostAggregator:
       deployMethod: disabled
+      priority:
+        enabled: true
+        name: dkp-high-priority
 
     priority:
       enabled: true


### PR DESCRIPTION
**What problem does this PR solve?**:

- harbor has critical priority so cloudnative-pg gets the same priority.
- kubecost has always been at high priority.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-105638
https://jira.nutanix.com/browse/NCN-105641

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
