### PR TITLE
refactor: Appscenerio interface add 2 new methods

### DIFF
--- a/apptests/appscenarios/appscenarios.go
+++ b/apptests/appscenarios/appscenarios.go
@@ -16,6 +16,8 @@ import (
 	"github.com/mesosphere/kommander-applications/apptests/environment"
 )
 
+var upgradeKAppsRepoPath string
+
 // AppScenario defines the behavior and name of an application test scenario
 type AppScenario interface {
 	Name() string                                    // scenario name

--- a/apptests/appscenarios/appscenarios.go
+++ b/apptests/appscenarios/appscenarios.go
@@ -18,8 +18,10 @@ import (
 
 // AppScenario defines the behavior and name of an application test scenario
 type AppScenario interface {
-	Install(context.Context, *environment.Env) error // logic implemented by a scenario
 	Name() string                                    // scenario name
+	Install(context.Context, *environment.Env) error // logic implemented by a scenario
+	InstallPreviousVersion(ctx context.Context, env *environment.Env) error
+	Upgrade(ctx context.Context, env *environment.Env) error
 }
 
 // absolutePathTo returns the absolute path to the given application directory.

--- a/apptests/appscenarios/ciliumhubblerelaytraefik.go
+++ b/apptests/appscenarios/ciliumhubblerelaytraefik.go
@@ -2,6 +2,7 @@ package appscenarios
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	"github.com/mesosphere/kommander-applications/apptests/constants"
@@ -69,4 +70,8 @@ func (c ciliumHubbleRelayTraefik) install(ctx context.Context, env *environment.
 	}
 
 	return err
+}
+
+func (c ciliumHubbleRelayTraefik) Upgrade(ctx context.Context, env *environment.Env) error {
+	return fmt.Errorf("upgrade is not yet implemented")
 }

--- a/apptests/appscenarios/gatekeeper.go
+++ b/apptests/appscenarios/gatekeeper.go
@@ -2,6 +2,7 @@ package appscenarios
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"time"
 
@@ -113,4 +114,8 @@ func (g gatekeeper) install(ctx context.Context, env *environment.Env, appPath s
 	err = env.ApplyYAML(ctx, filepath.Join(appPath, "/constraints/enforce-kustomization-sa.yaml"), substMap)
 
 	return err
+}
+
+func (g gatekeeper) Upgrade(ctx context.Context, env *environment.Env) error {
+	return fmt.Errorf("upgrade is not yet implemented")
 }

--- a/apptests/appscenarios/karma.go
+++ b/apptests/appscenarios/karma.go
@@ -2,6 +2,7 @@ package appscenarios
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	"github.com/mesosphere/kommander-applications/apptests/constants"
@@ -69,4 +70,8 @@ func (k karma) install(ctx context.Context, env *environment.Env, appPath string
 	}
 
 	return err
+}
+
+func (k karma) Upgrade(ctx context.Context, env *environment.Env) error {
+	return fmt.Errorf("upgrade is not yet implemented")
 }

--- a/apptests/appscenarios/reloader.go
+++ b/apptests/appscenarios/reloader.go
@@ -2,6 +2,7 @@ package appscenarios
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	"github.com/mesosphere/kommander-applications/apptests/constants"
@@ -98,4 +99,8 @@ func (r reloader) ApplyNginxDeployment(ctx context.Context, env *environment.Env
 	}
 
 	return nil
+}
+
+func (r reloader) Upgrade(ctx context.Context, env *environment.Env) error {
+	return fmt.Errorf("upgrade is not yet implemented")
 }

--- a/apptests/appscenarios/suite_test.go
+++ b/apptests/appscenarios/suite_test.go
@@ -25,7 +25,6 @@ var (
 	network              *docker.NetworkResource
 	k8sClient            genericClient.Client
 	restClientV1Pods     rest.Interface
-	upgradeKAppsRepoPath string
 )
 
 var _ = BeforeSuite(func() {

--- a/apptests/appscenarios/traefik.go
+++ b/apptests/appscenarios/traefik.go
@@ -120,3 +120,7 @@ func (t traefik) applyTraefikOverrideCM(ctx context.Context, env *environment.En
 
 	return nil
 }
+
+func (t traefik) Upgrade(ctx context.Context, env *environment.Env) error {
+	return fmt.Errorf("upgrade is not yet implemented")
+}


### PR DESCRIPTION
**What problem does this PR solve?**:
adding methods to interface to be used by other modules

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
