### PR TITLE
fix: GPU metrics scraping

### DIFF
--- a/services/kube-prometheus-stack/69.1.2/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/69.1.2/defaults/cm.yaml
@@ -225,21 +225,6 @@ data:
               source_labels:
               - __meta_kubernetes_pod_name
               target_label: pod
-          - job_name: 'gpu_metrics'
-            metrics_path: /metrics
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            kubernetes_sd_configs:
-              - role: node
-            relabel_configs:
-              - source_labels: [__address__]
-                regex: '(.*):10250'
-                replacement: '$${1}:9400'
-                target_label: __address__
-              - source_labels: [__meta_kubernetes_node_labelpresent_nvidia_com_gpu_count]
-                regex: true
-                action: keep
           - job_name: 'kubernetes-calico-node'
             metrics_path: /metrics
             tls_config:

--- a/services/nvidia-gpu-operator/24.9.2/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.9.2/defaults/cm.yaml
@@ -32,6 +32,10 @@ data:
       version: 3.3.9-1-ubuntu22.04
     dcgmExporter:
       enabled: true
+      serviceMonitor:
+        enabled: true
+        additionalLabels:
+          prometheus.kommander.d2iq.io/select: "true"
       version: 4.0.0-4.0.1-ubuntu22.04
     validator:
       repository: nvcr.io/nvidia/cloud-native


### PR DESCRIPTION
**What problem does this PR solve?**:

Nvidia gpu metrics scrapping who don’t work out of the box

i don't know why but this is configured to collect metrics against node IP despite dcgmExporter running in pod network space

i move config from static kube-prometheus-stack target config to a more dynamic approach using the GPU Operator to create a proper servicemonitor ressource