### PR TITLE
fix: updating k8s/container-toolkit:v1.17.45ubuntu20.04-CVE fix

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -370,15 +370,15 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/NVIDIA/k8s-device-plugin
-  - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.17.4-ubuntu20.04
+  - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.17.5-ubuntu20.04
     sources:
       - license_path: LICENSE
         ref: ${image_tag%-ubuntu20.04}
         url: https://github.com/NVIDIA/nvidia-container-toolkit
-  - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.17.4-ubi8
+  - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.17.5-ubi9
     sources:
       - license_path: LICENSE
-        ref: ${image_tag%-ubi8}
+        ref: ${image_tag%-ubi9}
         url: https://github.com/NVIDIA/nvidia-container-toolkit
   - container_image: nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04
     sources:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -375,7 +375,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag%-ubuntu20.04}
         url: https://github.com/NVIDIA/nvidia-container-toolkit
-  - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.17.5-ubi9
+  - container_image: nvcr.io/nvidia/k8s/container-toolkit:v1.17.5-ubi8
     sources:
       - license_path: LICENSE
         ref: ${image_tag%-ubi9}

--- a/services/nvidia-gpu-operator/24.9.2/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/24.9.2/defaults/cm.yaml
@@ -21,7 +21,7 @@ data:
       # this comment explains the dependency on the hosts
       # version of libc.so
       # https://github.com/NVIDIA/gpu-operator/issues/72#issuecomment-742023528
-      version: v1.17.4-ubuntu20.04
+      version: v1.17.5-ubuntu20.04
     gfd:
       # gfd is no longer published a standalone helm chart or image and instead uses
       # the k8s-device-plugin image.


### PR DESCRIPTION
**What problem does this PR solve?**:

update and container-toolkit image with fixed CVE's bumping to [1.17.5](container-toolkit:v1.17.45ubuntu20.04)

```
sandhya.ravi@GT9X7CVF5F k8s-1.30.6-patch % trivy i nvcr.io/nvidia/k8s/container-toolkit:v1.17.5-ubuntu20.04 
2025-03-19T10:02:50+05:30	INFO	Need to update DB
2025-03-19T10:02:50+05:30	INFO	Downloading DB...	repository="ghcr.io/aquasecurity/trivy-db:2"
61.06 MiB / 61.06 MiB [----------------------------------------------------------------------------------------------------] 100.00% 6.79 MiB p/s 9.2s
2025-03-19T10:03:01+05:30	INFO	Vulnerability scanning is enabled
2025-03-19T10:03:01+05:30	INFO	Secret scanning is enabled
2025-03-19T10:03:01+05:30	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-03-19T10:03:01+05:30	INFO	Please see also https://aquasecurity.github.io/trivy/v0.53/docs/scanner/secret#recommendation for faster secret detection
2025-03-19T10:03:28+05:30	INFO	Detected OS	family="ubuntu" version="20.04"
2025-03-19T10:03:28+05:30	INFO	[ubuntu] Detecting vulnerabilities...	os_version="20.04" pkg_num=149
2025-03-19T10:03:28+05:30	INFO	Number of language-specific files	num=1
2025-03-19T10:03:28+05:30	INFO	[gobinary] Detecting vulnerabilities...
2025-03-19T10:03:28+05:30	WARN	Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.53/docs/scanner/vulnerability#severity-selection for details.


nvcr.io/nvidia/k8s/container-toolkit:v1.17.5-ubuntu20.04 (ubuntu 20.04)


Total: 50 (UNKNOWN: 0, LOW: 42, MEDIUM: 8, HIGH: 0, CRITICAL: 

> 0)
```

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-106584


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
