### PR TITLE
feat: bump node-exporter to 1.9.0

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -464,7 +464,7 @@ resources:
         notice_path: NOTICE
         ref: ${image_tag}
         url: https://github.com/prometheus/alertmanager
-  - container_image: quay.io/prometheus/node-exporter:v1.8.2
+  - container_image: quay.io/prometheus/node-exporter:v1.9.0
     sources:
       - license_path: LICENSE
         notice_path: NOTICE

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -464,7 +464,7 @@ resources:
         notice_path: NOTICE
         ref: ${image_tag}
         url: https://github.com/prometheus/alertmanager
-  - container_image: quay.io/prometheus/node-exporter:v1.9.0
+  - container_image: quay.io/prometheus/node-exporter:v1.8.2
     sources:
       - license_path: LICENSE
         notice_path: NOTICE

--- a/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
@@ -454,7 +454,7 @@ data:
         enable: true
         image:
           tag: v1.9.0
-      container_image: quay.io/prometheus/node-exporter:v1.9.0
+    container_image: quay.io/prometheus/node-exporter:v1.9.0
       prometheus:
         monitor:
           scheme: https

--- a/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
@@ -450,6 +450,11 @@ data:
         enabled: true
         image:
           tag: v0.18.2
+      node-exporter
+        enable: true
+        image:
+          tag: v1.9.0
+      container_image: quay.io/prometheus/node-exporter:v1.9.0
       prometheus:
         monitor:
           scheme: https

--- a/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
@@ -454,7 +454,6 @@ data:
         enable: true
         image:
           tag: v1.9.0
-    container_image: quay.io/prometheus/node-exporter:v1.9.0
       prometheus:
         monitor:
           scheme: https

--- a/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
@@ -450,10 +450,10 @@ data:
         enabled: true
         image:
           tag: v0.18.2
-      node-exporter
-        enable: true
         image:
-          tag: v1.9.0
+          registry: quay.io
+          repository: prometheus/node-exporter
+          tag: v1.9.0 
       prometheus:
         monitor:
           scheme: https

--- a/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
@@ -454,6 +454,7 @@ data:
         enable: true
         image:
           tag: v1.9.0
+    container_image: quay.io/prometheus/node-exporter:v1.9.0
       prometheus:
         monitor:
           scheme: https

--- a/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
@@ -450,10 +450,10 @@ data:
         enabled: true
         image:
           tag: v0.18.2
+      node-exporter
+        enable: true
         image:
-          registry: quay.io
-          repository: prometheus/node-exporter
-          tag: v1.9.0 
+          tag: v1.9.0
       prometheus:
         monitor:
           scheme: https

--- a/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
@@ -465,9 +465,3 @@ data:
             sourceLabels:
             - __meta_kubernetes_pod_node_name
             targetLabel: node
-    container_image: quay.io/prometheus/node-exporter:v1.9.0
-    sources:
-      - license_path: LICENSE
-         notice_path: NOTICE
-         ref: ${image_tag}
-        url: https://github.com/prometheus/node_exporter

--- a/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
@@ -465,3 +465,9 @@ data:
             sourceLabels:
             - __meta_kubernetes_pod_node_name
             targetLabel: node
+    container_image: quay.io/prometheus/node-exporter:v1.9.0
+    sources:
+      - license_path: LICENSE
+         notice_path: NOTICE
+         ref: ${image_tag}
+        url: https://github.com/prometheus/node_exporter

--- a/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
@@ -450,6 +450,10 @@ data:
         enabled: true
         image:
           tag: v0.18.2
+        image:
+          registry: quay.io
+          repository: prometheus/node-exporter
+          tag: v1.9.0 
       prometheus:
         monitor:
           scheme: https

--- a/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/69.8.0/defaults/cm.yaml
@@ -450,10 +450,6 @@ data:
         enabled: true
         image:
           tag: v0.18.2
-        image:
-          registry: quay.io
-          repository: prometheus/node-exporter
-          tag: v1.9.0 
       prometheus:
         monitor:
           scheme: https


### PR DESCRIPTION
Upgrades the following apps to use version 1.9.0 of node exporter:

prometheus node-exporter from version 1.8.2 to 1.9.0