### PR TITLE
fix: add reloader annotation to cosi driver

### DIFF
--- a/services/cosi-driver-nutanix/0.2.0/cosi-driver-nutanix.yaml
+++ b/services/cosi-driver-nutanix/0.2.0/cosi-driver-nutanix.yaml
@@ -30,11 +30,13 @@ spec:
   postRenderers:
     - kustomize:
         patches:
-          - patch: |-
-              apiVersion: apps/v1
+          - patch: |
+              - op: add
+                path: /metadata/annotations/secret.reloader.stakater.com~1reload
+                value: ${releaseName} # UI Creates a federatedsecret whose name is equal to AppDeployment name (which will be equal to releaseName).
+            target:
+              group: apps
+              version: v1
               kind: Deployment
-              metadata:
-                name: ${releaseName}
-                namespace: ${releaseNamespace}
-                annotations:
-                  secret.reloader.stakater.com/reload: ${releaseName}
+              name: ${releaseName}
+              namespace: ${releaseNamespace}

--- a/services/cosi-driver-nutanix/0.2.0/cosi-driver-nutanix.yaml
+++ b/services/cosi-driver-nutanix/0.2.0/cosi-driver-nutanix.yaml
@@ -27,3 +27,14 @@ spec:
     - kind: ConfigMap
       name: cosi-driver-nutanix-0.2.0-d2iq-defaults
   targetNamespace: ${releaseNamespace}
+  postRenderers:
+    - kustomize:
+        patches:
+          - patch: |-
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ${releaseName}
+                namespace: ${releaseNamespace}
+                annotations:
+                  secret.reloader.stakater.com/reload: ${releaseName}


### PR DESCRIPTION
**What problem does this PR solve?**:
currently cosi driver deployment doesnt auto restart after config secret change on UI

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-105746


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
