### PR TITLE
feat: gateway api

### DIFF
--- a/services/traefik/34.1.0/defaults/traefik.yaml
+++ b/services/traefik/34.1.0/defaults/traefik.yaml
@@ -47,7 +47,17 @@ data:
         app: traefik
 
     gateway:
-      enabled: false
+      enabled: true
+      listeners:
+        web:
+          port: 8000
+          protocol: HTTP
+        websecure:
+          port: 8443
+          protocol: HTTPS
+          certificateRefs:
+            - name: kommander-traefik-tls
+          mode: Terminate
 
     extraObjects:
       - apiVersion: traefik.io/v1alpha1
@@ -179,7 +189,7 @@ data:
         enabled: true
         # -- Toggles support for the Experimental Channel resources (Gateway API release channels documentation).
         # This option currently enables support for TCPRoute and TLSRoute.
-        experimentalChannel: false
+        experimentalChannel: true
 
     # This value should be equal to release name. Justification with timeline of changes:
     # 1. This was set to `kommander-treafik` in an old chart version - https://github.com/traefik/traefik-helm-chart/blob/v10.30.1/traefik/templates/deployment.yaml#L42 (Shipped in DKP 2.4)


### PR DESCRIPTION
**What problem does this PR solve?**:

Gateway API support for Traefik


**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
