### PR TITLE
fix: Update dependencies for NKP Insights

### DIFF
--- a/services/nkp-insights/1.4.4/metadata.yaml
+++ b/services/nkp-insights/1.4.4/metadata.yaml
@@ -8,6 +8,7 @@ licensing:
   - Enterprise
 requiredDependencies:
   - kube-prometheus-stack
+  - cloudnative-pg
 certifications:
   - airgapped
   - supported

--- a/services/nkp-insights/metadata.yaml
+++ b/services/nkp-insights/metadata.yaml
@@ -8,8 +8,7 @@ licensing:
   - Enterprise
 requiredDependencies:
   - kube-prometheus-stack
-  - rook-ceph
-  - rook-ceph-cluster
+  - cloudnative-pg
 certifications:
   - airgapped
   - supported


### PR DESCRIPTION
**What problem does this PR solve?**:
Add `cloudnative-pg` to the required dependencies for Insights. Remove left-overs of Rook Ceph from the second metadata file.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
