### PR TITLE
feat(cosi): support annotations for BC and BA

### DIFF
--- a/services/cosi-driver-nutanix/0.2.0/cosi-resources-nutanix.yaml
+++ b/services/cosi-driver-nutanix/0.2.0/cosi-resources-nutanix.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: 0.0.1-alpha.3
+      version: 0.0.1-alpha.4
   interval: 15s
   dependsOn:
     # This dependency is not honored during Upgrade, only during Install.

--- a/services/harbor/1.16.2/cosi-storage/cosi-bucket.yaml
+++ b/services/harbor/1.16.2/cosi-storage/cosi-bucket.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: 0.0.1-alpha.3
+      version: 0.0.1-alpha.4
   interval: 15s
   install:
     crds: CreateReplace

--- a/services/kubecost/2.5.2/cosi-storage/cosi-bucket.yaml
+++ b/services/kubecost/2.5.2/cosi-storage/cosi-bucket.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: 0.0.1-alpha.3
+      version: 0.0.1-alpha.4
   interval: 15s
   install:
     crds: CreateReplace

--- a/services/kubecost/2.5.2/defaults/cm.yaml
+++ b/services/kubecost/2.5.2/defaults/cm.yaml
@@ -270,12 +270,16 @@ data:
       bucketClaims:
         - name: cosi-kubecost # Max length should be less than 26 chars.
           namespace: ${releaseNamespace}
+          annotations:
+            helm.sh/resource-policy: keep
           bucketClassName: cosi-ceph-nkp
           protocols:
             - s3
       bucketAccesses:
         - name: cosi-kubecost
           namespace: ${releaseNamespace}
+          annotations:
+            helm.sh/resource-policy: keep
           bucketAccessClassName: cosi-ceph-nkp
           bucketClaimName: cosi-kubecost
           protocol: s3

--- a/services/rook-ceph-cluster/1.16.2/objectbucketclaims/cosi-bucket.yaml
+++ b/services/rook-ceph-cluster/1.16.2/objectbucketclaims/cosi-bucket.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: mesosphere.github.io-charts-stable
         namespace: kommander-flux
-      version: 0.0.1-alpha.3
+      version: 0.0.1-alpha.4
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:
- Updates cosi bucket kit chart to support annotations on harbor and kubecost charts.
- Adds the `helm.sh/resource-policy: keep` for kubecost cosi CRs.
  - Tested the change by installing kubecost and then deleting it after which i made sure the `BucketClaim` lingered around. Upon installing again, kubecost was able to consume the old bucket.
- Haven't tested harbor but I imagine it will follow the same pattern. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-105676

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
