### PR TITLE
refactor: reorder defaultProApps to deploy ai navigator towards the end.

### DIFF
--- a/services/kommander/0.15.0/defaults/cm.yaml
+++ b/services/kommander/0.15.0/defaults/cm.yaml
@@ -75,7 +75,6 @@ data:
       - "thanos"
       - "nkp-insights-management"
       defaultProApps:
-      - "ai-navigator-app"
       - "grafana-logging"
       - "grafana-loki"
       - "kube-prometheus-stack"
@@ -86,14 +85,13 @@ data:
       - "rook-ceph"
       - "rook-ceph-cluster"
       - "velero"
+      - "ai-navigator-app"
     kommander-ui:
       enabled: false
     capimate:
       image:
         tag: v0.0.0-dev.0
     managementApps: # List of apps that are specific to management cluster. Used for platform expansion workflow (exclusively).
-    - "ai-navigator-app"
-    - "ai-navigator-cluster-info-agent"
     - "centralized-grafana"
     - "chartmuseum"
     - "dex"
@@ -108,6 +106,8 @@ data:
     - "thanos"
     - "traefik-forward-auth-mgmt"
     - "kubetunnel"
+    - "ai-navigator-app"
+    - "ai-navigator-cluster-info-agent"
     attached:
       prerequisites:
         defaultApps:


### PR DESCRIPTION
**What problem does this PR solve?**:

`deploy/kommander-licensing-cm ` is failiing in airgapped environments with the following error:

```
2025-05-06T05:52:00.787Z	ERROR	controllers.LicenseProAppDeployment	Reconciler error	{"reconcileID": "7fba97b1-dd1e-417c-ae7d-b2761b13d80c", "error": "unable to get latest version of app ai-navigator-app: no ClusterApps found for app ai-navigator-app"}
```

This is because ai-navigator-app is excluded in airgapped artifacts. As an interim fix for 2.15, we can move it down the list so that other apps are deployed and then the controller will fail on the last app. This has been the behavior since 2.12.0 - https://github.com/mesosphere/kommander-applications/blob/v2.12.0/services/kommander/0.12.0/defaults/cm.yaml#L80

This is an interim fix for 2.15 and we will figure out an ideal fix for 2.16 later.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-107450

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
