### PR TITLE
feat: Extend Kubestate metrics for CRDs and custom prometheus rules

### DIFF
--- a/services/kube-prometheus-stack/70.4.2/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/70.4.2/defaults/cm.yaml
@@ -293,6 +293,63 @@ data:
       enabled: false
     kubeScheduler:
       enabled: false
+    additionalPrometheusRulesMap:
+      auto-renewal-certificate-alerts:
+        groups:
+          - name: AutoRenewalCertificateAlerts
+            rules:
+              - alert: CertificateExpiringSoon
+                expr: |
+                  (min by(namespace) (
+                    kube_customresource_machine_cert_expiry_days
+                  ) - time()) / 86400 > 1 + scalar(kube_customresource_rollout_trigger_days_before_cert_expiry)
+                  and
+                  (min by(namespace) (
+                  kube_customresource_machine_cert_expiry_days
+                  ) - time()) / 86400 <= 7 + scalar(kube_customresource_rollout_trigger_days_before_cert_expiry)
+                for: 1d
+                labels:
+                  severity: warning
+                annotations:
+                  summary: "Certificate expiring soon"
+                  description: "Certificate will expire in less than 7 days"
+              - alert: CertificateRollingOutSoon
+                expr: |
+                  (min by(namespace) (
+                    kube_customresource_machine_cert_expiry_days
+                  ) - time()) / 86400 >= 1 + scalar(kube_customresource_rollout_trigger_days_before_cert_expiry)
+                  and
+                  (min by(namespace) (
+                  kube_customresource_machine_cert_expiry_days
+                  ) - time()) / 86400 < 0 + scalar(kube_customresource_rollout_trigger_days_before_cert_expiry)
+                for: 1d
+                labels:
+                  severity: info
+                annotations:
+                  summary: "Certificate rolling out soon"
+                  description: "Certificate will expire within a day, rollout is expected"
+              - alert: CertificateExpired
+                expr: |
+                  (min by(namespace) (
+                    kube_customresource_machine_cert_expiry_days
+                  ) - time()) / 86400 < 0.1
+                for: 1m
+                labels:
+                  severity: critical
+                annotations:
+                  summary: "Certificate renewal failed"
+                  description: "Certificate has expired and was not renewed"
+              - alert: CertificateRenewed
+                expr: |
+                  (min by(namespace) (
+                    kube_customresource_machine_cert_expiry_days
+                  ) - time()) / 86400 == 365
+                for: 1d
+                labels:
+                  severity: info
+                annotations:
+                  summary: "Certificate renewed successfully"
+                  description: "Certificate has been renewed successfully"
     alertmanager:
       enabled: true
       config:

--- a/services/kube-prometheus-stack/70.4.2/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/70.4.2/defaults/cm.yaml
@@ -448,6 +448,48 @@ data:
       metricLabelsAllowlist:
         - pods=[*]
         - namespaces=[*]
+      rbac:
+        extraRules:
+          - apiGroups: [ "cluster.x-k8s.io" ]
+            resources: ["machines"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["controlplane.cluster.x-k8s.io"]
+            resources: ["kubeadmcontrolplanes"]
+            verbs: ["get", "list", "watch"]
+      customResourceState:
+        enabled: true
+        config:
+          kind: CustomResourceStateMetrics
+          spec:
+            resources:
+              - groupVersionKind:
+                  group: controlplane.cluster.x-k8s.io
+                  version: v1beta1
+                  kind: KubeadmControlPlane
+                labelsFromPath:
+                  kubeadmcontrolplane: ["metadata", "name"]
+                  namespace: ["metadata", "namespace"]
+                metrics:
+                  - name: rollout_trigger_days_before_cert_expiry
+                    help: "Number of days before certificate expiry when a rollout is triggered"
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: ["spec", "rolloutBefore", "certificatesExpiryDays"]
+              - groupVersionKind:
+                  group: cluster.x-k8s.io
+                  version: v1beta1
+                  kind: Machine
+                labelsFromPath:
+                  machine: ["metadata", "name"]
+                  namespace: ["metadata", "namespace"]
+                metrics:
+                  - name: machine_cert_expiry_days
+                    help: "Number of days until the certificate associated with the Machine expires"
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: ["metadata", "annotations", "machine.cluster.x-k8s.io/certificates-expiry"]
       prometheus:
         monitor:
           additionalLabels:


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-107084
https://jira.nutanix.com/browse/NCN-107085


**Special notes for your reviewer**:
Metrics like machine_cert_expiry_days and rollout_trigger_days_before_cert_expiry are exposed by extending kube-state-metrics via the customResourceState config.

Alerting Rules Implemented:
CertificateExpiringSoon: Triggers when certificate expiry is within 1 and 7 days
CertificateRollingOutSoon: Triggers if expiry is exactly 1 day away and rollout threshold is met.
CertificateRolledOut: Triggers when the certificate is successfully renewed (e.g., 365 days left).
CertificateExpired: Triggers if expiry date has passed (i.e., less than 0 days remaining).



