### PR TITLE
fix: revert dcgm-export to helm chart default value

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -372,7 +372,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag%-ubi8}
         url: https://github.com/NVIDIA/nvidia-container-toolkit
-  - container_image: nvcr.io/nvidia/k8s/dcgm-exporter:4.0.0-4.0.1-ubuntu22.04
+  - container_image: nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04
     sources:
       - license_path: LICENSE
         ref: ${image_tag%-ubuntu22.04}

--- a/services/nvidia-gpu-operator/24.9.2/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.9.2/defaults/cm.yaml
@@ -36,7 +36,7 @@ data:
         enabled: true
         additionalLabels:
           prometheus.kommander.d2iq.io/select: "true"
-      version: 4.0.0-4.0.1-ubuntu22.04
+      version: 3.3.9-3.6.1-ubuntu22.04
     validator:
       repository: nvcr.io/nvidia/cloud-native
       version: v24.9.2

--- a/services/nvidia-gpu-operator/24.9.2/grafana-dashboards/gpu-operator.json
+++ b/services/nvidia-gpu-operator/24.9.2/grafana-dashboards/gpu-operator.json
@@ -101,6 +101,7 @@
       "targets": [
         {
           "expr": "DCGM_FI_DEV_GPU_TEMP",
+          "instant": true,
           "interval": "",
           "legendFormat": "GPU {{gpu}}",
           "refId": "A"
@@ -928,10 +929,7 @@
   "refresh": false,
   "schemaVersion": 22,
   "style": "dark",
-  "tags": [
-    "nvidia",
-    "platform apps"
-  ],
+  "tags": [],
   "templating": {
     "list": [
       {


### PR DESCRIPTION
**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-105855

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
