### PR TITLE
fix: Exclude listing nkp-pulse images in airgapped bundle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Currently the following applications are excluded from airgapped builds:
 - NKP-Pulse
 
 To exclude an application, please ensure the following files have been updated:
-- [Exclude Airgapped](exclude-airgapped)
+- [Exclude Airgapped](.exclude-airgapped)
 - [Justfile](justfile)
-- [List Images](hack/list-images)
+- [List Images](hack/list-images.sh)
 
 Please ensure PRs are tested with the label `open-kommander-pr` to ensure there aren't any downstream build breaks.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,16 @@ Due to the automation of image version bumping, the original comments were unabl
 | `docker.io/mesosphere/capimate:${kommander}`          | Note that this image is within `resources` rather than `ignore`. The `capimate` source code is in `capimate` subdirectory but it shares go.mod with main konvoy2 source code. `directory: capimate`                                                                                                                     |
 | `gcr.io/kubecost1/frontend`                           | Partnership                                                                                                                                                                                                                                                                                                             |
 | `gcr.io/kubecost1/cost-model`                         | Partnership                                                                                                                                                                                                                                                                                                             |
+
+### Airgapped Build Exclusions
+
+Currently the following applications are excluded from airgapped builds:
+- AI-Navigator
+- NKP-Pulse
+
+To exclude an application, please ensure the following files have been updated:
+- [Exclude Airgapped](exclude-airgapped)
+- [Justfile](justfile)
+- [List Images](hack/list-images)
+
+Please ensure PRs are tested with the label `open-kommander-pr` to ensure there aren't any downstream build breaks.

--- a/hack/list-images.sh
+++ b/hack/list-images.sh
@@ -201,5 +201,6 @@ sed --expression='s|^docker.io/||' \
     --expression='s|\(^[^:]\+:\?$\)|\1:latest|' \
     --expression='/^[[:space:]]*$/d' \
     --expression='/ai-navigator-/d' \
+    --expression='/nkp-pulse-/d' \
     "${IMAGES_FILE}" | \
   sort --unique

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -224,14 +224,6 @@ resources:
     sources:
       - ref: ${image_tag}
         url: https://github.com/mesosphere/kubetunnel
-  - container_image: pullthrough.infra.nkp.sh/mesosphere/nkp-pulse-management:v0.2.6
-    sources:
-      - ref: ${image_tag}
-        url: https://github.com/mesosphere/nkp-pulse
-  - container_image: pullthrough.infra.nkp.sh/mesosphere/nkp-pulse-workspace:v0.2.6
-    sources:
-      - ref: ${image_tag}
-        url: https://github.com/mesosphere/nkp-pulse
   - container_image: docker.io/mesosphere/traefik-forward-auth:v3.2.1
     sources:
       - license_path: LICENSE.thomseddon.md


### PR DESCRIPTION
**What problem does this PR solve?**:

Fixes issues occurring in Kommander E2E airgapped tests. NKP-Pulse isn't supported in air-gapped environments.

**Which issue(s) does this PR fix?**:
[Slack Thread](https://nutanix.slack.com/archives/C06AQ8T3AHW/p1744201209246309)

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
