### PR TITLE
refactor: move AppScenarios interface into apptests module

### DIFF
--- a/apptests/appscenarios/appscenarios.go
+++ b/apptests/appscenarios/appscenarios.go
@@ -18,14 +18,6 @@ import (
 
 var upgradeKAppsRepoPath string
 
-// AppScenario defines the behavior and name of an application test scenario
-type AppScenario interface {
-	Name() string                                    // scenario name
-	Install(context.Context, *environment.Env) error // logic implemented by a scenario
-	InstallPreviousVersion(ctx context.Context, env *environment.Env) error
-	Upgrade(ctx context.Context, env *environment.Env) error
-}
-
 // absolutePathTo returns the absolute path to the given application directory.
 func absolutePathTo(application string) (string, error) {
 	wd, err := os.Getwd()

--- a/apptests/appscenarios/certmanager.go
+++ b/apptests/appscenarios/certmanager.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/mesosphere/kommander-applications/apptests/environment"
+	"github.com/mesosphere/kommander-applications/apptests/scenarios"
 )
 
 type certManager struct{}
@@ -13,7 +14,7 @@ func (r certManager) Name() string {
 	return "cert-manager"
 }
 
-var _ AppScenario = (*reloader)(nil)
+var _ scenarios.AppScenario = (*reloader)(nil)
 
 func (r certManager) Install(ctx context.Context, env *environment.Env) error {
 	appPath, err := absolutePathTo(r.Name())

--- a/apptests/appscenarios/ciliumhubblerelaytraefik.go
+++ b/apptests/appscenarios/ciliumhubblerelaytraefik.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mesosphere/kommander-applications/apptests/constants"
 	"github.com/mesosphere/kommander-applications/apptests/environment"
+	"github.com/mesosphere/kommander-applications/apptests/scenarios"
 )
 
 type ciliumHubbleRelayTraefik struct {
@@ -18,7 +19,7 @@ func (c ciliumHubbleRelayTraefik) Name() string {
 	return constants.CiliumHubbleRelayTraefik
 }
 
-var _ AppScenario = (*ciliumHubbleRelayTraefik)(nil)
+var _ scenarios.AppScenario = (*ciliumHubbleRelayTraefik)(nil)
 
 func NewCiliumHubbleRelayTraefik() *ciliumHubbleRelayTraefik {
 	appPath, _ := absolutePathTo(constants.CiliumHubbleRelayTraefik)

--- a/apptests/appscenarios/externaldns.go
+++ b/apptests/appscenarios/externaldns.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/mesosphere/kommander-applications/apptests/constants"
 	"github.com/mesosphere/kommander-applications/apptests/environment"
+	"github.com/mesosphere/kommander-applications/apptests/scenarios"
 )
 
 type externalDns struct{}
@@ -14,7 +15,7 @@ func (r externalDns) Name() string {
 	return constants.ExternalDns
 }
 
-var _ AppScenario = (*reloader)(nil)
+var _ scenarios.AppScenario = (*reloader)(nil)
 
 func (r externalDns) Install(ctx context.Context, env *environment.Env) error {
 	appPath, err := absolutePathTo(r.Name())

--- a/apptests/appscenarios/gatekeeper.go
+++ b/apptests/appscenarios/gatekeeper.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mesosphere/kommander-applications/apptests/constants"
 	"github.com/mesosphere/kommander-applications/apptests/environment"
 	"github.com/mesosphere/kommander-applications/apptests/flux"
+	"github.com/mesosphere/kommander-applications/apptests/scenarios"
 )
 
 type gatekeeper struct {
@@ -23,7 +24,7 @@ type gatekeeper struct {
 	appPathPreviousVersion string
 }
 
-var _ AppScenario = (*gatekeeper)(nil)
+var _ scenarios.AppScenario = (*gatekeeper)(nil)
 
 func setupGatekeeperSchema(env *environment.Env) error {
 	scheme := flux.NewScheme()

--- a/apptests/appscenarios/karma.go
+++ b/apptests/appscenarios/karma.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mesosphere/kommander-applications/apptests/constants"
 	"github.com/mesosphere/kommander-applications/apptests/environment"
+	"github.com/mesosphere/kommander-applications/apptests/scenarios"
 )
 
 type karma struct {
@@ -18,7 +19,7 @@ func (k karma) Name() string {
 	return constants.Karma
 }
 
-var _ AppScenario = (*karma)(nil)
+var _ scenarios.AppScenario = (*karma)(nil)
 
 func NewKarma() *karma {
 	appPath, _ := absolutePathTo(constants.Karma)

--- a/apptests/appscenarios/kommanderflux.go
+++ b/apptests/appscenarios/kommanderflux.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/mesosphere/kommander-applications/apptests/constants"
 	"github.com/mesosphere/kommander-applications/apptests/environment"
+	"github.com/mesosphere/kommander-applications/apptests/scenarios"
 )
 
 type kommanderFlux struct{}
@@ -14,7 +15,7 @@ func (r kommanderFlux) Name() string {
 	return constants.Flux
 }
 
-var _ AppScenario = (*reloader)(nil)
+var _ scenarios.AppScenario = (*reloader)(nil)
 
 func (r kommanderFlux) Install(ctx context.Context, env *environment.Env) error {
 	appPath, err := absolutePathTo(r.Name())

--- a/apptests/appscenarios/kubecost.go
+++ b/apptests/appscenarios/kubecost.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mesosphere/kommander-applications/apptests/constants"
 	"github.com/mesosphere/kommander-applications/apptests/environment"
+	"github.com/mesosphere/kommander-applications/apptests/scenarios"
 )
 
 type kubeCost struct{}
@@ -19,7 +20,7 @@ func (r kubeCost) Name() string {
 	return constants.KubeCost
 }
 
-var _ AppScenario = (*reloader)(nil)
+var _ scenarios.AppScenario = (*reloader)(nil)
 
 func (r kubeCost) Install(ctx context.Context, env *environment.Env) error {
 	appPath, err := absolutePathTo(r.Name())

--- a/apptests/appscenarios/reloader.go
+++ b/apptests/appscenarios/reloader.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mesosphere/kommander-applications/apptests/constants"
 	"github.com/mesosphere/kommander-applications/apptests/environment"
+	"github.com/mesosphere/kommander-applications/apptests/scenarios"
 )
 
 type reloader struct {
@@ -18,7 +19,7 @@ func (r reloader) Name() string {
 	return constants.Reloader
 }
 
-var _ AppScenario = (*reloader)(nil)
+var _ scenarios.AppScenario = (*reloader)(nil)
 
 var nginxCMName = "nginx-config"
 

--- a/apptests/appscenarios/rookceph.go
+++ b/apptests/appscenarios/rookceph.go
@@ -6,11 +6,13 @@ import (
 	"path/filepath"
 
 	fluxhelmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/mesosphere/kommander-applications/apptests/constants"
 	"github.com/mesosphere/kommander-applications/apptests/environment"
 	"github.com/mesosphere/kommander-applications/apptests/flux"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/mesosphere/kommander-applications/apptests/scenarios"
 )
 
 type rookCeph struct{}
@@ -19,7 +21,7 @@ func (r rookCeph) Name() string {
 	return constants.RookCeph
 }
 
-var _ AppScenario = (*reloader)(nil)
+var _ scenarios.AppScenario = (*reloader)(nil)
 
 func (r rookCeph) Install(ctx context.Context, env *environment.Env) error {
 	appPath, err := absolutePathTo(r.Name())

--- a/apptests/appscenarios/traefik.go
+++ b/apptests/appscenarios/traefik.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mesosphere/kommander-applications/apptests/constants"
 	"github.com/mesosphere/kommander-applications/apptests/environment"
 	"github.com/mesosphere/kommander-applications/apptests/flux"
+	"github.com/mesosphere/kommander-applications/apptests/scenarios"
 )
 
 type traefik struct {
@@ -23,7 +24,7 @@ func (t traefik) Name() string {
 	return constants.Traefik
 }
 
-var _ AppScenario = (*traefik)(nil)
+var _ scenarios.AppScenario = (*traefik)(nil)
 
 func NewTraefik() *traefik {
 	appPath, _ := absolutePathTo(constants.Traefik)

--- a/apptests/appscenarios/velero.go
+++ b/apptests/appscenarios/velero.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mesosphere/kommander-applications/apptests/constants"
 	"github.com/mesosphere/kommander-applications/apptests/environment"
+	"github.com/mesosphere/kommander-applications/apptests/scenarios"
 )
 
 type velero struct{}
@@ -15,7 +16,7 @@ func (v velero) Name() string {
 	return constants.Velero
 }
 
-var _ AppScenario = (*reloader)(nil)
+var _ scenarios.AppScenario = (*reloader)(nil)
 
 func (v velero) Install(ctx context.Context, env *environment.Env) error {
 	appPath, err := absolutePathTo(v.Name())

--- a/apptests/scenarios/suite.go
+++ b/apptests/scenarios/suite.go
@@ -1,0 +1,15 @@
+package scenarios
+
+import (
+	"context"
+
+	"github.com/mesosphere/kommander-applications/apptests/environment"
+)
+
+// AppScenario defines the behavior and name of an application test scenario
+type AppScenario interface {
+	Name() string                                    // scenario name
+	Install(context.Context, *environment.Env) error // logic implemented by a scenario
+	InstallPreviousVersion(ctx context.Context, env *environment.Env) error
+	Upgrade(ctx context.Context, env *environment.Env) error
+}


### PR DESCRIPTION
**What problem does this PR solve?**:

Doing this allows us to use the interface in downstream catalog repositories.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
