### PR TITLE
refactor: reorder defaultProApps to deploy ai nav towards the end

### DIFF
--- a/services/kommander/0.16.0/defaults/cm.yaml
+++ b/services/kommander/0.16.0/defaults/cm.yaml
@@ -76,7 +76,6 @@ data:
       - "thanos"
       - "nkp-insights-management"
       defaultProApps:
-      - "ai-navigator-app"
       - "grafana-logging"
       - "grafana-loki"
       - "kube-prometheus-stack"
@@ -88,14 +87,13 @@ data:
       - "rook-ceph-cluster"
       - "velero"
       - "cilium-hubble-relay-traefik"
+      - "ai-navigator-app"
     kommander-ui:
       enabled: false
     capimate:
       image:
         tag: v0.0.0-dev.0
     managementApps: # List of apps that are specific to management cluster. Used for platform expansion workflow (exclusively).
-    - "ai-navigator-app"
-    - "ai-navigator-cluster-info-agent"
     - "centralized-grafana"
     - "chartmuseum"
     - "dex"
@@ -111,6 +109,8 @@ data:
     - "thanos"
     - "traefik-forward-auth-mgmt"
     - "kubetunnel"
+    - "ai-navigator-app"
+    - "ai-navigator-cluster-info-agent"
     attached:
       prerequisites:
         defaultApps:


### PR DESCRIPTION
**What problem does this PR solve?**:
ports https://github.com/mesosphere/kommander-applications/pull/3495

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-107450

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
