### PR TITLE
fix(kps): Missing node-exporter rbac proxy rule

### DIFF
--- a/services/kube-prometheus-stack/48.3.3/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/48.3.3/defaults/cm.yaml
@@ -43,6 +43,12 @@ data:
           - name: grpc
             port: 10901
             targetPort: grpc
+      additionalRulesForClusterRole:
+        # see https://github.com/prometheus-community/helm-charts/issues/3338
+        - apiGroups: [""]
+          resources:
+            - services/kube-prometheus-stack-prometheus-node-exporter
+          verbs: [ "get", "list", "watch" ]
       additionalServiceMonitors:
         # **NOTE** Any changes here need to be copied to kube-prometheus-stack-overrides.yaml
         # https://github.com/mesosphere/kommander-cli/blob/main/pkg/installer/config/manifests/kube-prometheus-stack/overrides.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:
follow up to https://github.com/mesosphere/kommander-applications/pull/2624
https://github.com/prometheus-community/helm-charts/issues/3338
Was fixed in KPS 57.1.1 https://github.com/prometheus-community/helm-charts/pull/3946 which is higher than the version of KPS in 2.8, so manually adding the rule via default values.

After applying the rule, prometheus was able to access node metrics and error disappeared from UI

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
