### PR TITLE
chore: decrease kubecost aggregator default storage

### DIFF
--- a/services/kubecost/2.5.2/defaults/cm.yaml
+++ b/services/kubecost/2.5.2/defaults/cm.yaml
@@ -200,7 +200,7 @@ data:
         storageRequest: 1Gi
       aggregatorDbStorage:
         storageClass: ""  # default storage class
-        storageRequest: 128Gi
+        storageRequest: 32Gi
       cloudCost:
         # The cloudCost component of Aggregator depends on
         # kubecostAggregator.deployMethod:


### PR DESCRIPTION
**What problem does this PR solve?**:

looks like current 128G is good for :
> This configuration is estimated to be sufficient for environments monitoring < 60k unique containers per day. You can check this metric on the /diagnostics page.
https://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl/aggregator#aggregator-optimizations

looking at the soak cluster [https://dkp214.ksphere-soak.d2iq.cloud/dkp/kommander/monitoring/grafana/d/919b92a8e8041bd567[…]gregator-db-storage-kubecost-aggregator-0&refresh=10s](https://dkp214.ksphere-soak.d2iq.cloud/dkp/kommander/monitoring/grafana/d/919b92a8e8041bd567af9edab12c840c/kubernetes-persistent-volumes?orgId=1&from=now-1h&to=now&timezone=utc&var-datasource=default&var-cluster=18fb9f52-da44-433d-8486-fcbc5e113df8&var-namespace=kommander&var-volume=aggregator-db-storage-kubecost-aggregator-0&refresh=10s) 175Mb is consumed of 128G. 

Because we use cosi backend for persistence of ETL data, aggregator acts as a local cache for optimal performance of API queries. 32G should be plenty of storage.

this is on a 2.13 cluster:

```
 k get pvc -nkommander|grep kubecost                                                                                                                                                                                                                                                       10:38:08
kubecost-cost-analyzer                                                       Bound         pvc-cd9c8951-0b8f-46fd-8802-a3e2e1a1400d   32Gi       RWO            ebs-sc         <unset>                 2y274d
kubecost-prometheus-alertmanager                                             Bound         pvc-1350e733-31df-4584-b9e4-cbb25b6d6868   2Gi        RWO            ebs-sc         <unset>                 2y274d
kubecost-prometheus-server                                                   Bound         pvc-cd9db453-5ddd-43d5-a216-9a8da3fafe72   32Gi       RWO            ebs-sc         <unset>                 2y274d
```
this is on a 2.14 cluster 
```
k get pvc -nkommander|grep kubecost                                                                                                                                                                                                                                               10:38:31
aggregator-db-storage-kubecost-aggregator-0                                  Bound    pvc-d0981eaa-5124-45da-b242-c1b77cfc41cc   128Gi      RWO            ebs-sc         <unset>                 12h
kubecost-cost-analyzer                                                       Bound    pvc-c6eabd8b-17a7-4b60-b8a7-e5327cb26c0b   32Gi       RWO            ebs-sc         <unset>                 12h
kubecost-prometheus-alertmanager                                             Bound    pvc-8a30d7d1-81a2-456b-9180-64edaa834844   2Gi        RWO            ebs-sc         <unset>                 12h
kubecost-prometheus-server                                                   Bound    pvc-41574404-59e3-4126-b5f3-76d70d25aaf0   32Gi       RWO            ebs-sc         <unset>                 12h
persistent-configs-kubecost-aggregator-0                                     Bound    pvc-a0d4c803-c576-4963-a6a7-ba4f71f0bddb   1Gi        RWO            ebs-sc         <unset>                 12h
```
by doing `s/128/32` we will be close to 2.13 hardware requirements.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://jira.nutanix.com/browse/NCN-105990


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
