### PR TITLE
chore: Remove unused feature flag

### DIFF
--- a/charts/kommander-operator/templates/deployment.yaml
+++ b/charts/kommander-operator/templates/deployment.yaml
@@ -29,10 +29,6 @@ spec:
         - name: {{ include "kommander-operator.appName" . }}
           image: "{{ .Values.kommanderoperator.image.repository }}:{{ .Values.kommanderoperator.image.tag }}"
           imagePullPolicy: {{ .Values.kommanderoperator.image.pullPolicy }}
-          {{- if .Values.kommanderoperator.useUpgrade }}
-          args:
-          - --feature-gates=UseUpgrade=true
-          {{- end }}
           ports:
             - name: http
               containerPort: 80

--- a/charts/kommander-operator/values.yaml
+++ b/charts/kommander-operator/values.yaml
@@ -2,8 +2,6 @@
 
 replicaCount: 1
 kommanderoperator:
-  # feature flag to enable declarative upgrade logic in the operator
-  useUpgrade: false
   image:
     repository: mesosphere/kommander2-core-installer
     tag:


### PR DESCRIPTION
**What problem does this PR solve?**:
As of https://github.com/mesosphere/kommander/pull/5790 we are not going to use this feature flag anymore.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
