### PR TITLE
feat: Introduce cilium-hubble-relay-traefik

### DIFF
--- a/.github/service-labeler.yaml
+++ b/.github/service-labeler.yaml
@@ -18,6 +18,10 @@ services/chartmuseum:
 - changed-files:
   - any-glob-to-any-file:
     - services/chartmuseum/**
+services/cilium-hubble-relay-traefik:
+- changed-files:
+  - any-glob-to-any-file:
+    - services/cilium-hubble-relay-traefik/**
 services/cloudnative-pg:
 - changed-files:
   - any-glob-to-any-file:

--- a/apptests/appscenarios/ciliumhubblerelaytraefik.go
+++ b/apptests/appscenarios/ciliumhubblerelaytraefik.go
@@ -1,0 +1,72 @@
+package appscenarios
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/mesosphere/kommander-applications/apptests/constants"
+	"github.com/mesosphere/kommander-applications/apptests/environment"
+)
+
+type ciliumHubbleRelayTraefik struct {
+	appPathCurrentVersion  string
+	appPathPreviousVersion string
+}
+
+func (c ciliumHubbleRelayTraefik) Name() string {
+	return constants.CiliumHubbleRelayTraefik
+}
+
+var _ AppScenario = (*ciliumHubbleRelayTraefik)(nil)
+
+func NewCiliumHubbleRelayTraefik() *ciliumHubbleRelayTraefik {
+	appPath, _ := absolutePathTo(constants.CiliumHubbleRelayTraefik)
+	appPrevVerPath, _ := getkAppsUpgradePath(constants.CiliumHubbleRelayTraefik)
+	return &ciliumHubbleRelayTraefik{
+		appPathCurrentVersion:  appPath,
+		appPathPreviousVersion: appPrevVerPath,
+	}
+}
+
+func (c ciliumHubbleRelayTraefik) Install(ctx context.Context, env *environment.Env) error {
+	err := c.install(ctx, env, c.appPathCurrentVersion)
+	return err
+}
+
+func (c ciliumHubbleRelayTraefik) InstallPreviousVersion(ctx context.Context, env *environment.Env) error {
+	err := c.install(ctx, env, c.appPathPreviousVersion)
+
+	return err
+}
+
+func (c ciliumHubbleRelayTraefik) InstallDependency(ctx context.Context, env *environment.Env, depAppName string) error {
+	appPath, err := absolutePathTo(depAppName)
+	if err != nil {
+		return err
+	}
+	err = c.install(ctx, env, appPath)
+
+	return err
+}
+
+func (c ciliumHubbleRelayTraefik) install(ctx context.Context, env *environment.Env, appPath string) error {
+	// apply defaults config maps first
+	defaultKustomizations := filepath.Join(appPath, "/defaults")
+	err := env.ApplyKustomizations(ctx, defaultKustomizations, map[string]string{
+		"releaseNamespace":   kommanderNamespace,
+		"workspaceNamespace": kommanderNamespace,
+	})
+	if err != nil {
+		return err
+	}
+	// apply the rest of kustomizations
+	err = env.ApplyKustomizations(ctx, appPath, map[string]string{
+		"releaseNamespace":   kommanderNamespace,
+		"workspaceNamespace": kommanderNamespace,
+	})
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/apptests/appscenarios/ciliumhubblerelaytraefik_test.go
+++ b/apptests/appscenarios/ciliumhubblerelaytraefik_test.go
@@ -1,0 +1,324 @@
+package appscenarios
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	fluxhelmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	apimeta "github.com/fluxcd/pkg/apis/meta"
+	"github.com/mesosphere/kommander-applications/apptests/constants"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Cilium Hubble Relay Traefik Tests", Label(constants.CiliumHubbleRelayTraefik), func() {
+	var c *ciliumHubbleRelayTraefik
+
+	BeforeEach(OncePerOrdered, func() {
+		err := SetupKindCluster()
+		Expect(err).To(BeNil())
+
+		err = env.InstallLatestFlux(ctx)
+		Expect(err).To(BeNil())
+
+		err = env.ApplyKommanderBaseKustomizations(ctx)
+		Expect(err).To(BeNil())
+
+		c = NewCiliumHubbleRelayTraefik()
+	})
+
+	AfterEach(OncePerOrdered, func() {
+		if os.Getenv("SKIP_CLUSTER_TEARDOWN") != "" {
+			return
+		}
+
+		err := env.Destroy(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("Cilium Hubble Relay Traefik Install Test", Ordered, Label("install"), func() {
+		var ciliumHubbleRelayHR *fluxhelmv2beta2.HelmRelease
+
+		It("should install Cilium Hubble Relay Traefik dependencies", func() {
+			installCiliumHubbleRelayTraefikDependencies()
+		})
+
+		It("should install successfully with default config", func() {
+			err := c.Install(ctx, env)
+			Expect(err).To(BeNil())
+
+			ciliumHubbleRelayHR = &fluxhelmv2beta2.HelmRelease{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       fluxhelmv2beta2.HelmReleaseKind,
+					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      c.Name(),
+					Namespace: kommanderNamespace,
+				},
+			}
+
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, ctrlClient.ObjectKeyFromObject(ciliumHubbleRelayHR), ciliumHubbleRelayHR)
+				if err != nil {
+					return err
+				}
+
+				for _, cond := range ciliumHubbleRelayHR.Status.Conditions {
+					if cond.Status == metav1.ConditionTrue &&
+						cond.Type == apimeta.ReadyCondition {
+						return nil
+					}
+				}
+				return fmt.Errorf("helm release not ready yet")
+			}).WithPolling(pollInterval).WithTimeout(5 * time.Minute).Should(Succeed())
+		})
+
+		It("should forward requests to Hubble Relay", func() {
+			connectToHubbleRelayViaLoadbalancer()
+		})
+	})
+
+	PDescribe("Cilium Hubble Relay Traefik Upgrade Test", Ordered, Label("upgrade"), func() {
+		var ciliumHubbleRelayHR *fluxhelmv2beta2.HelmRelease
+
+		It("should install Cilium Hubble Relay Traefik dependencies", func() {
+			installCiliumHubbleRelayTraefikDependencies()
+		})
+
+		It("should install previous version successfully with default config", func() {
+			err := c.InstallPreviousVersion(ctx, env)
+			Expect(err).To(BeNil())
+
+			ciliumHubbleRelayHR = &fluxhelmv2beta2.HelmRelease{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       fluxhelmv2beta2.HelmReleaseKind,
+					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      c.Name(),
+					Namespace: kommanderNamespace,
+				},
+			}
+
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, ctrlClient.ObjectKeyFromObject(ciliumHubbleRelayHR), ciliumHubbleRelayHR)
+				if err != nil {
+					return err
+				}
+
+				for _, cond := range ciliumHubbleRelayHR.Status.Conditions {
+					if cond.Status == metav1.ConditionTrue &&
+						cond.Type == apimeta.ReadyCondition {
+						return nil
+					}
+				}
+				return fmt.Errorf("helm release not ready yet")
+			}).WithPolling(pollInterval).WithTimeout(5 * time.Minute).Should(Succeed())
+		})
+
+		It("should forward requests to Hubble Relay before upgrade", func() {
+			connectToHubbleRelayViaLoadbalancer()
+		})
+
+		It("should upgrade successfully", func() {
+			err := c.Install(ctx, env)
+			Expect(err).To(BeNil())
+
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, ctrlClient.ObjectKeyFromObject(ciliumHubbleRelayHR), ciliumHubbleRelayHR)
+				if err != nil {
+					return err
+				}
+
+				for _, cond := range ciliumHubbleRelayHR.Status.Conditions {
+					if cond.Status == metav1.ConditionTrue &&
+						cond.Type == apimeta.ReadyCondition {
+						return nil
+					}
+				}
+				return fmt.Errorf("helm release not ready yet")
+			}).WithPolling(pollInterval).WithTimeout(5 * time.Minute).Should(Succeed())
+		})
+
+		It("should forward requests to Hubble Relay after upgrade", func() {
+			connectToHubbleRelayViaLoadbalancer()
+		})
+	})
+})
+
+func installCiliumHubbleRelayTraefikDependencies() {
+	By("Installing cert-manager")
+	cm := certManager{}
+	err := cm.Install(ctx, env)
+	Expect(err).To(BeNil())
+
+	hr := &fluxhelmv2beta2.HelmRelease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       fluxhelmv2beta2.HelmReleaseKind,
+			APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.CertManager,
+			Namespace: kommanderNamespace,
+		},
+	}
+
+	Eventually(func() error {
+		err = k8sClient.Get(ctx, ctrlClient.ObjectKeyFromObject(hr), hr)
+		if err != nil {
+			return err
+		}
+
+		for _, cond := range hr.Status.Conditions {
+			if cond.Status == metav1.ConditionTrue &&
+				cond.Type == apimeta.ReadyCondition {
+				return nil
+			}
+		}
+		return fmt.Errorf("helm release not ready yet")
+	}).WithPolling(pollInterval).WithTimeout(5 * time.Minute).Should(Succeed())
+
+	By("Verifying that cert-manager CRDs are installed")
+	certManagerCrds := &fluxhelmv2beta2.HelmRelease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       fluxhelmv2beta2.HelmReleaseKind,
+			APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cert-manager-crds",
+			Namespace: kommanderNamespace,
+		},
+	}
+
+	Eventually(func() error {
+		err := k8sClient.Get(ctx, ctrlClient.ObjectKeyFromObject(certManagerCrds), certManagerCrds)
+		if err != nil {
+			return err
+		}
+
+		for _, cond := range certManagerCrds.Status.Conditions {
+			if cond.Status == metav1.ConditionTrue &&
+				cond.Type == apimeta.ReadyCondition {
+				return nil
+			}
+		}
+		return fmt.Errorf("helm release not ready yet")
+	}).WithPolling(pollInterval).WithTimeout(5 * time.Minute).Should(Succeed())
+
+	By("Installing kommander-ca")
+	testDataDir, err := getTestDataDir()
+	Expect(err).To(BeNil())
+	err = env.ApplyYAML(ctx, filepath.Join(testDataDir, "cert-manager/kommander-ca"), nil)
+	Expect(err).To(BeNil())
+
+	By("Installing traefik")
+	tfk := NewTraefik()
+	err = tfk.Install(ctx, env)
+	Expect(err).To(BeNil())
+
+	hr = &fluxhelmv2beta2.HelmRelease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       fluxhelmv2beta2.HelmReleaseKind,
+			APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tfk.Name(),
+			Namespace: kommanderNamespace,
+		},
+	}
+
+	Eventually(func() error {
+		err = k8sClient.Get(ctx, ctrlClient.ObjectKeyFromObject(hr), hr)
+		if err != nil {
+			return err
+		}
+
+		for _, cond := range hr.Status.Conditions {
+			if cond.Status == metav1.ConditionTrue &&
+				cond.Type == apimeta.ReadyCondition {
+				return nil
+			}
+		}
+		return fmt.Errorf("helm release not ready yet")
+	}).WithPolling(pollInterval).WithTimeout(5 * time.Minute).Should(Succeed())
+
+	By("Installing a fake helm relay server")
+	testDataPath, err := getTestDataDir()
+	Expect(err).To(BeNil())
+
+	fakeHubbleRelayManifest := filepath.Join(testDataPath, "cilium-hubble-relay-traefik", "hubble-relay-fake.yaml")
+	err = env.ApplyYAML(ctx, fakeHubbleRelayManifest, map[string]string{})
+	Expect(err).To(BeNil())
+}
+
+func connectToHubbleRelayViaLoadbalancer() {
+	// Wait for the loadbalancer IP
+	traefikSvc := &corev1.Service{}
+	Eventually(func(g Gomega) {
+		err := k8sClient.Get(
+			ctx,
+			types.NamespacedName{
+				Name:      "kommander-traefik",
+				Namespace: "kommander",
+			}, traefikSvc,
+		)
+		g.Expect(err).To(BeNil())
+		g.Expect(
+			len(traefikSvc.Status.LoadBalancer.Ingress)).To(BeNumerically(">=", 1),
+			"loadbalancer IP not available",
+		)
+	}).WithPolling(pollInterval).WithTimeout(2 * time.Minute).Should(Succeed())
+	loadbalancerIP := traefikSvc.Status.LoadBalancer.Ingress[0].IP
+
+	// Make the request
+	hubbleRelayURL := url.URL{
+		Scheme: "https",
+		Host:   "hubble.hubble-relay.cilium.io:443",
+	}
+
+	Eventually(func(g Gomega) {
+		// Make the request
+		req, err := http.NewRequest("GET", hubbleRelayURL.String(), nil)
+		g.Expect(err).To(BeNil())
+
+		dialer := &net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}
+		client := &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					if addr == hubbleRelayURL.Host {
+						// The request host is used for the SNI header, but the actual address is the loadbalancer
+						addr = fmt.Sprintf("%s:443", loadbalancerIP)
+					}
+					return dialer.DialContext(ctx, network, addr)
+				},
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true, // The server certificate is self-signed
+				},
+			},
+		}
+		resp, err := client.Do(req)
+		g.Expect(err).To(BeNil())
+		defer resp.Body.Close()
+
+		// Validate the response
+		g.Expect(resp.StatusCode).To(Equal(200))
+		g.Expect(len(resp.TLS.PeerCertificates)).To(BeNumerically(">", 0))
+		g.Expect(resp.TLS.PeerCertificates[0].Issuer.CommonName).To(Equal("Hubble Relay Fake - ECC Intermediate"))
+	}).WithPolling(pollInterval).WithTimeout(1 * time.Minute).Should(Succeed())
+}

--- a/apptests/constants/apps.go
+++ b/apptests/constants/apps.go
@@ -1,15 +1,16 @@
 package constants
 
 const (
-	CertManager  = "cert-manager"
-	Karma        = "karma"
-	KubeCost     = "kubecost"
-	Reloader     = "reloader"
-	Traefik      = "traefik"
-	KarmaTraefik = "karma-traefik"
-	Flux         = "kommander-flux"
-	ExternalDns  = "external-dns"
-	GateKeeper   = "gatekeeper"
-	RookCeph     = "rook-ceph"
-	Velero       = "velero"
+	CertManager              = "cert-manager"
+	Karma                    = "karma"
+	KubeCost                 = "kubecost"
+	Reloader                 = "reloader"
+	Traefik                  = "traefik"
+	KarmaTraefik             = "karma-traefik"
+	Flux                     = "kommander-flux"
+	ExternalDns              = "external-dns"
+	GateKeeper               = "gatekeeper"
+	RookCeph                 = "rook-ceph"
+	Velero                   = "velero"
+	CiliumHubbleRelayTraefik = "cilium-hubble-relay-traefik"
 )

--- a/apptests/testdata/cilium-hubble-relay-traefik/hubble-relay-fake.yaml
+++ b/apptests/testdata/cilium-hubble-relay-traefik/hubble-relay-fake.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: caddyfile
+  namespace: kube-system
+data:
+  Caddyfile: |
+    {
+      debug
+      pki {
+        ca local {
+          name "Hubble Relay Fake"
+        }
+      }
+    }
+    *.hubble-relay.cilium.io {
+        tls internal
+        respond / 200
+
+    }
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hubble-relay-fake
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: hubble-relay-fake
+spec:
+  containers:
+    - name: caddy
+      image: docker.io/caddy:2.9.1
+      volumeMounts:
+      - name: caddyfile
+        mountPath: /etc/caddy/
+      ports:
+      - containerPort: 443
+  volumes:
+    - name: caddyfile
+      configMap:
+        name: caddyfile
+  restartPolicy: OnFailure
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hubble-relay
+  namespace: kube-system
+spec:
+  selector:
+    app.kubernetes.io/name: hubble-relay-fake
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 443

--- a/services/cilium-hubble-relay-traefik/0.0.3/cilium-hubble-relay-traefik.yaml
+++ b/services/cilium-hubble-relay-traefik/0.0.3/cilium-hubble-relay-traefik.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: cilium-hubble-relay-traefik
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: cilium-hubble-relay-traefik
+      sourceRef:
+        kind: HelmRepository
+        name: mesosphere.github.io-charts-staging
+        namespace: kommander-flux
+      version: 0.0.3
+  interval: 15s
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+  releaseName: cilium-hubble-relay-traefik
+  valuesFrom:
+    - kind: ConfigMap
+      name: cilium-hubble-relay-traefik-0.0.3-d2iq-defaults

--- a/services/cilium-hubble-relay-traefik/0.0.3/defaults/cm.yaml
+++ b/services/cilium-hubble-relay-traefik/0.0.3/defaults/cm.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-hubble-relay-traefik-0.0.3-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    ---
+    enabled: true

--- a/services/cilium-hubble-relay-traefik/0.0.3/defaults/kustomization.yaml
+++ b/services/cilium-hubble-relay-traefik/0.0.3/defaults/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cm.yaml

--- a/services/cilium-hubble-relay-traefik/0.0.3/kustomization.yaml
+++ b/services/cilium-hubble-relay-traefik/0.0.3/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cilium-hubble-relay-traefik.yaml

--- a/services/cilium-hubble-relay-traefik/metadata.yaml
+++ b/services/cilium-hubble-relay-traefik/metadata.yaml
@@ -1,6 +1,9 @@
 type: internal
 scope:
   - workspace
+requiredDependencies:
+  - traefik
+allowMultipleInstances: false
 licensing:
   - Pro
   - Ultimate

--- a/services/cilium-hubble-relay-traefik/metadata.yaml
+++ b/services/cilium-hubble-relay-traefik/metadata.yaml
@@ -1,0 +1,8 @@
+type: internal
+scope:
+  - workspace
+licensing:
+  - Pro
+  - Ultimate
+  - Essential
+  - Enterprise

--- a/services/kommander/0.16.0/defaults/cm.yaml
+++ b/services/kommander/0.16.0/defaults/cm.yaml
@@ -86,6 +86,7 @@ data:
       - "rook-ceph"
       - "rook-ceph-cluster"
       - "velero"
+      - "cilium-hubble-relay-traefik"
     kommander-ui:
       enabled: false
     capimate:
@@ -124,3 +125,4 @@ data:
         - "karma-traefik"
         - "gatekeeper"
         - "kommander-flux"
+        - "cilium-hubble-relay-traefik"


### PR DESCRIPTION
**What problem does this PR solve?**:
This deploys the helm chart that configures a traefik route for the Cilium Hubble Relay service.

Adds an install apptest for the service, and an upgrade test that is skipped, for now, because no previous version of the service exists, and the upgrade test framework requires a previous version.

The install apptest verifies that the IngressRouteTCP created by cilium-hubble-relay-traefik does correctly route requests to the hubble-relay service with TLS passthrough. The test:
- Installs traefik and its dependencies
- Installs cilium-hubble-relay-traefik
- Runs an HTTPS server that presents a self-signed server cert with a specific CN.
- Routes the hubble-relay Service to that HTTPS server.
- Verifies that a request to traefik using the expected SNI is routed to the service, and that server cert has the expected CN.
-     
**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-105953

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
This service is internal.

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
