### PR TITLE
chore: bumping dex image

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -121,7 +121,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/mesosphere/dex-k8s-authenticator
-  - container_image: docker.io/mesosphere/dex:v2.41.1-d2iq.1
+  - container_image: docker.io/mesosphere/dex:v2.41.1-d2iq.2
     sources:
       - license_path: LICENSE
         ref: ${image_tag}

--- a/services/dex/2.14.1/defaults/cm.yaml
+++ b/services/dex/2.14.1/defaults/cm.yaml
@@ -9,7 +9,7 @@ data:
     priorityClassName: "dkp-critical-priority"
     kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.4}"
     image: mesosphere/dex
-    imageTag: v2.41.1-d2iq.1
+    imageTag: v2.41.1-d2iq.2
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
**What problem does this PR solve?**:

Bumping dex to include a11y changes and some other recent theme changes
https://github.com/mesosphere/dex/tree/refs/tags/v2.41.1-d2iq.2

**Which issue(s) does this PR fix?**:
n/a

**Special notes for your reviewer**:
solely bumping dex image


**Does this PR introduce a user-facing change?**:
n/a - ui changes

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
