### PR TITLE
chore: Disallow NKP-Pulse for D2iQ Licenses

### DIFF
--- a/services/nkp-pulse-management/metadata.yaml
+++ b/services/nkp-pulse-management/metadata.yaml
@@ -5,5 +5,4 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essential
-  - Enterprise
+# NKP-Pulse is not supported on D2iQ Licenses.

--- a/services/nkp-pulse-workspace/metadata.yaml
+++ b/services/nkp-pulse-workspace/metadata.yaml
@@ -5,5 +5,4 @@ licensing:
   - Starter
   - Pro
   - Ultimate
-  - Essential
-  - Enterprise
+# NKP-Pulse is not supported on D2iQ Licenses.


### PR DESCRIPTION
**What problem does this PR solve?**:

NKP-Pulse only supports Nutanix Licenses (`Starter`, `Pro`, `Ultimate`). Disallow enabling of Pulse for D2iQ Licenses (`Essential`, `Enterprise`)

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:

The Nutanix SaaS Pulse Endpoint must be able to associate data that is received to a known customer. This involves doing a join of the cluster-id sending the data with a customer in the Nutanix Salesforce database. D2iQ based licenses aren't part of this Salesforce database and hence this data will get dropped by the Pulse Endpoint. As such we won't enable Pulse with D2iQ Licenses.

<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
