### PR TITLE
feat: use oci for kommander charts

### DIFF
--- a/charts/kommander-operator/Chart.yaml
+++ b/charts/kommander-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-name: kommander-operator
-appVersion: "0.3.2"
-version: 0.3.2
+name: kommander-operator-chart
+appVersion: "0.3.3"
+version: 0.3.3
 description: kommander-operator helm chart.
 maintainers:
   - name: azhovan

--- a/common/helm-repositories/mesosphere-repos.yaml
+++ b/common/helm-repositories/mesosphere-repos.yaml
@@ -50,3 +50,15 @@ spec:
   interval: 10m
   timeout: 1m
   url: "${helmMirrorURL:=https://mesosphere.github.io/dkp-insights-charts-attached}"
+---
+# TODO: decide to use this or OCIRepo
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: mesosphere-oci-repo
+  namespace: kommander-flux
+spec:
+  type: "oci"
+  interval: 10m
+  timeout: 1m
+  url: "${helmMirrorURL:=oci://docker.io:mesosphere}"

--- a/common/helm-repositories/mesosphere-repos.yaml
+++ b/common/helm-repositories/mesosphere-repos.yaml
@@ -61,4 +61,4 @@ spec:
   type: "oci"
   interval: 10m
   timeout: 1m
-  url: "${helmMirrorURL:=oci://docker.io:mesosphere}"
+  url: "${helmMirrorURL:=oci://docker.io/mesosphere}"

--- a/services/kommander-appmanagement/0.15.0/kommander-appmanagement.yaml
+++ b/services/kommander-appmanagement/0.15.0/kommander-appmanagement.yaml
@@ -7,10 +7,10 @@ metadata:
 spec:
   chart:
     spec:
-      chart: kommander-appmanagement
+      chart: kommander-appmanagement-chart
       sourceRef:
         kind: HelmRepository
-        name: mesosphere.github.io-kommander-charts
+        name: mesosphere-oci-repo
         namespace: kommander-flux
       version: "${kommanderChartVersion:=v2.15.0-dev}"
   interval: 15s

--- a/services/kommander/0.15.0/kommander.yaml
+++ b/services/kommander/0.15.0/kommander.yaml
@@ -12,10 +12,10 @@ spec:
       name: kubefed
   chart:
     spec:
-      chart: kommander
+      chart: kommander-chart
       sourceRef:
         kind: HelmRepository
-        name: mesosphere.github.io-kommander-charts
+        name: mesosphere-oci-repo
         namespace: kommander-flux
       version: "${kommanderChartVersion:=v2.15.0-dev}"
   interval: 15s


### PR DESCRIPTION
**What problem does this PR solve?**:
currently it doesn't support bundling oci artifact images into our airgap bundle

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (NCN-NUMBER)
-->

https://jira.nutanix.com/browse/NCN-104850

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
kommander: https://github.com/mesosphere/kommander/pull/5634

blocked by https://github.com/mesosphere/mindthegap/pull/862

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: `CLI: Some bug fix. (COPS-xxxx)`
-->
```release-note

```
