### PR TITLE
chore: Post release bumps

### DIFF
--- a/upgrade-matrix.yaml
+++ b/upgrade-matrix.yaml
@@ -65,3 +65,6 @@ upgrades:
     - from: v2.14.1-dev
       to: v2.15.0-dev
       k8sversion: "1.31"
+    - from: v2.15.0-dev
+      to: v2.16.0-dev
+      k8sversion: "1.32"


### PR DESCRIPTION
Post-release bumps are PRs created by [gh-dkp](https://github.com/mesosphere/gh-dkp/)
to adjust repositories after releases.
