### PR TITLE
chore: Re-add NKP Pulse for NKP 2.15 release.

### DIFF
--- a/.exclude-airgapped
+++ b/.exclude-airgapped
@@ -1,3 +1,6 @@
 common/helm-repositories/ai-navigator-repos.yaml
 services/ai-navigator-app
 services/ai-navigator-cluster-info-agent
+common/helm-repositories/nkp-pulse-repos.yaml
+services/nkp-pulse-management
+services/nkp-pulse-workspace

--- a/.github/service-labeler.yaml
+++ b/.github/service-labeler.yaml
@@ -142,6 +142,14 @@ services/nkp-insights-management:
 - changed-files:
   - any-glob-to-any-file:
     - services/nkp-insights-management/**
+services/nkp-pulse-management:
+- changed-files:
+  - any-glob-to-any-file:
+    - services/nkp-pulse-management/**
+services/nkp-pulse-workspace:
+- changed-files:
+  - any-glob-to-any-file:
+    - services/nkp-pulse-workspace/**
 services/nvidia-gpu-operator:
 - changed-files:
   - any-glob-to-any-file:

--- a/common/helm-repositories/kustomization.yaml
+++ b/common/helm-repositories/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - kubefed.yaml
   - kubetunnel.yaml
   - mesosphere-repos.yaml
+  - nkp-pulse-repos.yaml
   - nvidia.yaml
   - prometheus-community.yaml
   - reloader.yaml

--- a/common/helm-repositories/nkp-pulse-repos.yaml
+++ b/common/helm-repositories/nkp-pulse-repos.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: mesosphere.github.io-nkp-pulse-charts
+  namespace: kommander-flux
+spec:
+  interval: 10m
+  timeout: 1m
+  url: "${helmMirrorURL:=https://mesosphere.github.io/nkp-pulse}"

--- a/justfile
+++ b/justfile
@@ -67,6 +67,7 @@ _cleanup:
 _prepare-files-for-a-bundle output_dir:
     rsync --quiet --archive --recursive --files-from={{ include_file }} --exclude-from={{ exclude_file }} {{ justfile_directory() }} {{ output_dir }}
     yq 'del(.resources[] | select(. == "ai-navigator-repos.yaml"))' --inplace {{ output_dir }}/common/helm-repositories/kustomization.yaml
+    yq 'del(.resources[] | select(. == "nkp-pulse-repos.yaml"))' --inplace {{ output_dir }}/common/helm-repositories/kustomization.yaml
 
 
 import 'just/test.just'

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -224,6 +224,14 @@ resources:
     sources:
       - ref: ${image_tag}
         url: https://github.com/mesosphere/kubetunnel
+  - container_image: docker.io/mesosphere/nkp-pulse-management:v0.0.1-dev.0
+    sources:
+      - ref: ${image_tag}
+        url: https://github.com/mesosphere/nkp-pulse
+  - container_image: docker.io/mesosphere/nkp-pulse-workspace:v0.0.1-dev.0
+    sources:
+      - ref: ${image_tag}
+        url: https://github.com/mesosphere/nkp-pulse
   - container_image: docker.io/mesosphere/traefik-forward-auth:v3.2.1
     sources:
       - license_path: LICENSE.thomseddon.md

--- a/services/kommander/0.15.0/defaults/cm.yaml
+++ b/services/kommander/0.15.0/defaults/cm.yaml
@@ -99,6 +99,7 @@ data:
     - "dex"
     - "dex-k8s-authenticator"
     - "nkp-insights-management"
+    - "nkp-pulse-management"
     - "git-operator"
     - "karma"
     - "kommander"

--- a/services/nkp-pulse-management/0.0.1-dev.0/defaults/cm.yaml
+++ b/services/nkp-pulse-management/0.0.1-dev.0/defaults/cm.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nkp-pulse-management-v0.0.1-dev.0-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    workspaceApp:
+      kind: ClusterApp
+      name: nkp-pulse-workspace-v0.0.1-dev.0

--- a/services/nkp-pulse-management/0.0.1-dev.0/defaults/kustomization.yaml
+++ b/services/nkp-pulse-management/0.0.1-dev.0/defaults/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cm.yaml

--- a/services/nkp-pulse-management/0.0.1-dev.0/helmrelease.yaml
+++ b/services/nkp-pulse-management/0.0.1-dev.0/helmrelease.yaml
@@ -1,0 +1,23 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: nkp-pulse-management
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: nkp-pulse-management
+      sourceRef:
+        kind: HelmRepository
+        name: mesosphere.github.io-nkp-pulse-charts
+        namespace: kommander-flux
+      version: v0.0.1-dev.0
+  interval: 15s
+  releaseName: nkp-pulse-management
+  targetNamespace: ${releaseNamespace}
+  upgrade:
+    remediation:
+      strategy: uninstall
+  valuesFrom:
+    - kind: ConfigMap
+      name: nkp-pulse-management-v0.0.1-dev.0-d2iq-defaults

--- a/services/nkp-pulse-management/0.0.1-dev.0/kustomization.yaml
+++ b/services/nkp-pulse-management/0.0.1-dev.0/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/services/nkp-pulse-management/metadata.yaml
+++ b/services/nkp-pulse-management/metadata.yaml
@@ -1,0 +1,9 @@
+type: internal
+scope:
+  - workspace
+licensing:
+  - Starter
+  - Pro
+  - Ultimate
+  - Essential
+  - Enterprise

--- a/services/nkp-pulse-workspace/0.0.1-dev.0/defaults/cm.yaml
+++ b/services/nkp-pulse-workspace/0.0.1-dev.0/defaults/cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nkp-pulse-workspace-v0.0.1-dev.0-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: ""

--- a/services/nkp-pulse-workspace/0.0.1-dev.0/defaults/kustomization.yaml
+++ b/services/nkp-pulse-workspace/0.0.1-dev.0/defaults/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cm.yaml

--- a/services/nkp-pulse-workspace/0.0.1-dev.0/helmrelease.yaml
+++ b/services/nkp-pulse-workspace/0.0.1-dev.0/helmrelease.yaml
@@ -1,0 +1,23 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: nkp-pulse-workspace
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: nkp-pulse-workspace
+      sourceRef:
+        kind: HelmRepository
+        name: mesosphere.github.io-nkp-pulse-charts
+        namespace: kommander-flux
+      version: v0.0.1-dev.0
+  interval: 15s
+  releaseName: nkp-pulse-workspace
+  targetNamespace: ${releaseNamespace}
+  upgrade:
+    remediation:
+      strategy: uninstall
+  valuesFrom:
+    - kind: ConfigMap
+      name: nkp-pulse-workspace-v0.0.1-dev.0-d2iq-defaults

--- a/services/nkp-pulse-workspace/0.0.1-dev.0/kustomization.yaml
+++ b/services/nkp-pulse-workspace/0.0.1-dev.0/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/services/nkp-pulse-workspace/metadata.yaml
+++ b/services/nkp-pulse-workspace/metadata.yaml
@@ -1,0 +1,9 @@
+type: internal
+scope:
+  - workspace
+licensing:
+  - Starter
+  - Pro
+  - Ultimate
+  - Essential
+  - Enterprise


### PR DESCRIPTION

**What problem does this PR solve?**:

Revert PR #3076 via commit b0d160e9eaaca85ca79e3be5546bcd3bd5c4f2fa and re-add NKP-Pulse to k-apps.

We can then land the latest version via #3223 which will merge into this.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
