### PR TITLE
refactor: rename d2iq defaults cm

### DIFF
--- a/hack/flux/update-flux.sh
+++ b/hack/flux/update-flux.sh
@@ -42,7 +42,7 @@ function update_flux() {
     cp "$REPO_ROOT"/hack/flux/templates/* templates/
     kustomize build --output templates templates
     rm templates/flux.yaml templates/kustomization.yaml
-    yq e -i ".metadata.name=\"kommander-flux-$LATEST_FLUX_VERSION-d2iq-defaults\"" defaults/cm.yaml
+    yq e -i ".metadata.name=\"kommander-flux-$LATEST_FLUX_VERSION-nkp-defaults\"" defaults/cm.yaml
     pushd "templates"
     kustomize create --autodetect
     popd && popd

--- a/hack/flux/update-flux.sh
+++ b/hack/flux/update-flux.sh
@@ -42,7 +42,7 @@ function update_flux() {
     cp "$REPO_ROOT"/hack/flux/templates/* templates/
     kustomize build --output templates templates
     rm templates/flux.yaml templates/kustomization.yaml
-    yq e -i ".metadata.name=\"kommander-flux-$LATEST_FLUX_VERSION-nkp-defaults\"" defaults/cm.yaml
+    yq e -i ".metadata.name=\"kommander-flux-$LATEST_FLUX_VERSION-config-defaults\"" defaults/cm.yaml
     pushd "templates"
     kustomize create --autodetect
     popd && popd

--- a/hack/release/pkg/appversion/appversion.go
+++ b/hack/release/pkg/appversion/appversion.go
@@ -21,12 +21,12 @@ import (
 var (
 	ErrVersionNotFound = errors.New("cannot detect existing kommander app version")
 
-	// kommander-0.4.0-nkp-defaults
+	// kommander-0.4.0-config-defaults
 	// kommander-0.4.0-overrides
 	varNames = regexp.MustCompile(
 		`(?P<prefix>kommander(-appmanagement)?-)` +
 			constants.SemverRegexp +
-			`(?P<suffix>(-nkp-defaults)|(-overrides))`,
+			`(?P<suffix>(-config-defaults)|(-overrides))`,
 	)
 )
 

--- a/hack/release/pkg/appversion/appversion.go
+++ b/hack/release/pkg/appversion/appversion.go
@@ -21,12 +21,12 @@ import (
 var (
 	ErrVersionNotFound = errors.New("cannot detect existing kommander app version")
 
-	// kommander-0.4.0-d2iq-defaults
+	// kommander-0.4.0-nkp-defaults
 	// kommander-0.4.0-overrides
 	varNames = regexp.MustCompile(
 		`(?P<prefix>kommander(-appmanagement)?-)` +
 			constants.SemverRegexp +
-			`(?P<suffix>(-d2iq-defaults)|(-overrides))`,
+			`(?P<suffix>(-nkp-defaults)|(-overrides))`,
 	)
 )
 

--- a/hack/release/pkg/appversion/appversion_test.go
+++ b/hack/release/pkg/appversion/appversion_test.go
@@ -53,9 +53,9 @@ func TestRegexps(t *testing.T) {
 		suffix string
 	}{
 		{
-			input:  "kommander-0.4.0-d2iq-defaults",
+			input:  "kommander-0.4.0-nkp-defaults",
 			prefix: "kommander-",
-			suffix: "-d2iq-defaults",
+			suffix: "-nkp-defaults",
 		},
 		{
 			input:  "kommander-0.4.0-overrides",
@@ -63,9 +63,9 @@ func TestRegexps(t *testing.T) {
 			suffix: "-overrides",
 		},
 		{
-			input:  "kommander-appmanagement-0.4.0-d2iq-defaults",
+			input:  "kommander-appmanagement-0.4.0-nkp-defaults",
 			prefix: "kommander-appmanagement-",
-			suffix: "-d2iq-defaults",
+			suffix: "-nkp-defaults",
 		},
 	}
 

--- a/hack/release/pkg/appversion/appversion_test.go
+++ b/hack/release/pkg/appversion/appversion_test.go
@@ -53,9 +53,9 @@ func TestRegexps(t *testing.T) {
 		suffix string
 	}{
 		{
-			input:  "kommander-0.4.0-nkp-defaults",
+			input:  "kommander-0.4.0-config-defaults",
 			prefix: "kommander-",
-			suffix: "-nkp-defaults",
+			suffix: "-config-defaults",
 		},
 		{
 			input:  "kommander-0.4.0-overrides",
@@ -63,9 +63,9 @@ func TestRegexps(t *testing.T) {
 			suffix: "-overrides",
 		},
 		{
-			input:  "kommander-appmanagement-0.4.0-nkp-defaults",
+			input:  "kommander-appmanagement-0.4.0-config-defaults",
 			prefix: "kommander-appmanagement-",
-			suffix: "-nkp-defaults",
+			suffix: "-config-defaults",
 		},
 	}
 

--- a/services/ai-navigator-app/0.2.10/defaults/cm.yaml
+++ b/services/ai-navigator-app/0.2.10/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ai-navigator-app-0.2.10-d2iq-defaults
+  name: ai-navigator-app-0.2.10-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/ai-navigator-app/0.2.10/defaults/cm.yaml
+++ b/services/ai-navigator-app/0.2.10/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ai-navigator-app-0.2.10-nkp-defaults
+  name: ai-navigator-app-0.2.10-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/ai-navigator-app/0.2.10/helmrelease/helmrelease.yaml
+++ b/services/ai-navigator-app/0.2.10/helmrelease/helmrelease.yaml
@@ -23,4 +23,4 @@ spec:
       retries: 30
   valuesFrom:
     - kind: ConfigMap
-      name: ai-navigator-app-0.2.10-nkp-defaults
+      name: ai-navigator-app-0.2.10-config-defaults

--- a/services/ai-navigator-app/0.2.10/helmrelease/helmrelease.yaml
+++ b/services/ai-navigator-app/0.2.10/helmrelease/helmrelease.yaml
@@ -23,4 +23,4 @@ spec:
       retries: 30
   valuesFrom:
     - kind: ConfigMap
-      name: ai-navigator-app-0.2.10-d2iq-defaults
+      name: ai-navigator-app-0.2.10-nkp-defaults

--- a/services/ai-navigator-cluster-info-agent/0.1.3/defaults/cm.yaml
+++ b/services/ai-navigator-cluster-info-agent/0.1.3/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ai-navigator-cluster-info-agent-0.1.3-d2iq-defaults
+  name: ai-navigator-cluster-info-agent-0.1.3-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/ai-navigator-cluster-info-agent/0.1.3/defaults/cm.yaml
+++ b/services/ai-navigator-cluster-info-agent/0.1.3/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ai-navigator-cluster-info-agent-0.1.3-nkp-defaults
+  name: ai-navigator-cluster-info-agent-0.1.3-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/ai-navigator-cluster-info-agent/0.1.3/helmrelease/helmrelease.yaml
+++ b/services/ai-navigator-cluster-info-agent/0.1.3/helmrelease/helmrelease.yaml
@@ -23,4 +23,4 @@ spec:
       retries: 30
   valuesFrom:
     - kind: ConfigMap
-      name: ai-navigator-cluster-info-agent-0.1.3-nkp-defaults
+      name: ai-navigator-cluster-info-agent-0.1.3-config-defaults

--- a/services/ai-navigator-cluster-info-agent/0.1.3/helmrelease/helmrelease.yaml
+++ b/services/ai-navigator-cluster-info-agent/0.1.3/helmrelease/helmrelease.yaml
@@ -23,4 +23,4 @@ spec:
       retries: 30
   valuesFrom:
     - kind: ConfigMap
-      name: ai-navigator-cluster-info-agent-0.1.3-d2iq-defaults
+      name: ai-navigator-cluster-info-agent-0.1.3-nkp-defaults

--- a/services/centralized-grafana/71.0.0/centralized-grafana.yaml
+++ b/services/centralized-grafana/71.0.0/centralized-grafana.yaml
@@ -25,7 +25,7 @@ spec:
   releaseName: centralized-grafana
   valuesFrom:
     - kind: ConfigMap
-      name: centralized-grafana-71.0.0-d2iq-defaults
+      name: centralized-grafana-71.0.0-config-defaults
   targetNamespace: ${releaseNamespace}
 ---
 apiVersion: v1

--- a/services/centralized-grafana/71.0.0/defaults/cm.yaml
+++ b/services/centralized-grafana/71.0.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: centralized-grafana-71.0.0-d2iq-defaults
+  name: centralized-grafana-71.0.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/cert-manager/1.16.4/defaults/cm.yaml
+++ b/services/cert-manager/1.16.4/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cert-manager-1.16.4-nkp-defaults
+  name: cert-manager-1.16.4-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/cert-manager/1.16.4/defaults/cm.yaml
+++ b/services/cert-manager/1.16.4/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cert-manager-1.16.4-d2iq-defaults
+  name: cert-manager-1.16.4-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/cert-manager/1.16.4/release/release.yaml
+++ b/services/cert-manager/1.16.4/release/release.yaml
@@ -26,7 +26,7 @@ spec:
   targetNamespace: cert-manager
   valuesFrom:
     - kind: ConfigMap
-      name: cert-manager-1.16.4-d2iq-defaults
+      name: cert-manager-1.16.4-nkp-defaults
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease

--- a/services/cert-manager/1.16.4/release/release.yaml
+++ b/services/cert-manager/1.16.4/release/release.yaml
@@ -26,7 +26,7 @@ spec:
   targetNamespace: cert-manager
   valuesFrom:
     - kind: ConfigMap
-      name: cert-manager-1.16.4-nkp-defaults
+      name: cert-manager-1.16.4-config-defaults
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease

--- a/services/chartmuseum/3.10.3/chartmuseum.yaml
+++ b/services/chartmuseum/3.10.3/chartmuseum.yaml
@@ -26,7 +26,7 @@ spec:
   targetNamespace: ${releaseNamespace}
   valuesFrom:
     - kind: ConfigMap
-      name: chartmuseum-3.10.3-d2iq-defaults
+      name: chartmuseum-3.10.3-nkp-defaults
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/services/chartmuseum/3.10.3/chartmuseum.yaml
+++ b/services/chartmuseum/3.10.3/chartmuseum.yaml
@@ -26,7 +26,7 @@ spec:
   targetNamespace: ${releaseNamespace}
   valuesFrom:
     - kind: ConfigMap
-      name: chartmuseum-3.10.3-nkp-defaults
+      name: chartmuseum-3.10.3-config-defaults
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/services/chartmuseum/3.10.3/defaults/cm.yaml
+++ b/services/chartmuseum/3.10.3/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: chartmuseum-3.10.3-nkp-defaults
+  name: chartmuseum-3.10.3-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/chartmuseum/3.10.3/defaults/cm.yaml
+++ b/services/chartmuseum/3.10.3/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: chartmuseum-3.10.3-d2iq-defaults
+  name: chartmuseum-3.10.3-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/cilium-hubble-relay-traefik/0.0.3/cilium-hubble-relay-traefik.yaml
+++ b/services/cilium-hubble-relay-traefik/0.0.3/cilium-hubble-relay-traefik.yaml
@@ -25,4 +25,4 @@ spec:
   releaseName: cilium-hubble-relay-traefik
   valuesFrom:
     - kind: ConfigMap
-      name: cilium-hubble-relay-traefik-0.0.3-nkp-defaults
+      name: cilium-hubble-relay-traefik-0.0.3-config-defaults

--- a/services/cilium-hubble-relay-traefik/0.0.3/cilium-hubble-relay-traefik.yaml
+++ b/services/cilium-hubble-relay-traefik/0.0.3/cilium-hubble-relay-traefik.yaml
@@ -25,4 +25,4 @@ spec:
   releaseName: cilium-hubble-relay-traefik
   valuesFrom:
     - kind: ConfigMap
-      name: cilium-hubble-relay-traefik-0.0.3-d2iq-defaults
+      name: cilium-hubble-relay-traefik-0.0.3-nkp-defaults

--- a/services/cilium-hubble-relay-traefik/0.0.3/defaults/cm.yaml
+++ b/services/cilium-hubble-relay-traefik/0.0.3/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cilium-hubble-relay-traefik-0.0.3-d2iq-defaults
+  name: cilium-hubble-relay-traefik-0.0.3-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/cilium-hubble-relay-traefik/0.0.3/defaults/cm.yaml
+++ b/services/cilium-hubble-relay-traefik/0.0.3/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cilium-hubble-relay-traefik-0.0.3-nkp-defaults
+  name: cilium-hubble-relay-traefik-0.0.3-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/cloudnative-pg/0.23.2/cloudnative-pg.yaml
+++ b/services/cloudnative-pg/0.23.2/cloudnative-pg.yaml
@@ -24,5 +24,5 @@ spec:
   releaseName: cloudnative-pg
   valuesFrom:
     - kind: ConfigMap
-      name: cloudnative-pg-0.23.2-d2iq-defaults
+      name: cloudnative-pg-0.23.2-nkp-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/cloudnative-pg/0.23.2/cloudnative-pg.yaml
+++ b/services/cloudnative-pg/0.23.2/cloudnative-pg.yaml
@@ -24,5 +24,5 @@ spec:
   releaseName: cloudnative-pg
   valuesFrom:
     - kind: ConfigMap
-      name: cloudnative-pg-0.23.2-nkp-defaults
+      name: cloudnative-pg-0.23.2-config-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/cloudnative-pg/0.23.2/defaults/cm.yaml
+++ b/services/cloudnative-pg/0.23.2/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cloudnative-pg-0.23.2-d2iq-defaults
+  name: cloudnative-pg-0.23.2-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/cloudnative-pg/0.23.2/defaults/cm.yaml
+++ b/services/cloudnative-pg/0.23.2/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cloudnative-pg-0.23.2-nkp-defaults
+  name: cloudnative-pg-0.23.2-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/cosi-driver-nutanix/0.4.0/cosi-driver-nutanix.yaml
+++ b/services/cosi-driver-nutanix/0.4.0/cosi-driver-nutanix.yaml
@@ -25,7 +25,7 @@ spec:
   releaseName: cosi-driver-nutanix
   valuesFrom:
     - kind: ConfigMap
-      name: cosi-driver-nutanix-0.4.0-nkp-defaults
+      name: cosi-driver-nutanix-0.4.0-config-defaults
   targetNamespace: ${releaseNamespace}
   postRenderers:
     - kustomize:

--- a/services/cosi-driver-nutanix/0.4.0/cosi-driver-nutanix.yaml
+++ b/services/cosi-driver-nutanix/0.4.0/cosi-driver-nutanix.yaml
@@ -25,7 +25,7 @@ spec:
   releaseName: cosi-driver-nutanix
   valuesFrom:
     - kind: ConfigMap
-      name: cosi-driver-nutanix-0.4.0-d2iq-defaults
+      name: cosi-driver-nutanix-0.4.0-nkp-defaults
   targetNamespace: ${releaseNamespace}
   postRenderers:
     - kustomize:

--- a/services/cosi-driver-nutanix/0.4.0/cosi-resources-nutanix.yaml
+++ b/services/cosi-driver-nutanix/0.4.0/cosi-resources-nutanix.yaml
@@ -30,7 +30,7 @@ spec:
   targetNamespace: ${releaseNamespace}
   valuesFrom:
     - kind: ConfigMap
-      name: cosi-driver-nutanix-0.4.0-d2iq-defaults
+      name: cosi-driver-nutanix-0.4.0-nkp-defaults
       valuesKey: cosi-bucket-kit-values.yaml
     - kind: ConfigMap
       name: cosi-driver-nutanix-overrides

--- a/services/cosi-driver-nutanix/0.4.0/cosi-resources-nutanix.yaml
+++ b/services/cosi-driver-nutanix/0.4.0/cosi-resources-nutanix.yaml
@@ -30,7 +30,7 @@ spec:
   targetNamespace: ${releaseNamespace}
   valuesFrom:
     - kind: ConfigMap
-      name: cosi-driver-nutanix-0.4.0-nkp-defaults
+      name: cosi-driver-nutanix-0.4.0-config-defaults
       valuesKey: cosi-bucket-kit-values.yaml
     - kind: ConfigMap
       name: cosi-driver-nutanix-overrides

--- a/services/cosi-driver-nutanix/0.4.0/defaults/cm.yaml
+++ b/services/cosi-driver-nutanix/0.4.0/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cosi-driver-nutanix-0.4.0-d2iq-defaults
+  name: cosi-driver-nutanix-0.4.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/cosi-driver-nutanix/0.4.0/defaults/cm.yaml
+++ b/services/cosi-driver-nutanix/0.4.0/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cosi-driver-nutanix-0.4.0-nkp-defaults
+  name: cosi-driver-nutanix-0.4.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/dex-k8s-authenticator/1.4.5/defaults/cm.yaml
+++ b/services/dex-k8s-authenticator/1.4.5/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: dex-k8s-authenticator-1.4.5-nkp-defaults
+  name: dex-k8s-authenticator-1.4.5-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/dex-k8s-authenticator/1.4.5/defaults/cm.yaml
+++ b/services/dex-k8s-authenticator/1.4.5/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: dex-k8s-authenticator-1.4.5-d2iq-defaults
+  name: dex-k8s-authenticator-1.4.5-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/dex-k8s-authenticator/1.4.5/dex-k8s-authenticator.yaml
+++ b/services/dex-k8s-authenticator/1.4.5/dex-k8s-authenticator.yaml
@@ -34,7 +34,7 @@ spec:
   releaseName: dex-k8s-authenticator
   valuesFrom:
     - kind: ConfigMap
-      name: dex-k8s-authenticator-1.4.5-nkp-defaults
+      name: dex-k8s-authenticator-1.4.5-config-defaults
     - kind: ConfigMap
       name: dex-k8s-authenticator-overrides
       optional: true

--- a/services/dex-k8s-authenticator/1.4.5/dex-k8s-authenticator.yaml
+++ b/services/dex-k8s-authenticator/1.4.5/dex-k8s-authenticator.yaml
@@ -34,7 +34,7 @@ spec:
   releaseName: dex-k8s-authenticator
   valuesFrom:
     - kind: ConfigMap
-      name: dex-k8s-authenticator-1.4.5-d2iq-defaults
+      name: dex-k8s-authenticator-1.4.5-nkp-defaults
     - kind: ConfigMap
       name: dex-k8s-authenticator-overrides
       optional: true

--- a/services/dex/2.14.2/defaults/cm.yaml
+++ b/services/dex/2.14.2/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: dex-2.14.2-nkp-defaults
+  name: dex-2.14.2-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/dex/2.14.2/defaults/cm.yaml
+++ b/services/dex/2.14.2/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: dex-2.14.2-d2iq-defaults
+  name: dex-2.14.2-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/dex/2.14.2/dex.yaml
+++ b/services/dex/2.14.2/dex.yaml
@@ -24,7 +24,7 @@ spec:
   releaseName: dex
   valuesFrom:
     - kind: ConfigMap
-      name: dex-2.14.2-d2iq-defaults
+      name: dex-2.14.2-nkp-defaults
     - kind: ConfigMap
       name: dex-overrides
       optional: true

--- a/services/dex/2.14.2/dex.yaml
+++ b/services/dex/2.14.2/dex.yaml
@@ -24,7 +24,7 @@ spec:
   releaseName: dex
   valuesFrom:
     - kind: ConfigMap
-      name: dex-2.14.2-nkp-defaults
+      name: dex-2.14.2-config-defaults
     - kind: ConfigMap
       name: dex-overrides
       optional: true

--- a/services/external-dns/8.5.0/defaults/cm.yaml
+++ b/services/external-dns/8.5.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: external-dns-8.5.0-d2iq-defaults
+  name: external-dns-8.5.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/external-dns/8.5.0/external-dns.yaml
+++ b/services/external-dns/8.5.0/external-dns.yaml
@@ -24,5 +24,5 @@ spec:
   releaseName: external-dns
   valuesFrom:
     - kind: ConfigMap
-      name: external-dns-8.5.0-d2iq-defaults
+      name: external-dns-8.5.0-config-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/fluent-bit/0.48.10/defaults/cm.yaml
+++ b/services/fluent-bit/0.48.10/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: fluent-bit-0.48.10-d2iq-defaults
+  name: fluent-bit-0.48.10-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/fluent-bit/0.48.10/defaults/cm.yaml
+++ b/services/fluent-bit/0.48.10/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: fluent-bit-0.48.10-nkp-defaults
+  name: fluent-bit-0.48.10-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/fluent-bit/0.48.10/fluent-bit.yaml
+++ b/services/fluent-bit/0.48.10/fluent-bit.yaml
@@ -27,4 +27,4 @@ spec:
   releaseName: kommander-fluent-bit
   valuesFrom:
     - kind: ConfigMap
-      name: fluent-bit-0.48.10-nkp-defaults
+      name: fluent-bit-0.48.10-config-defaults

--- a/services/fluent-bit/0.48.10/fluent-bit.yaml
+++ b/services/fluent-bit/0.48.10/fluent-bit.yaml
@@ -27,4 +27,4 @@ spec:
   releaseName: kommander-fluent-bit
   valuesFrom:
     - kind: ConfigMap
-      name: fluent-bit-0.48.10-d2iq-defaults
+      name: fluent-bit-0.48.10-nkp-defaults

--- a/services/gatekeeper/3.18.2/defaults/cm.yaml
+++ b/services/gatekeeper/3.18.2/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gatekeeper-3.18.2-nkp-defaults
+  name: gatekeeper-3.18.2-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/gatekeeper/3.18.2/defaults/cm.yaml
+++ b/services/gatekeeper/3.18.2/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gatekeeper-3.18.2-d2iq-defaults
+  name: gatekeeper-3.18.2-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/gatekeeper/3.18.2/release/release.yaml
+++ b/services/gatekeeper/3.18.2/release/release.yaml
@@ -25,7 +25,7 @@ spec:
   releaseName: kommander-gatekeeper
   valuesFrom:
     - kind: ConfigMap
-      name: gatekeeper-3.18.2-nkp-defaults
+      name: gatekeeper-3.18.2-config-defaults
     - kind: ConfigMap
       name: gatekeeper-overrides
       optional: true
@@ -88,7 +88,7 @@ spec:
   releaseName: gatekeeper-proxy-mutations
   valuesFrom:
     - kind: ConfigMap
-      name: gatekeeper-3.18.2-nkp-defaults
+      name: gatekeeper-3.18.2-config-defaults
     - kind: ConfigMap
       name: gatekeeper-overrides
       optional: true

--- a/services/gatekeeper/3.18.2/release/release.yaml
+++ b/services/gatekeeper/3.18.2/release/release.yaml
@@ -25,7 +25,7 @@ spec:
   releaseName: kommander-gatekeeper
   valuesFrom:
     - kind: ConfigMap
-      name: gatekeeper-3.18.2-d2iq-defaults
+      name: gatekeeper-3.18.2-nkp-defaults
     - kind: ConfigMap
       name: gatekeeper-overrides
       optional: true
@@ -88,7 +88,7 @@ spec:
   releaseName: gatekeeper-proxy-mutations
   valuesFrom:
     - kind: ConfigMap
-      name: gatekeeper-3.18.2-d2iq-defaults
+      name: gatekeeper-3.18.2-nkp-defaults
     - kind: ConfigMap
       name: gatekeeper-overrides
       optional: true

--- a/services/gateway-api-crds/1.6.0/defaults/cm.yaml
+++ b/services/gateway-api-crds/1.6.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gateway-api-1.6.0-d2iq-defaults
+  name: gateway-api-1.6.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/gateway-api-crds/1.6.0/defaults/cm.yaml
+++ b/services/gateway-api-crds/1.6.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gateway-api-1.6.0-nkp-defaults
+  name: gateway-api-1.6.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/gateway-api-crds/1.6.0/gateway-api-crds.yaml
+++ b/services/gateway-api-crds/1.6.0/gateway-api-crds.yaml
@@ -15,4 +15,4 @@ spec:
         namespace: kommander-flux
   valuesFrom:
     - kind: ConfigMap
-      name: gateway-api-1.6.0-d2iq-defaults
+      name: gateway-api-1.6.0-nkp-defaults

--- a/services/gateway-api-crds/1.6.0/gateway-api-crds.yaml
+++ b/services/gateway-api-crds/1.6.0/gateway-api-crds.yaml
@@ -15,4 +15,4 @@ spec:
         namespace: kommander-flux
   valuesFrom:
     - kind: ConfigMap
-      name: gateway-api-1.6.0-nkp-defaults
+      name: gateway-api-1.6.0-config-defaults

--- a/services/grafana-logging/8.15.0/defaults/cm.yaml
+++ b/services/grafana-logging/8.15.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: grafana-logging-8.15.0-d2iq-defaults
+  name: grafana-logging-8.15.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/grafana-logging/8.15.0/grafana.yaml
+++ b/services/grafana-logging/8.15.0/grafana.yaml
@@ -24,7 +24,7 @@ spec:
   releaseName: grafana-logging
   valuesFrom:
     - kind: ConfigMap
-      name: grafana-logging-8.15.0-d2iq-defaults
+      name: grafana-logging-8.15.0-config-defaults
   targetNamespace: ${releaseNamespace}
 ---
 apiVersion: v1

--- a/services/grafana-loki/0.80.3/defaults/cm.yaml
+++ b/services/grafana-loki/0.80.3/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: grafana-loki-0.80.3-nkp-defaults
+  name: grafana-loki-0.80.3-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/grafana-loki/0.80.3/defaults/cm.yaml
+++ b/services/grafana-loki/0.80.3/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: grafana-loki-0.80.3-d2iq-defaults
+  name: grafana-loki-0.80.3-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/grafana-loki/0.80.3/grafana-loki-helmrelease/grafana-loki.yaml
+++ b/services/grafana-loki/0.80.3/grafana-loki-helmrelease/grafana-loki.yaml
@@ -25,4 +25,4 @@ spec:
   releaseName: grafana-loki
   valuesFrom:
     - kind: ConfigMap
-      name: grafana-loki-0.80.3-d2iq-defaults
+      name: grafana-loki-0.80.3-nkp-defaults

--- a/services/grafana-loki/0.80.3/grafana-loki-helmrelease/grafana-loki.yaml
+++ b/services/grafana-loki/0.80.3/grafana-loki-helmrelease/grafana-loki.yaml
@@ -25,4 +25,4 @@ spec:
   releaseName: grafana-loki
   valuesFrom:
     - kind: ConfigMap
-      name: grafana-loki-0.80.3-nkp-defaults
+      name: grafana-loki-0.80.3-config-defaults

--- a/services/harbor/1.17.0/cosi-storage/cosi-bucket.yaml
+++ b/services/harbor/1.17.0/cosi-storage/cosi-bucket.yaml
@@ -27,7 +27,7 @@ spec:
   targetNamespace: ncr-system
   valuesFrom:
     - kind: ConfigMap
-      name: harbor-1.17.0-d2iq-defaults
+      name: harbor-1.17.0-nkp-defaults
       valuesKey: harbor-cosi-values.yaml
     - kind: ConfigMap
       name: harbor-config-overrides

--- a/services/harbor/1.17.0/cosi-storage/cosi-bucket.yaml
+++ b/services/harbor/1.17.0/cosi-storage/cosi-bucket.yaml
@@ -27,7 +27,7 @@ spec:
   targetNamespace: ncr-system
   valuesFrom:
     - kind: ConfigMap
-      name: harbor-1.17.0-nkp-defaults
+      name: harbor-1.17.0-config-defaults
       valuesKey: harbor-cosi-values.yaml
     - kind: ConfigMap
       name: harbor-config-overrides

--- a/services/harbor/1.17.0/database/cluster.yaml
+++ b/services/harbor/1.17.0/database/cluster.yaml
@@ -27,7 +27,7 @@ spec:
   targetNamespace: ncr-system
   valuesFrom:
     - kind: ConfigMap
-      name: harbor-database-0.2.0-d2iq-defaults
+      name: harbor-database-0.2.0-nkp-defaults
     - kind: ConfigMap
       name: harbor-database-overrides
       optional: true

--- a/services/harbor/1.17.0/database/cluster.yaml
+++ b/services/harbor/1.17.0/database/cluster.yaml
@@ -27,7 +27,7 @@ spec:
   targetNamespace: ncr-system
   valuesFrom:
     - kind: ConfigMap
-      name: harbor-database-0.2.0-nkp-defaults
+      name: harbor-database-0.2.0-config-defaults
     - kind: ConfigMap
       name: harbor-database-overrides
       optional: true

--- a/services/harbor/1.17.0/defaults/database.yaml
+++ b/services/harbor/1.17.0/defaults/database.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: harbor-database-0.2.0-nkp-defaults
+  name: harbor-database-0.2.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/harbor/1.17.0/defaults/database.yaml
+++ b/services/harbor/1.17.0/defaults/database.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: harbor-database-0.2.0-d2iq-defaults
+  name: harbor-database-0.2.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/harbor/1.17.0/defaults/harbor.yaml
+++ b/services/harbor/1.17.0/defaults/harbor.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: harbor-1.17.0-d2iq-defaults
+  name: harbor-1.17.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/harbor/1.17.0/defaults/harbor.yaml
+++ b/services/harbor/1.17.0/defaults/harbor.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: harbor-1.17.0-nkp-defaults
+  name: harbor-1.17.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/harbor/1.17.0/defaults/valkey.yaml
+++ b/services/harbor/1.17.0/defaults/valkey.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: harbor-valkey-3.0.1-nkp-defaults
+  name: harbor-valkey-3.0.1-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/harbor/1.17.0/defaults/valkey.yaml
+++ b/services/harbor/1.17.0/defaults/valkey.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: harbor-valkey-3.0.1-d2iq-defaults
+  name: harbor-valkey-3.0.1-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/harbor/1.17.0/manual-storage/manual-bucket.yaml
+++ b/services/harbor/1.17.0/manual-storage/manual-bucket.yaml
@@ -27,7 +27,7 @@ spec:
   targetNamespace: ${releaseNamespace}
   valuesFrom:
     - kind: ConfigMap
-      name: harbor-1.17.0-d2iq-defaults
+      name: harbor-1.17.0-nkp-defaults
       valuesKey: harbor-copy-secret-values.yaml
     - kind: ConfigMap
       name: harbor-config-overrides

--- a/services/harbor/1.17.0/manual-storage/manual-bucket.yaml
+++ b/services/harbor/1.17.0/manual-storage/manual-bucket.yaml
@@ -27,7 +27,7 @@ spec:
   targetNamespace: ${releaseNamespace}
   valuesFrom:
     - kind: ConfigMap
-      name: harbor-1.17.0-nkp-defaults
+      name: harbor-1.17.0-config-defaults
       valuesKey: harbor-copy-secret-values.yaml
     - kind: ConfigMap
       name: harbor-config-overrides

--- a/services/harbor/1.17.0/release/harbor.yaml
+++ b/services/harbor/1.17.0/release/harbor.yaml
@@ -27,7 +27,7 @@ spec:
   targetNamespace: ncr-system
   valuesFrom:
     - kind: ConfigMap
-      name: harbor-1.17.0-nkp-defaults
+      name: harbor-1.17.0-config-defaults
     - kind: ConfigMap
       name: harbor-config-overrides
       optional: true

--- a/services/harbor/1.17.0/release/harbor.yaml
+++ b/services/harbor/1.17.0/release/harbor.yaml
@@ -27,7 +27,7 @@ spec:
   targetNamespace: ncr-system
   valuesFrom:
     - kind: ConfigMap
-      name: harbor-1.17.0-d2iq-defaults
+      name: harbor-1.17.0-nkp-defaults
     - kind: ConfigMap
       name: harbor-config-overrides
       optional: true

--- a/services/harbor/1.17.0/valkey/valkey.yaml
+++ b/services/harbor/1.17.0/valkey/valkey.yaml
@@ -27,7 +27,7 @@ spec:
   targetNamespace: ncr-system
   valuesFrom:
     - kind: ConfigMap
-      name: harbor-valkey-3.0.1-d2iq-defaults
+      name: harbor-valkey-3.0.1-nkp-defaults
     - kind: ConfigMap
       name: harbor-valkey-overrides
       optional: true

--- a/services/harbor/1.17.0/valkey/valkey.yaml
+++ b/services/harbor/1.17.0/valkey/valkey.yaml
@@ -27,7 +27,7 @@ spec:
   targetNamespace: ncr-system
   valuesFrom:
     - kind: ConfigMap
-      name: harbor-valkey-3.0.1-nkp-defaults
+      name: harbor-valkey-3.0.1-config-defaults
     - kind: ConfigMap
       name: harbor-valkey-overrides
       optional: true

--- a/services/istio/1.23.3/defaults/cm.yaml
+++ b/services/istio/1.23.3/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio-1.23.3-nkp-defaults
+  name: istio-1.23.3-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/istio/1.23.3/defaults/cm.yaml
+++ b/services/istio/1.23.3/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio-1.23.3-d2iq-defaults
+  name: istio-1.23.3-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/istio/1.23.3/helmrelease/helmrelease.yaml
+++ b/services/istio/1.23.3/helmrelease/helmrelease.yaml
@@ -29,4 +29,4 @@ spec:
   targetNamespace: istio-system
   valuesFrom:
     - kind: ConfigMap
-      name: istio-1.23.3-d2iq-defaults
+      name: istio-1.23.3-nkp-defaults

--- a/services/istio/1.23.3/helmrelease/helmrelease.yaml
+++ b/services/istio/1.23.3/helmrelease/helmrelease.yaml
@@ -29,4 +29,4 @@ spec:
   targetNamespace: istio-system
   valuesFrom:
     - kind: ConfigMap
-      name: istio-1.23.3-nkp-defaults
+      name: istio-1.23.3-config-defaults

--- a/services/jaeger/2.57.1/defaults/cm.yaml
+++ b/services/jaeger/2.57.1/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: jaeger-2.57.1-d2iq-defaults
+  name: jaeger-2.57.1-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/jaeger/2.57.1/defaults/cm.yaml
+++ b/services/jaeger/2.57.1/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: jaeger-2.57.1-nkp-defaults
+  name: jaeger-2.57.1-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/jaeger/2.57.1/helmrelease/release.yaml
+++ b/services/jaeger/2.57.1/helmrelease/release.yaml
@@ -29,7 +29,7 @@ spec:
   targetNamespace: istio-system
   valuesFrom:
     - kind: ConfigMap
-      name: jaeger-2.57.1-d2iq-defaults
+      name: jaeger-2.57.1-nkp-defaults
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/services/jaeger/2.57.1/helmrelease/release.yaml
+++ b/services/jaeger/2.57.1/helmrelease/release.yaml
@@ -29,7 +29,7 @@ spec:
   targetNamespace: istio-system
   valuesFrom:
     - kind: ConfigMap
-      name: jaeger-2.57.1-nkp-defaults
+      name: jaeger-2.57.1-config-defaults
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/services/karma-traefik/0.0.2/defaults/cm.yaml
+++ b/services/karma-traefik/0.0.2/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: karma-traefik-0.0.2-nkp-defaults
+  name: karma-traefik-0.0.2-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/karma-traefik/0.0.2/defaults/cm.yaml
+++ b/services/karma-traefik/0.0.2/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: karma-traefik-0.0.2-d2iq-defaults
+  name: karma-traefik-0.0.2-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/karma-traefik/0.0.2/karma-traefik.yaml
+++ b/services/karma-traefik/0.0.2/karma-traefik.yaml
@@ -25,4 +25,4 @@ spec:
   releaseName: karma-traefik
   valuesFrom:
     - kind: ConfigMap
-      name: karma-traefik-0.0.2-d2iq-defaults
+      name: karma-traefik-0.0.2-nkp-defaults

--- a/services/karma-traefik/0.0.2/karma-traefik.yaml
+++ b/services/karma-traefik/0.0.2/karma-traefik.yaml
@@ -25,4 +25,4 @@ spec:
   releaseName: karma-traefik
   valuesFrom:
     - kind: ConfigMap
-      name: karma-traefik-0.0.2-nkp-defaults
+      name: karma-traefik-0.0.2-config-defaults

--- a/services/karma/2.0.6/defaults/cm.yaml
+++ b/services/karma/2.0.6/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: karma-2.0.6-d2iq-defaults
+  name: karma-2.0.6-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/karma/2.0.6/defaults/cm.yaml
+++ b/services/karma/2.0.6/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: karma-2.0.6-nkp-defaults
+  name: karma-2.0.6-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/karma/2.0.6/karma.yaml
+++ b/services/karma/2.0.6/karma.yaml
@@ -27,7 +27,7 @@ spec:
   releaseName: karma
   valuesFrom:
     - kind: ConfigMap
-      name: karma-2.0.6-d2iq-defaults
+      name: karma-2.0.6-nkp-defaults
   targetNamespace: ${releaseNamespace}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/services/karma/2.0.6/karma.yaml
+++ b/services/karma/2.0.6/karma.yaml
@@ -27,7 +27,7 @@ spec:
   releaseName: karma
   valuesFrom:
     - kind: ConfigMap
-      name: karma-2.0.6-nkp-defaults
+      name: karma-2.0.6-config-defaults
   targetNamespace: ${releaseNamespace}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/services/kiali/2.8.0/defaults/cm.yaml
+++ b/services/kiali/2.8.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kiali-2.8.0-d2iq-defaults
+  name: kiali-2.8.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kiali/2.8.0/defaults/cm.yaml
+++ b/services/kiali/2.8.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kiali-2.8.0-nkp-defaults
+  name: kiali-2.8.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kiali/2.8.0/kiali.yaml
+++ b/services/kiali/2.8.0/kiali.yaml
@@ -29,7 +29,7 @@ spec:
   releaseName: kiali
   valuesFrom:
     - kind: ConfigMap
-      name: kiali-2.8.0-nkp-defaults
+      name: kiali-2.8.0-config-defaults
   targetNamespace: istio-system
 ---
 apiVersion: v1

--- a/services/kiali/2.8.0/kiali.yaml
+++ b/services/kiali/2.8.0/kiali.yaml
@@ -29,7 +29,7 @@ spec:
   releaseName: kiali
   valuesFrom:
     - kind: ConfigMap
-      name: kiali-2.8.0-d2iq-defaults
+      name: kiali-2.8.0-nkp-defaults
   targetNamespace: istio-system
 ---
 apiVersion: v1

--- a/services/knative/1.17.0/defaults/cm.yaml
+++ b/services/knative/1.17.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: knative-1.17.0-d2iq-defaults
+  name: knative-1.17.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/knative/1.17.0/defaults/cm.yaml
+++ b/services/knative/1.17.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: knative-1.17.0-nkp-defaults
+  name: knative-1.17.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/knative/1.17.0/knative-serving.yaml
+++ b/services/knative/1.17.0/knative-serving.yaml
@@ -28,7 +28,7 @@ spec:
   targetNamespace: knative-serving
   valuesFrom:
     - kind: ConfigMap
-      name: knative-1.17.0-d2iq-defaults
+      name: knative-1.17.0-nkp-defaults
     - kind: ConfigMap
       name: knative-overrides
       optional: true

--- a/services/knative/1.17.0/knative-serving.yaml
+++ b/services/knative/1.17.0/knative-serving.yaml
@@ -28,7 +28,7 @@ spec:
   targetNamespace: knative-serving
   valuesFrom:
     - kind: ConfigMap
-      name: knative-1.17.0-nkp-defaults
+      name: knative-1.17.0-config-defaults
     - kind: ConfigMap
       name: knative-overrides
       optional: true

--- a/services/kommander-appmanagement/0.16.0/defaults/cm.yaml
+++ b/services/kommander-appmanagement/0.16.0/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kommander-appmanagement-0.16.0-nkp-defaults
+  name: kommander-appmanagement-0.16.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kommander-appmanagement/0.16.0/defaults/cm.yaml
+++ b/services/kommander-appmanagement/0.16.0/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kommander-appmanagement-0.16.0-d2iq-defaults
+  name: kommander-appmanagement-0.16.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kommander-appmanagement/0.16.0/kommander-appmanagement.yaml
+++ b/services/kommander-appmanagement/0.16.0/kommander-appmanagement.yaml
@@ -32,7 +32,7 @@ spec:
   releaseName: kommander-appmanagement
   valuesFrom:
     - kind: ConfigMap
-      name: kommander-appmanagement-0.16.0-nkp-defaults
+      name: kommander-appmanagement-0.16.0-config-defaults
     - kind: ConfigMap
       name: kommander-appmanagement-overrides
       optional: true

--- a/services/kommander-appmanagement/0.16.0/kommander-appmanagement.yaml
+++ b/services/kommander-appmanagement/0.16.0/kommander-appmanagement.yaml
@@ -32,7 +32,7 @@ spec:
   releaseName: kommander-appmanagement
   valuesFrom:
     - kind: ConfigMap
-      name: kommander-appmanagement-0.16.0-d2iq-defaults
+      name: kommander-appmanagement-0.16.0-nkp-defaults
     - kind: ConfigMap
       name: kommander-appmanagement-overrides
       optional: true

--- a/services/kommander-flux/2.5.1/defaults/cm.yaml
+++ b/services/kommander-flux/2.5.1/defaults/cm.yaml
@@ -4,5 +4,5 @@ data:
     ---
 kind: ConfigMap
 metadata:
-  name: kommander-flux-2.5.1-d2iq-defaults
+  name: kommander-flux-2.5.1-nkp-defaults
   namespace: ${releaseNamespace}

--- a/services/kommander-flux/2.5.1/defaults/cm.yaml
+++ b/services/kommander-flux/2.5.1/defaults/cm.yaml
@@ -4,5 +4,5 @@ data:
     ---
 kind: ConfigMap
 metadata:
-  name: kommander-flux-2.5.1-nkp-defaults
+  name: kommander-flux-2.5.1-config-defaults
   namespace: ${releaseNamespace}

--- a/services/kommander-ui/17.88.2/defaults/cm.yaml
+++ b/services/kommander-ui/17.88.2/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kommander-ui-17.88.2-d2iq-defaults
+  name: kommander-ui-17.88.2-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kommander-ui/17.88.2/kommander-ui.yaml
+++ b/services/kommander-ui/17.88.2/kommander-ui.yaml
@@ -27,7 +27,7 @@ spec:
       retries: 30
   valuesFrom:
     - kind: ConfigMap
-      name: kommander-ui-17.88.2-d2iq-defaults
+      name: kommander-ui-17.88.2-config-defaults
     - kind: ConfigMap
       name: kommander-ui-overrides
       optional: true

--- a/services/kommander/0.16.0/defaults/cm.yaml
+++ b/services/kommander/0.16.0/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kommander-0.16.0-d2iq-defaults
+  name: kommander-0.16.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kommander/0.16.0/defaults/cm.yaml
+++ b/services/kommander/0.16.0/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kommander-0.16.0-nkp-defaults
+  name: kommander-0.16.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kommander/0.16.0/kommander.yaml
+++ b/services/kommander/0.16.0/kommander.yaml
@@ -41,7 +41,7 @@ spec:
   releaseName: kommander
   valuesFrom:
     - kind: ConfigMap
-      name: kommander-0.16.0-d2iq-defaults
+      name: kommander-0.16.0-nkp-defaults
     - kind: ConfigMap
       name: kommander-overrides
       optional: true

--- a/services/kommander/0.16.0/kommander.yaml
+++ b/services/kommander/0.16.0/kommander.yaml
@@ -41,7 +41,7 @@ spec:
   releaseName: kommander
   valuesFrom:
     - kind: ConfigMap
-      name: kommander-0.16.0-nkp-defaults
+      name: kommander-0.16.0-config-defaults
     - kind: ConfigMap
       name: kommander-overrides
       optional: true

--- a/services/kube-oidc-proxy/0.3.5/defaults/cm.yaml
+++ b/services/kube-oidc-proxy/0.3.5/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kube-oidc-proxy-0.3.5-nkp-defaults
+  name: kube-oidc-proxy-0.3.5-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/kube-oidc-proxy/0.3.5/defaults/cm.yaml
+++ b/services/kube-oidc-proxy/0.3.5/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kube-oidc-proxy-0.3.5-d2iq-defaults
+  name: kube-oidc-proxy-0.3.5-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/kube-oidc-proxy/0.3.5/kube-oidc-proxy.yaml
+++ b/services/kube-oidc-proxy/0.3.5/kube-oidc-proxy.yaml
@@ -34,5 +34,5 @@ spec:
   releaseName: kube-oidc-proxy
   valuesFrom:
     - kind: ConfigMap
-      name: kube-oidc-proxy-0.3.5-d2iq-defaults
+      name: kube-oidc-proxy-0.3.5-nkp-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/kube-oidc-proxy/0.3.5/kube-oidc-proxy.yaml
+++ b/services/kube-oidc-proxy/0.3.5/kube-oidc-proxy.yaml
@@ -34,5 +34,5 @@ spec:
   releaseName: kube-oidc-proxy
   valuesFrom:
     - kind: ConfigMap
-      name: kube-oidc-proxy-0.3.5-nkp-defaults
+      name: kube-oidc-proxy-0.3.5-config-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/kube-prometheus-stack/71.0.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/71.0.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kube-prometheus-stack-71.0.0-d2iq-defaults
+  name: kube-prometheus-stack-71.0.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kube-prometheus-stack/71.0.0/helmrelease/kube-prometheus-stack.yaml
+++ b/services/kube-prometheus-stack/71.0.0/helmrelease/kube-prometheus-stack.yaml
@@ -27,7 +27,7 @@ spec:
   releaseName: kube-prometheus-stack
   valuesFrom:
     - kind: ConfigMap
-      name: kube-prometheus-stack-71.0.0-d2iq-defaults
+      name: kube-prometheus-stack-71.0.0-config-defaults
     - kind: ConfigMap
       name: kube-prometheus-stack-mgmt-overrides
       optional: true

--- a/services/kubecost/2.7.2/cosi-storage/cosi-bucket.yaml
+++ b/services/kubecost/2.7.2/cosi-storage/cosi-bucket.yaml
@@ -26,7 +26,7 @@ spec:
   targetNamespace: ${releaseNamespace}
   valuesFrom:
     - kind: ConfigMap
-      name: kubecost-2.7.2-d2iq-defaults
+      name: kubecost-2.7.2-config-defaults
       valuesKey: ${kubecostClusterMode:=primary}-cosi-values.yaml # This will ensure kubecost agents installs do not get cosi buckets.
       optional: true
     - kind: ConfigMap

--- a/services/kubecost/2.7.2/defaults/cm.yaml
+++ b/services/kubecost/2.7.2/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubecost-2.7.2-d2iq-defaults
+  name: kubecost-2.7.2-config-defaults
   namespace: ${releaseNamespace}
 data:
   # Using just values.yaml will result in kubecost running in agent mode.

--- a/services/kubecost/2.7.2/release/release.yaml
+++ b/services/kubecost/2.7.2/release/release.yaml
@@ -25,14 +25,14 @@ spec:
   releaseName: kubecost
   valuesFrom: # The order is important. The last entry will override the previous ones.
     - kind: ConfigMap
-      name: kubecost-2.7.2-d2iq-defaults
+      name: kubecost-2.7.2-config-defaults
       valuesKey: values.yaml
     - kind: ConfigMap
-      name: kubecost-2.7.2-d2iq-defaults
+      name: kubecost-2.7.2-config-defaults
       valuesKey: ${kubecostClusterMode:=primary}-values.yaml # Configures the kubecost cluster as primary with no object storage for single cluster mode.
       optional: true
     - kind: ConfigMap
-      name: kubecost-2.7.2-d2iq-defaults
+      name: kubecost-2.7.2-config-defaults
       valuesKey: ${kubecostClusterMode:=primary}-object-storage-${objectStoreStatus:=not-applicable}-values.yaml # Configures the primary kubecost cluster with object storage for multi cluster mode.
       optional: true
   targetNamespace: ${releaseNamespace}

--- a/services/kubefed/0.11.1/defaults/cm.yaml
+++ b/services/kubefed/0.11.1/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubefed-0.11.1-nkp-defaults
+  name: kubefed-0.11.1-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kubefed/0.11.1/defaults/cm.yaml
+++ b/services/kubefed/0.11.1/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubefed-0.11.1-d2iq-defaults
+  name: kubefed-0.11.1-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kubefed/0.11.1/release/release.yaml
+++ b/services/kubefed/0.11.1/release/release.yaml
@@ -26,7 +26,7 @@ spec:
   releaseName: kubefed
   valuesFrom:
     - kind: ConfigMap
-      name: kubefed-0.11.1-d2iq-defaults
+      name: kubefed-0.11.1-nkp-defaults
     - kind: ConfigMap
       name: kubefed-overrides
       optional: true

--- a/services/kubefed/0.11.1/release/release.yaml
+++ b/services/kubefed/0.11.1/release/release.yaml
@@ -26,7 +26,7 @@ spec:
   releaseName: kubefed
   valuesFrom:
     - kind: ConfigMap
-      name: kubefed-0.11.1-nkp-defaults
+      name: kubefed-0.11.1-config-defaults
     - kind: ConfigMap
       name: kubefed-overrides
       optional: true

--- a/services/kubernetes-dashboard/7.12.0/defaults/cm.yaml
+++ b/services/kubernetes-dashboard/7.12.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubernetes-dashboard-7.12.0-d2iq-defaults
+  name: kubernetes-dashboard-7.12.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kubernetes-dashboard/7.12.0/defaults/cm.yaml
+++ b/services/kubernetes-dashboard/7.12.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubernetes-dashboard-7.12.0-nkp-defaults
+  name: kubernetes-dashboard-7.12.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kubernetes-dashboard/7.12.0/helmrelease/kubernetes-dashboard.yaml
+++ b/services/kubernetes-dashboard/7.12.0/helmrelease/kubernetes-dashboard.yaml
@@ -24,7 +24,7 @@ spec:
   releaseName: kubernetes-dashboard
   valuesFrom:
     - kind: ConfigMap
-      name: kubernetes-dashboard-7.12.0-nkp-defaults
+      name: kubernetes-dashboard-7.12.0-config-defaults
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/kubernetes-dashboard/7.12.0/helmrelease/kubernetes-dashboard.yaml
+++ b/services/kubernetes-dashboard/7.12.0/helmrelease/kubernetes-dashboard.yaml
@@ -24,7 +24,7 @@ spec:
   releaseName: kubernetes-dashboard
   valuesFrom:
     - kind: ConfigMap
-      name: kubernetes-dashboard-7.12.0-d2iq-defaults
+      name: kubernetes-dashboard-7.12.0-nkp-defaults
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/kubetunnel/0.0.39/defaults/cm.yaml
+++ b/services/kubetunnel/0.0.39/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubetunnel-0.0.39-nkp-defaults
+  name: kubetunnel-0.0.39-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kubetunnel/0.0.39/defaults/cm.yaml
+++ b/services/kubetunnel/0.0.39/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubetunnel-0.0.39-d2iq-defaults
+  name: kubetunnel-0.0.39-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/kubetunnel/0.0.39/kubetunnel.yaml
+++ b/services/kubetunnel/0.0.39/kubetunnel.yaml
@@ -24,4 +24,4 @@ spec:
   releaseName: kubetunnel
   valuesFrom:
     - kind: ConfigMap
-      name: kubetunnel-0.0.39-nkp-defaults
+      name: kubetunnel-0.0.39-config-defaults

--- a/services/kubetunnel/0.0.39/kubetunnel.yaml
+++ b/services/kubetunnel/0.0.39/kubetunnel.yaml
@@ -24,4 +24,4 @@ spec:
   releaseName: kubetunnel
   valuesFrom:
     - kind: ConfigMap
-      name: kubetunnel-0.0.39-d2iq-defaults
+      name: kubetunnel-0.0.39-nkp-defaults

--- a/services/logging-operator/5.2.0/defaults/cm.yaml
+++ b/services/logging-operator/5.2.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: logging-operator-5.2.0-d2iq-defaults
+  name: logging-operator-5.2.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-
@@ -27,7 +27,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: logging-operator-logging-5.2.0-d2iq-defaults
+  name: logging-operator-logging-5.2.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/logging-operator/5.2.0/defaults/cm.yaml
+++ b/services/logging-operator/5.2.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: logging-operator-5.2.0-nkp-defaults
+  name: logging-operator-5.2.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-
@@ -27,7 +27,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: logging-operator-logging-5.2.0-nkp-defaults
+  name: logging-operator-logging-5.2.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/logging-operator/5.2.0/logging-operator-logging.yaml
+++ b/services/logging-operator/5.2.0/logging-operator-logging.yaml
@@ -27,7 +27,7 @@ spec:
   releaseName: logging-operator-logging
   valuesFrom:
     - kind: ConfigMap
-      name: logging-operator-logging-5.2.0-d2iq-defaults
+      name: logging-operator-logging-5.2.0-nkp-defaults
     # FIXME: To make logging-operator-logging work properly with federated
     # overrides, the `logging-operator` app should be split into two,
     # after which this entry should be replaced with `configOverrides`

--- a/services/logging-operator/5.2.0/logging-operator-logging.yaml
+++ b/services/logging-operator/5.2.0/logging-operator-logging.yaml
@@ -27,7 +27,7 @@ spec:
   releaseName: logging-operator-logging
   valuesFrom:
     - kind: ConfigMap
-      name: logging-operator-logging-5.2.0-nkp-defaults
+      name: logging-operator-logging-5.2.0-config-defaults
     # FIXME: To make logging-operator-logging work properly with federated
     # overrides, the `logging-operator` app should be split into two,
     # after which this entry should be replaced with `configOverrides`

--- a/services/logging-operator/5.2.0/logging-operator.yaml
+++ b/services/logging-operator/5.2.0/logging-operator.yaml
@@ -25,4 +25,4 @@ spec:
   releaseName: logging-operator
   valuesFrom:
     - kind: ConfigMap
-      name: logging-operator-5.2.0-nkp-defaults
+      name: logging-operator-5.2.0-config-defaults

--- a/services/logging-operator/5.2.0/logging-operator.yaml
+++ b/services/logging-operator/5.2.0/logging-operator.yaml
@@ -25,4 +25,4 @@ spec:
   releaseName: logging-operator
   valuesFrom:
     - kind: ConfigMap
-      name: logging-operator-5.2.0-d2iq-defaults
+      name: logging-operator-5.2.0-nkp-defaults

--- a/services/nkp-insights-management/1.4.4/defaults/cm.yaml
+++ b/services/nkp-insights-management/1.4.4/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nkp-insights-management-1.4.4-nkp-defaults
+  name: nkp-insights-management-1.4.4-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/nkp-insights-management/1.4.4/defaults/cm.yaml
+++ b/services/nkp-insights-management/1.4.4/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nkp-insights-management-1.4.4-d2iq-defaults
+  name: nkp-insights-management-1.4.4-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/nkp-insights-management/1.4.4/helmrelease/helmrelease.yaml
+++ b/services/nkp-insights-management/1.4.4/helmrelease/helmrelease.yaml
@@ -28,4 +28,4 @@ spec:
       retries: 30
   valuesFrom:
     - kind: ConfigMap
-      name: nkp-insights-management-1.4.4-nkp-defaults
+      name: nkp-insights-management-1.4.4-config-defaults

--- a/services/nkp-insights-management/1.4.4/helmrelease/helmrelease.yaml
+++ b/services/nkp-insights-management/1.4.4/helmrelease/helmrelease.yaml
@@ -28,4 +28,4 @@ spec:
       retries: 30
   valuesFrom:
     - kind: ConfigMap
-      name: nkp-insights-management-1.4.4-d2iq-defaults
+      name: nkp-insights-management-1.4.4-nkp-defaults

--- a/services/nkp-insights/1.4.4/defaults/cm.yaml
+++ b/services/nkp-insights/1.4.4/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nkp-insights-1.4.4-d2iq-defaults
+  name: nkp-insights-1.4.4-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/nkp-insights/1.4.4/defaults/cm.yaml
+++ b/services/nkp-insights/1.4.4/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nkp-insights-1.4.4-nkp-defaults
+  name: nkp-insights-1.4.4-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/nkp-insights/1.4.4/helmrelease/helmrelease.yaml
+++ b/services/nkp-insights/1.4.4/helmrelease/helmrelease.yaml
@@ -24,4 +24,4 @@ spec:
       strategy: uninstall
   valuesFrom:
     - kind: ConfigMap
-      name: nkp-insights-1.4.4-nkp-defaults
+      name: nkp-insights-1.4.4-config-defaults

--- a/services/nkp-insights/1.4.4/helmrelease/helmrelease.yaml
+++ b/services/nkp-insights/1.4.4/helmrelease/helmrelease.yaml
@@ -24,4 +24,4 @@ spec:
       strategy: uninstall
   valuesFrom:
     - kind: ConfigMap
-      name: nkp-insights-1.4.4-d2iq-defaults
+      name: nkp-insights-1.4.4-nkp-defaults

--- a/services/nkp-pulse-management/0.2.6/defaults/cm.yaml
+++ b/services/nkp-pulse-management/0.2.6/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nkp-pulse-management-0.2.6-nkp-defaults
+  name: nkp-pulse-management-0.2.6-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/nkp-pulse-management/0.2.6/defaults/cm.yaml
+++ b/services/nkp-pulse-management/0.2.6/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nkp-pulse-management-0.2.6-d2iq-defaults
+  name: nkp-pulse-management-0.2.6-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/nkp-pulse-management/0.2.6/helmrelease.yaml
+++ b/services/nkp-pulse-management/0.2.6/helmrelease.yaml
@@ -20,4 +20,4 @@ spec:
       strategy: uninstall
   valuesFrom:
     - kind: ConfigMap
-      name: nkp-pulse-management-0.2.6-d2iq-defaults
+      name: nkp-pulse-management-0.2.6-nkp-defaults

--- a/services/nkp-pulse-management/0.2.6/helmrelease.yaml
+++ b/services/nkp-pulse-management/0.2.6/helmrelease.yaml
@@ -20,4 +20,4 @@ spec:
       strategy: uninstall
   valuesFrom:
     - kind: ConfigMap
-      name: nkp-pulse-management-0.2.6-nkp-defaults
+      name: nkp-pulse-management-0.2.6-config-defaults

--- a/services/nkp-pulse-workspace/0.2.6/defaults/cm.yaml
+++ b/services/nkp-pulse-workspace/0.2.6/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nkp-pulse-workspace-0.2.6-nkp-defaults
+  name: nkp-pulse-workspace-0.2.6-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/nkp-pulse-workspace/0.2.6/defaults/cm.yaml
+++ b/services/nkp-pulse-workspace/0.2.6/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nkp-pulse-workspace-0.2.6-d2iq-defaults
+  name: nkp-pulse-workspace-0.2.6-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/nkp-pulse-workspace/0.2.6/helmrelease.yaml
+++ b/services/nkp-pulse-workspace/0.2.6/helmrelease.yaml
@@ -20,4 +20,4 @@ spec:
       strategy: uninstall
   valuesFrom:
     - kind: ConfigMap
-      name: nkp-pulse-workspace-0.2.6-nkp-defaults
+      name: nkp-pulse-workspace-0.2.6-config-defaults

--- a/services/nkp-pulse-workspace/0.2.6/helmrelease.yaml
+++ b/services/nkp-pulse-workspace/0.2.6/helmrelease.yaml
@@ -20,4 +20,4 @@ spec:
       strategy: uninstall
   valuesFrom:
     - kind: ConfigMap
-      name: nkp-pulse-workspace-0.2.6-d2iq-defaults
+      name: nkp-pulse-workspace-0.2.6-nkp-defaults

--- a/services/nvidia-gpu-operator/25.3.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/25.3.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nvidia-gpu-operator-25.3.0-nkp-defaults
+  name: nvidia-gpu-operator-25.3.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/nvidia-gpu-operator/25.3.0/defaults/cm.yaml
+++ b/services/nvidia-gpu-operator/25.3.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nvidia-gpu-operator-25.3.0-d2iq-defaults
+  name: nvidia-gpu-operator-25.3.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/nvidia-gpu-operator/25.3.0/helmrelease/nvidia.yaml
+++ b/services/nvidia-gpu-operator/25.3.0/helmrelease/nvidia.yaml
@@ -24,5 +24,5 @@ spec:
   releaseName: nvidia-gpu-operator
   valuesFrom:
     - kind: ConfigMap
-      name: nvidia-gpu-operator-25.3.0-d2iq-defaults
+      name: nvidia-gpu-operator-25.3.0-nkp-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/nvidia-gpu-operator/25.3.0/helmrelease/nvidia.yaml
+++ b/services/nvidia-gpu-operator/25.3.0/helmrelease/nvidia.yaml
@@ -24,5 +24,5 @@ spec:
   releaseName: nvidia-gpu-operator
   valuesFrom:
     - kind: ConfigMap
-      name: nvidia-gpu-operator-25.3.0-nkp-defaults
+      name: nvidia-gpu-operator-25.3.0-config-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/project-grafana-logging/8.15.0/defaults/cm.yaml
+++ b/services/project-grafana-logging/8.15.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: project-grafana-logging-8.15.0-d2iq-defaults
+  name: project-grafana-logging-8.15.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/project-grafana-logging/8.15.0/project-grafana.yaml
+++ b/services/project-grafana-logging/8.15.0/project-grafana.yaml
@@ -23,5 +23,5 @@ spec:
       retries: 30
   valuesFrom:
     - kind: ConfigMap
-      name: project-grafana-logging-8.15.0-d2iq-defaults
+      name: project-grafana-logging-8.15.0-config-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/project-grafana-loki/0.80.3/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.80.3/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: project-grafana-loki-0.80.3-nkp-defaults
+  name: project-grafana-loki-0.80.3-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/project-grafana-loki/0.80.3/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.80.3/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: project-grafana-loki-0.80.3-d2iq-defaults
+  name: project-grafana-loki-0.80.3-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/project-grafana-loki/0.80.3/object-bucket-claims.yaml
+++ b/services/project-grafana-loki/0.80.3/object-bucket-claims.yaml
@@ -24,7 +24,7 @@ spec:
   releaseName: project-loki-object-bucket-claims
   valuesFrom:
     - kind: ConfigMap
-      name: project-grafana-loki-0.80.3-d2iq-defaults
+      name: project-grafana-loki-0.80.3-nkp-defaults
     - kind: ConfigMap
       name: project-grafana-loki-overrides
       optional: true

--- a/services/project-grafana-loki/0.80.3/object-bucket-claims.yaml
+++ b/services/project-grafana-loki/0.80.3/object-bucket-claims.yaml
@@ -24,7 +24,7 @@ spec:
   releaseName: project-loki-object-bucket-claims
   valuesFrom:
     - kind: ConfigMap
-      name: project-grafana-loki-0.80.3-nkp-defaults
+      name: project-grafana-loki-0.80.3-config-defaults
     - kind: ConfigMap
       name: project-grafana-loki-overrides
       optional: true

--- a/services/project-grafana-loki/0.80.3/project-grafana-loki.yaml
+++ b/services/project-grafana-loki/0.80.3/project-grafana-loki.yaml
@@ -25,4 +25,4 @@ spec:
   releaseName: project-grafana-loki
   valuesFrom:
     - kind: ConfigMap
-      name: project-grafana-loki-0.80.3-d2iq-defaults
+      name: project-grafana-loki-0.80.3-nkp-defaults

--- a/services/project-grafana-loki/0.80.3/project-grafana-loki.yaml
+++ b/services/project-grafana-loki/0.80.3/project-grafana-loki.yaml
@@ -25,4 +25,4 @@ spec:
   releaseName: project-grafana-loki
   valuesFrom:
     - kind: ConfigMap
-      name: project-grafana-loki-0.80.3-nkp-defaults
+      name: project-grafana-loki-0.80.3-config-defaults

--- a/services/prometheus-adapter/4.14.1/defaults/cm.yaml
+++ b/services/prometheus-adapter/4.14.1/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prometheus-adapter-4.14.1-d2iq-defaults
+  name: prometheus-adapter-4.14.1-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/prometheus-adapter/4.14.1/defaults/cm.yaml
+++ b/services/prometheus-adapter/4.14.1/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prometheus-adapter-4.14.1-nkp-defaults
+  name: prometheus-adapter-4.14.1-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/prometheus-adapter/4.14.1/helmrelease/prometheus-adapter.yaml
+++ b/services/prometheus-adapter/4.14.1/helmrelease/prometheus-adapter.yaml
@@ -27,5 +27,5 @@ spec:
   releaseName: prometheus-adapter
   valuesFrom:
     - kind: ConfigMap
-      name: prometheus-adapter-4.14.1-d2iq-defaults
+      name: prometheus-adapter-4.14.1-nkp-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/prometheus-adapter/4.14.1/helmrelease/prometheus-adapter.yaml
+++ b/services/prometheus-adapter/4.14.1/helmrelease/prometheus-adapter.yaml
@@ -27,5 +27,5 @@ spec:
   releaseName: prometheus-adapter
   valuesFrom:
     - kind: ConfigMap
-      name: prometheus-adapter-4.14.1-nkp-defaults
+      name: prometheus-adapter-4.14.1-config-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/prometheus-thanos-traefik/0.0.2/defaults/cm.yaml
+++ b/services/prometheus-thanos-traefik/0.0.2/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prometheus-thanos-traefik-0.0.2-nkp-defaults
+  name: prometheus-thanos-traefik-0.0.2-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/prometheus-thanos-traefik/0.0.2/defaults/cm.yaml
+++ b/services/prometheus-thanos-traefik/0.0.2/defaults/cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prometheus-thanos-traefik-0.0.2-d2iq-defaults
+  name: prometheus-thanos-traefik-0.0.2-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/prometheus-thanos-traefik/0.0.2/prometheus-thanos-traefik.yaml
+++ b/services/prometheus-thanos-traefik/0.0.2/prometheus-thanos-traefik.yaml
@@ -25,4 +25,4 @@ spec:
   releaseName: prometheus-thanos-traefik
   valuesFrom:
     - kind: ConfigMap
-      name: prometheus-thanos-traefik-0.0.2-nkp-defaults
+      name: prometheus-thanos-traefik-0.0.2-config-defaults

--- a/services/prometheus-thanos-traefik/0.0.2/prometheus-thanos-traefik.yaml
+++ b/services/prometheus-thanos-traefik/0.0.2/prometheus-thanos-traefik.yaml
@@ -25,4 +25,4 @@ spec:
   releaseName: prometheus-thanos-traefik
   valuesFrom:
     - kind: ConfigMap
-      name: prometheus-thanos-traefik-0.0.2-d2iq-defaults
+      name: prometheus-thanos-traefik-0.0.2-nkp-defaults

--- a/services/reloader/2.1.2/defaults/cm.yaml
+++ b/services/reloader/2.1.2/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: reloader-2.1.2-nkp-defaults
+  name: reloader-2.1.2-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/reloader/2.1.2/defaults/cm.yaml
+++ b/services/reloader/2.1.2/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: reloader-2.1.2-d2iq-defaults
+  name: reloader-2.1.2-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/reloader/2.1.2/reloader.yaml
+++ b/services/reloader/2.1.2/reloader.yaml
@@ -23,7 +23,7 @@ spec:
       retries: 30
   valuesFrom:
     - kind: ConfigMap
-      name: reloader-2.1.2-d2iq-defaults
+      name: reloader-2.1.2-nkp-defaults
     - kind: ConfigMap
       name: reloader-overrides
       optional: true

--- a/services/reloader/2.1.2/reloader.yaml
+++ b/services/reloader/2.1.2/reloader.yaml
@@ -23,7 +23,7 @@ spec:
       retries: 30
   valuesFrom:
     - kind: ConfigMap
-      name: reloader-2.1.2-nkp-defaults
+      name: reloader-2.1.2-config-defaults
     - kind: ConfigMap
       name: reloader-overrides
       optional: true

--- a/services/rook-ceph-cluster/1.17.0/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.17.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: rook-ceph-cluster-1.17.0-nkp-defaults
+  name: rook-ceph-cluster-1.17.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/rook-ceph-cluster/1.17.0/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.17.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: rook-ceph-cluster-1.17.0-d2iq-defaults
+  name: rook-ceph-cluster-1.17.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/rook-ceph-cluster/1.17.0/helmrelease/helmrelease.yaml
+++ b/services/rook-ceph-cluster/1.17.0/helmrelease/helmrelease.yaml
@@ -26,5 +26,5 @@ spec:
   releaseName: rook-ceph-cluster
   valuesFrom:
     - kind: ConfigMap
-      name: rook-ceph-cluster-1.17.0-d2iq-defaults
+      name: rook-ceph-cluster-1.17.0-nkp-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/rook-ceph-cluster/1.17.0/helmrelease/helmrelease.yaml
+++ b/services/rook-ceph-cluster/1.17.0/helmrelease/helmrelease.yaml
@@ -26,5 +26,5 @@ spec:
   releaseName: rook-ceph-cluster
   valuesFrom:
     - kind: ConfigMap
-      name: rook-ceph-cluster-1.17.0-nkp-defaults
+      name: rook-ceph-cluster-1.17.0-config-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/rook-ceph-cluster/1.17.0/objectbucketclaims/cosi-bucket.yaml
+++ b/services/rook-ceph-cluster/1.17.0/objectbucketclaims/cosi-bucket.yaml
@@ -26,7 +26,7 @@ spec:
   targetNamespace: ${releaseNamespace}
   valuesFrom:
     - kind: ConfigMap
-      name: rook-ceph-cluster-1.17.0-d2iq-defaults
+      name: rook-ceph-cluster-1.17.0-nkp-defaults
       valuesKey: cosi-bucket-kit-values.yaml
       optional: true
     - kind: ConfigMap

--- a/services/rook-ceph-cluster/1.17.0/objectbucketclaims/cosi-bucket.yaml
+++ b/services/rook-ceph-cluster/1.17.0/objectbucketclaims/cosi-bucket.yaml
@@ -26,7 +26,7 @@ spec:
   targetNamespace: ${releaseNamespace}
   valuesFrom:
     - kind: ConfigMap
-      name: rook-ceph-cluster-1.17.0-nkp-defaults
+      name: rook-ceph-cluster-1.17.0-config-defaults
       valuesKey: cosi-bucket-kit-values.yaml
       optional: true
     - kind: ConfigMap

--- a/services/rook-ceph-cluster/1.17.0/objectbucketclaims/helmrelease.yaml
+++ b/services/rook-ceph-cluster/1.17.0/objectbucketclaims/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
   releaseName: object-bucket-claims
   valuesFrom:
     - kind: ConfigMap
-      name: rook-ceph-cluster-1.17.0-nkp-defaults
+      name: rook-ceph-cluster-1.17.0-config-defaults
     - kind: ConfigMap
       name: rook-ceph-cluster-overrides
       optional: true

--- a/services/rook-ceph-cluster/1.17.0/objectbucketclaims/helmrelease.yaml
+++ b/services/rook-ceph-cluster/1.17.0/objectbucketclaims/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
   releaseName: object-bucket-claims
   valuesFrom:
     - kind: ConfigMap
-      name: rook-ceph-cluster-1.17.0-d2iq-defaults
+      name: rook-ceph-cluster-1.17.0-nkp-defaults
     - kind: ConfigMap
       name: rook-ceph-cluster-overrides
       optional: true

--- a/services/rook-ceph/1.17.0/defaults/cm.yaml
+++ b/services/rook-ceph/1.17.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: rook-ceph-1.17.0-d2iq-defaults
+  name: rook-ceph-1.17.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/rook-ceph/1.17.0/defaults/cm.yaml
+++ b/services/rook-ceph/1.17.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: rook-ceph-1.17.0-nkp-defaults
+  name: rook-ceph-1.17.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/rook-ceph/1.17.0/helmrelease/helmrelease.yaml
+++ b/services/rook-ceph/1.17.0/helmrelease/helmrelease.yaml
@@ -25,5 +25,5 @@ spec:
   releaseName: rook-ceph
   valuesFrom:
     - kind: ConfigMap
-      name: rook-ceph-1.17.0-d2iq-defaults
+      name: rook-ceph-1.17.0-nkp-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/rook-ceph/1.17.0/helmrelease/helmrelease.yaml
+++ b/services/rook-ceph/1.17.0/helmrelease/helmrelease.yaml
@@ -25,5 +25,5 @@ spec:
   releaseName: rook-ceph
   valuesFrom:
     - kind: ConfigMap
-      name: rook-ceph-1.17.0-nkp-defaults
+      name: rook-ceph-1.17.0-config-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/thanos/15.8.0/defaults/cm.yaml
+++ b/services/thanos/15.8.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: thanos-15.8.0-nkp-defaults
+  name: thanos-15.8.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/thanos/15.8.0/defaults/cm.yaml
+++ b/services/thanos/15.8.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: thanos-15.8.0-d2iq-defaults
+  name: thanos-15.8.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/thanos/15.8.0/thanos.yaml
+++ b/services/thanos/15.8.0/thanos.yaml
@@ -24,7 +24,7 @@ spec:
   releaseName: thanos
   valuesFrom:
     - kind: ConfigMap
-      name: thanos-15.8.0-d2iq-defaults
+      name: thanos-15.8.0-nkp-defaults
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/services/thanos/15.8.0/thanos.yaml
+++ b/services/thanos/15.8.0/thanos.yaml
@@ -24,7 +24,7 @@ spec:
   releaseName: thanos
   valuesFrom:
     - kind: ConfigMap
-      name: thanos-15.8.0-nkp-defaults
+      name: thanos-15.8.0-config-defaults
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/services/traefik-forward-auth-mgmt/0.3.14/defaults/cm.yaml
+++ b/services/traefik-forward-auth-mgmt/0.3.14/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: traefik-forward-auth-mgmt-0.3.14-d2iq-defaults
+  name: traefik-forward-auth-mgmt-0.3.14-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/traefik-forward-auth-mgmt/0.3.14/defaults/cm.yaml
+++ b/services/traefik-forward-auth-mgmt/0.3.14/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: traefik-forward-auth-mgmt-0.3.14-nkp-defaults
+  name: traefik-forward-auth-mgmt-0.3.14-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/traefik-forward-auth-mgmt/0.3.14/traefik-forward-auth-mgmt.yaml
+++ b/services/traefik-forward-auth-mgmt/0.3.14/traefik-forward-auth-mgmt.yaml
@@ -31,7 +31,7 @@ spec:
   releaseName: traefik-forward-auth-mgmt
   valuesFrom:
     - kind: ConfigMap
-      name: traefik-forward-auth-mgmt-0.3.14-nkp-defaults
+      name: traefik-forward-auth-mgmt-0.3.14-config-defaults
     - kind: ConfigMap
       name: traefik-forward-auth-mgmt-overrides
       optional: true

--- a/services/traefik-forward-auth-mgmt/0.3.14/traefik-forward-auth-mgmt.yaml
+++ b/services/traefik-forward-auth-mgmt/0.3.14/traefik-forward-auth-mgmt.yaml
@@ -31,7 +31,7 @@ spec:
   releaseName: traefik-forward-auth-mgmt
   valuesFrom:
     - kind: ConfigMap
-      name: traefik-forward-auth-mgmt-0.3.14-d2iq-defaults
+      name: traefik-forward-auth-mgmt-0.3.14-nkp-defaults
     - kind: ConfigMap
       name: traefik-forward-auth-mgmt-overrides
       optional: true

--- a/services/traefik-forward-auth/0.3.14/defaults/cm.yaml
+++ b/services/traefik-forward-auth/0.3.14/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: traefik-forward-auth-0.3.14-nkp-defaults
+  name: traefik-forward-auth-0.3.14-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/traefik-forward-auth/0.3.14/defaults/cm.yaml
+++ b/services/traefik-forward-auth/0.3.14/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: traefik-forward-auth-0.3.14-d2iq-defaults
+  name: traefik-forward-auth-0.3.14-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |-

--- a/services/traefik-forward-auth/0.3.14/traefik-forward-auth.yaml
+++ b/services/traefik-forward-auth/0.3.14/traefik-forward-auth.yaml
@@ -27,5 +27,5 @@ spec:
   releaseName: traefik-forward-auth
   valuesFrom:
     - kind: ConfigMap
-      name: traefik-forward-auth-0.3.14-nkp-defaults
+      name: traefik-forward-auth-0.3.14-config-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/traefik-forward-auth/0.3.14/traefik-forward-auth.yaml
+++ b/services/traefik-forward-auth/0.3.14/traefik-forward-auth.yaml
@@ -27,5 +27,5 @@ spec:
   releaseName: traefik-forward-auth
   valuesFrom:
     - kind: ConfigMap
-      name: traefik-forward-auth-0.3.14-d2iq-defaults
+      name: traefik-forward-auth-0.3.14-nkp-defaults
   targetNamespace: ${releaseNamespace}

--- a/services/traefik/35.2.0/crds/crds.yaml
+++ b/services/traefik/35.2.0/crds/crds.yaml
@@ -15,7 +15,7 @@ spec:
         namespace: kommander-flux
   valuesFrom:
     - kind: ConfigMap
-      name: traefik-crd-1.6.0-d2iq-defaults
+      name: traefik-crd-1.6.0-nkp-defaults
     - kind: ConfigMap
       name: traefik-crd-overrides
       optional: true

--- a/services/traefik/35.2.0/crds/crds.yaml
+++ b/services/traefik/35.2.0/crds/crds.yaml
@@ -15,7 +15,7 @@ spec:
         namespace: kommander-flux
   valuesFrom:
     - kind: ConfigMap
-      name: traefik-crd-1.6.0-nkp-defaults
+      name: traefik-crd-1.6.0-config-defaults
     - kind: ConfigMap
       name: traefik-crd-overrides
       optional: true

--- a/services/traefik/35.2.0/defaults/crds.yaml
+++ b/services/traefik/35.2.0/defaults/crds.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: traefik-crd-1.6.0-nkp-defaults
+  name: traefik-crd-1.6.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/traefik/35.2.0/defaults/crds.yaml
+++ b/services/traefik/35.2.0/defaults/crds.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: traefik-crd-1.6.0-d2iq-defaults
+  name: traefik-crd-1.6.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/traefik/35.2.0/defaults/traefik.yaml
+++ b/services/traefik/35.2.0/defaults/traefik.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: traefik-35.2.0-d2iq-defaults
+  name: traefik-35.2.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/traefik/35.2.0/defaults/traefik.yaml
+++ b/services/traefik/35.2.0/defaults/traefik.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: traefik-35.2.0-nkp-defaults
+  name: traefik-35.2.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/traefik/35.2.0/traefik/traefik.yaml
+++ b/services/traefik/35.2.0/traefik/traefik.yaml
@@ -28,7 +28,7 @@ spec:
   releaseName: kommander-traefik
   valuesFrom:
     - kind: ConfigMap
-      name: traefik-35.2.0-nkp-defaults
+      name: traefik-35.2.0-config-defaults
     - kind: ConfigMap
       name: traefik-overrides
       optional: true

--- a/services/traefik/35.2.0/traefik/traefik.yaml
+++ b/services/traefik/35.2.0/traefik/traefik.yaml
@@ -28,7 +28,7 @@ spec:
   releaseName: kommander-traefik
   valuesFrom:
     - kind: ConfigMap
-      name: traefik-35.2.0-d2iq-defaults
+      name: traefik-35.2.0-nkp-defaults
     - kind: ConfigMap
       name: traefik-overrides
       optional: true

--- a/services/velero/9.0.0/defaults/cm.yaml
+++ b/services/velero/9.0.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: velero-9.0.0-nkp-defaults
+  name: velero-9.0.0-config-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/velero/9.0.0/defaults/cm.yaml
+++ b/services/velero/9.0.0/defaults/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: velero-9.0.0-d2iq-defaults
+  name: velero-9.0.0-nkp-defaults
   namespace: ${releaseNamespace}
 data:
   values.yaml: |

--- a/services/velero/9.0.0/helmrelease/helmrelease.yaml
+++ b/services/velero/9.0.0/helmrelease/helmrelease.yaml
@@ -24,6 +24,6 @@ spec:
   releaseName: velero
   valuesFrom:
     - kind: ConfigMap
-      name: velero-9.0.0-nkp-defaults
+      name: velero-9.0.0-config-defaults
   targetNamespace: ${releaseNamespace}
 ---

--- a/services/velero/9.0.0/helmrelease/helmrelease.yaml
+++ b/services/velero/9.0.0/helmrelease/helmrelease.yaml
@@ -24,6 +24,6 @@ spec:
   releaseName: velero
   valuesFrom:
     - kind: ConfigMap
-      name: velero-9.0.0-d2iq-defaults
+      name: velero-9.0.0-nkp-defaults
   targetNamespace: ${releaseNamespace}
 ---


### PR DESCRIPTION
**What problem does this PR solve?**:
right now CM is suffixed with `d2iq-defaults`

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-107123

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
pairing kommander PR: https://github.com/mesosphere/kommander/pull/5863


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
