### PR TITLE
refactor: Migrate helm repository definition closer to service

### DIFF
--- a/services/kommander/0.16.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
+++ b/services/kommander/0.16.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
@@ -12,8 +12,8 @@ spec:
       chart: cluster-observer
       sourceRef:
         kind: HelmRepository
-        name: mesosphere.github.io-kommander-auditing-pipeline-charts
-        namespace: kommander-flux
+        name: kommander-kommander-auditing-pipeline-charts
+        namespace: kommander
       version: 1.4.1
   interval: 15s
   install:

--- a/services/kommander/0.16.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
+++ b/services/kommander/0.16.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
@@ -14,8 +14,8 @@ spec:
       chart: mtls-proxy
       sourceRef:
         kind: HelmRepository
-        name: mesosphere.github.io-charts-stable
-        namespace: kommander-flux
+        name: kommander-charts-stable
+        namespace: kommander
       version: 0.1.8
   interval: 15s
   install:

--- a/services/kommander/0.16.0/kustomization.yaml
+++ b/services/kommander/0.16.0/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - repository.yaml
   - kommander.yaml

--- a/services/kommander/0.16.0/repository.yaml
+++ b/services/kommander/0.16.0/repository.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: kommander-charts-stable
+  namespace: kommander
+spec:
+  interval: 10m
+  timeout: 1m
+  url: "${helmMirrorURL:=https://mesosphere.github.io/charts/stable}"
+---
+# This is to support the HelmReleases created by Kommander's cluster observer controller.
+# See https://github.com/mesosphere/kommander/blob/main/federation/pkg/controllers/clusterobserver_controller.go
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: kommander-kommander-auditing-pipeline-charts
+  namespace: kommander
+spec:
+  interval: 10m
+  timeout: 1m
+  url: "${helmMirrorURL:=https://mesosphere.github.io/kommander-auditing-pipeline/charts}"


### PR DESCRIPTION
**What problem does this PR solve?**:

- Previously, HelmRepository resources were defined separately from the application definitions. This change moves them into the same location as the applications they belong to, ensuring they are included in the same kustomization. This improves maintainability, modularity, and clarity in resource ownership and deployment flow.

**Which issue(s) does this PR fix?**:

<!-- Add a link to the JIRA issue below-->
- https://jira.nutanix.com/browse/NCN-105538

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

- This application is one of the applications that has been migrated. After the successful completion of this migration, the remaining applications will be moved. 

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
- No
