### PR TITLE
chore: Post release bumps

### DIFF
--- a/upgrade-matrix.yaml
+++ b/upgrade-matrix.yaml
@@ -56,3 +56,6 @@ upgrades:
     - from: v2.13.2-dev
       to: v2.14.0-dev
       k8sversion: "1.30"
+    - from: v2.14.0-dev
+      to: v2.15.0-dev
+      k8sversion: "1.31"


### PR DESCRIPTION
Post-release bumps are PRs created by [gh-dkp](https://github.com/mesosphere/gh-dkp/)
to adjust repositories after releases.
