### PR TITLE
fix: disable ipv6 in harbor config 

### DIFF
--- a/services/harbor/1.16.2/defaults/harbor.yaml
+++ b/services/harbor/1.16.2/defaults/harbor.yaml
@@ -6,11 +6,6 @@ metadata:
 data:
   values.yaml: |
     ---
-    core:
-      replicas: 3
-    portal:
-      replicas: 3
-
     existingSecretAdminPassword: harbor-admin-password
 
     expose:
@@ -24,6 +19,10 @@ data:
         annotations:
           traefik.ingress.kubernetes.io/router.entrypoints: registry
           traefik.ingress.kubernetes.io/router.tls: "true"
+
+    ipFamily:
+      ipv6:
+        enabled: false # NKP doesn't support ipv6 yet - https://jira.nutanix.com/browse/NCN-105325
 
     redis:
       type: external
@@ -54,13 +53,16 @@ data:
         existingSecret: "harbor-database-cluster-app"
 
     core:
+      replicas: 3
       priorityClassName: dkp-critical-priority
       podAnnotations:
         secret.reloader.stakater.com/reload: harbor-tls-core
     exporter:
       podAnnotations:
         secret.reloader.stakater.com/reload: harbor-tls-core
+      priorityClassName: dkp-high-priority
     portal:
+      replicas: 3
       priorityClassName: dkp-critical-priority
       podAnnotations:
         secret.reloader.stakater.com/reload: harbor-tls-portal
@@ -75,8 +77,6 @@ data:
     trivy:
       podAnnotations:
         secret.reloader.stakater.com/reload: harbor-tls-trivy
-      priorityClassName: dkp-high-priority
-    exporter:
       priorityClassName: dkp-high-priority
 
     metrics:


### PR DESCRIPTION
**What problem does this PR solve?**:

Disables ipv6 in harbor config.

Context - https://nutanix.slack.com/archives/C06A78Y063B/p1739827439361349?thread_ts=1739823742.885869&cid=C06A78Y063B

I cleaned up some duplicate keys in harbor config.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-105780

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
