### PR TITLE
feat: enable persistence for grafana

### DIFF
--- a/services/kube-prometheus-stack/70.4.2/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/70.4.2/defaults/cm.yaml
@@ -341,6 +341,13 @@ data:
       enabled: true
       defaultDashboardsEnabled: true
       priorityClassName: "dkp-critical-priority"
+      persistence:
+        enabled: true
+      initChownData:
+        image:
+          registry: docker.io
+          repository: library/busybox
+          tag: "1"
       image:
         registry: docker.io
         repository: grafana/grafana


### PR DESCRIPTION
**What problem does this PR solve?**:

Many customers have complained that after an upgrade, they have lost their custom Grafana dashboards or customized configurations. 

This PR enables persistence for the Grafana app using the default settings.