### PR TITLE
build: add cosi controller image

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -582,6 +582,11 @@ resources:
       - url: https://github.com/ceph/ceph-cosi
         ref: ${image_tag}
         license_path: LICENSE
+  - container_image: ghcr.io/mesosphere/dkp-container-images/objectstorage-controller:v20250110-a29e5f6
+    sources:
+      - url: https://github.com/kubernetes-sigs/container-object-storage-interface
+        ref: main
+        license_path: LICENSE
   - container_image: registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.1
     sources:
       - url: https://github.com/kubernetes-sigs/container-object-storage-interface

--- a/services/cosi-driver-nutanix/0.2.0/defaults/cm.yaml
+++ b/services/cosi-driver-nutanix/0.2.0/defaults/cm.yaml
@@ -8,6 +8,11 @@ data:
   values.yaml: |-
     cosiController:
       enabled: false # This should be deployed during k8s cluster creation by konvoy.
+      image:
+        registry: ghcr.io
+        repository: mesosphere/dkp-container-images/objectstorage-controller
+        tag: v20250110-a29e5f6
+        pullPolicy: IfNotPresent
     objectstorageProvisionerSidecar:
       image:
         registry: registry.k8s.io

--- a/services/cosi-driver-nutanix/0.2.0/extra-images.txt
+++ b/services/cosi-driver-nutanix/0.2.0/extra-images.txt
@@ -1,0 +1,1 @@
+ghcr.io/mesosphere/dkp-container-images/objectstorage-controller:v20250110-a29e5f6


### PR DESCRIPTION
**What problem does this PR solve?**:

`cosi-driver-nutanix` allows to install cosi controller image but this image is not added in licenses manifest. This is disabled by default and is handled by konvoy but I am adding it here for completeness (and also to make e2e tests easy on non konvoy clusters).


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
