### PR TITLE
fix: use fluentbit image from dockerhub (#3142)

### DIFF
--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -69,7 +69,7 @@ ignore:
   - nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2
 
 resources:
-  - container_image: cr.fluentbit.io/fluent/fluent-bit:2.2.3
+  - container_image: docker.io/fluent/fluent-bit:2.2.3
     sources:
       - license_path: LICENSE
         ref: v${image_tag}

--- a/services/fluent-bit/0.43.1/defaults/cm.yaml
+++ b/services/fluent-bit/0.43.1/defaults/cm.yaml
@@ -8,6 +8,8 @@ data:
     ---
     # overriding the default image tag to be consistent with logging-operator
     image:
+      # Pull from docker hub rather than cr.fluentbit.io to avoid rate limiting.
+      repository: docker.io/fluent/fluent-bit
       tag: 2.2.3
 
     priorityClassName: "dkp-critical-priority"

--- a/services/logging-operator/4.2.5/defaults/cm.yaml
+++ b/services/logging-operator/4.2.5/defaults/cm.yaml
@@ -111,7 +111,7 @@ data:
       image:
         # Explicitly specify the version here. This should be updated when logging-operator is upgraded.
         # Also, update the image in fluent-bit configuration if the image is upgraded here.
-        repository: fluent/fluent-bit
+        repository: docker.io/fluent/fluent-bit
         tag: 2.2.3
       resources:
        limits:


### PR DESCRIPTION
**What problem does this PR solve?**:
Use docker directly to pull fluentbit images.

backport of https://github.com/mesosphere/kommander-applications/pull/3142

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
