### PR TITLE
feat(cosi): bump cosi sidecar to v0.2.1

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -582,7 +582,7 @@ resources:
       - url: https://github.com/ceph/ceph-cosi
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v20250117-a29e5f6
+  - container_image: registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.1
     sources:
       - url: https://github.com/kubernetes-sigs/container-object-storage-interface
         ref: main

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -587,6 +587,11 @@ resources:
       - url: https://github.com/kubernetes-sigs/container-object-storage-interface
         ref: main
         license_path: LICENSE
+  - container_image: ghcr.io/mesosphere/dkp-container-images/objectstorage-sidecar:v20240513-v0.1.0-35-gefb3255
+    sources:
+      - url: https://github.com/kubernetes-sigs/container-object-storage-interface
+        ref: main
+        license_path: LICENSE
   - container_image: ghcr.io/cloudnative-pg/cloudnative-pg:1.25.0
     sources:
       - url: https://github.com/cloudnative-pg/cloudnative-pg

--- a/services/cosi-driver-nutanix/0.2.0/defaults/cm.yaml
+++ b/services/cosi-driver-nutanix/0.2.0/defaults/cm.yaml
@@ -10,10 +10,10 @@ data:
       enabled: false # This should be deployed during k8s cluster creation by konvoy.
     objectstorageProvisionerSidecar:
       image:
-        registry: gcr.io
+        registry: registry.k8s.io
         # keep this in sync with the sidecar that is deployed in CephCOSIDriver to avoid duplicate images in airgapped bundle.
-        repository: k8s-staging-sig-storage/objectstorage-sidecar
-        tag: v20250117-a29e5f6
+        repository: sig-storage/objectstorage-sidecar
+        tag: v0.2.1
         pullPolicy: IfNotPresent
     image:
       registry: ghcr.io

--- a/services/rook-ceph-cluster/1.16.2/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.16.2/defaults/cm.yaml
@@ -305,7 +305,7 @@ data:
             namespace: ${releaseNamespace}
             spec:
               deploymentStrategy: Auto
-              objectProvisionerImage: registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.1
+              objectProvisionerImage: ghcr.io/mesosphere/dkp-container-images/objectstorage-sidecar:v20240513-v0.1.0-35-gefb3255
           adminuser:
             enabled: true
             name: cosi-admin

--- a/services/rook-ceph-cluster/1.16.2/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.16.2/defaults/cm.yaml
@@ -305,6 +305,7 @@ data:
             namespace: ${releaseNamespace}
             spec:
               deploymentStrategy: Auto
+              objectProvisionerImage: registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.1
           adminuser:
             enabled: true
             name: cosi-admin

--- a/services/rook-ceph-cluster/1.16.2/objectbucketclaims/extra-images.txt
+++ b/services/rook-ceph-cluster/1.16.2/objectbucketclaims/extra-images.txt
@@ -1,2 +1,2 @@
 quay.io/ceph/cosi:v0.1.2
-gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v20250117-a29e5f6
+registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.1

--- a/services/rook-ceph-cluster/1.16.2/objectbucketclaims/extra-images.txt
+++ b/services/rook-ceph-cluster/1.16.2/objectbucketclaims/extra-images.txt
@@ -1,2 +1,2 @@
 quay.io/ceph/cosi:v0.1.2
-registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.1
+ghcr.io/mesosphere/dkp-container-images/objectstorage-sidecar:v20240513-v0.1.0-35-gefb3255


### PR DESCRIPTION
**What problem does this PR solve?**:

Fresh release - https://github.com/kubernetes-sigs/container-object-storage-interface/releases/tag/v0.2.1

Bumps cosi sidecar image to latest version (moves off of the deprecated gcr.io container registry). I made sure the new image does not add any new vulns:
![Screenshot 2025-02-13 at 9 17 17 PM](https://github.com/user-attachments/assets/2a1f031f-9fca-4523-9f73-4afd21a7d1cf)


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

Fixes https://jira.nutanix.com/browse/NCN-105729
Partially addresses https://jira.nutanix.com/browse/NCN-105713

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
