### PR TITLE
chore: make the kubectl image tag consistent

### DIFF
--- a/services/kubecost/2.5.2/defaults/cm.yaml
+++ b/services/kubecost/2.5.2/defaults/cm.yaml
@@ -286,7 +286,7 @@ data:
           credentialsSecretName: federated-store
       transformations:
         priorityClassName: dkp-high-priority
-        kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.30.5}
+        kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.4}
         kubecost:
           enabled: true
   # Overrides for kubecost to run in primary mode for multi cluster setup with object storage.


### PR DESCRIPTION
**What problem does this PR solve?**:

Adjusting the kubectl image to be consistent with what we add in the bundle https://github.com/mesosphere/kommander-applications/blob/release-2.14/licenses.d2iq.yaml#L524-L528 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
