### PR TITLE
fix(thanos): Set resources

### DIFF
--- a/services/thanos/15.7.24/defaults/cm.yaml
+++ b/services/thanos/15.7.24/defaults/cm.yaml
@@ -26,6 +26,13 @@ data:
       enabled: false
     query:
       priorityClassName: "dkp-critical-priority"
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1024Mi
+        limits:
+          cpu: 750m
+          memory: 1536Mi
       # Enable DNS discovery for stores
       dnsDiscovery:
         enabled: false


### PR DESCRIPTION
**What problem does this PR solve?**:
At some point, new resource presets field was introduced and set to "nano" by default
```
  "nano" (dict 
      "requests" (dict "cpu" "100m" "memory" "128Mi" "ephemeral-storage" "50Mi")
      "limits" (dict "cpu" "150m" "memory" "192Mi" "ephemeral-storage" "2Gi")
   )
```
https://github.com/bitnami/charts/blob/bbe546947f67cd71da25fafbf7920b888b93e8cd/bitnami/thanos/values.yaml#L265-L281

These presets are not meant to be used in production and we should be setting our own resource values.
https://github.com/bitnami/charts/blob/52607faf0d32ed0c7741b0fc224863596fcdc271/bitnami/common/templates/_resources.tpl#L28-L31

Looking at the usage in the ticket and also at the presets, I think we can go with the "medium" values, which I have used for our default resources config here.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-106195

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
