### PR TITLE
fix: preserve user labels on flux ns during upgrades

### DIFF
--- a/hack/flux/flux-update-kustomization.yaml
+++ b/hack/flux/flux-update-kustomization.yaml
@@ -4,6 +4,15 @@ resources:
   - flux.yaml
 patches:
   - target:
+      kind: Namespace
+      name: kommander-flux
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          # Ensures that any labels to namespace are preserved if a user adds them manually.
+          kustomize.toolkit.fluxcd.io/ssa: "Merge"
+  - target:
       group: apps
       version: v1
       kind: Deployment

--- a/services/kommander-flux/2.4.0/templates/v1_namespace_kommander-flux.yaml
+++ b/services/kommander-flux/2.4.0/templates/v1_namespace_kommander-flux.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: Merge
   labels:
     app.kubernetes.io/instance: kommander-flux
     app.kubernetes.io/part-of: flux


### PR DESCRIPTION
**What problem does this PR solve?**:

Whenever the `flux-configuration` `Kustomization` in `kommander` namespace is reconciled, we overwrite any user given labels on flux namespace. This breaks proxied environments cuz our docs currently ask user to label flux namespace manually. We should fix this manual ask from the user in long run but until then, we should use `merge` strategy in flux ssa. 

I am not bumping the flux component version here cuz this change is only limited to adding an annotation on namespace and does not cause any restarts or such.

This was first added in https://github.com/fluxcd/kustomize-controller/blob/main/CHANGELOG.md#0220 so we can safely backport it all way back to 2.8.x (which uses a 1.x.y version of kustomize-controller)

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://jira.nutanix.com/browse/NCN-106215

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
