### PR TITLE
chore: Switch metric source from Machine to KubeadmConfig

### DIFF
--- a/services/kube-prometheus-stack/71.0.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/71.0.0/defaults/cm.yaml
@@ -514,8 +514,8 @@ data:
         - namespaces=[*]
       rbac:
         extraRules:
-          - apiGroups: [ "cluster.x-k8s.io" ]
-            resources: ["machines"]
+          - apiGroups: [ "bootstrap.cluster.x-k8s.io" ]
+            resources: ["kubeadmconfigs"]
             verbs: ["get", "list", "watch"]
           - apiGroups: ["controlplane.cluster.x-k8s.io"]
             resources: ["kubeadmcontrolplanes"]
@@ -541,11 +541,11 @@ data:
                       gauge:
                         path: ["spec", "rolloutBefore", "certificatesExpiryDays"]
               - groupVersionKind:
-                  group: cluster.x-k8s.io
+                  group: bootstrap.cluster.x-k8s.io
                   version: v1beta1
-                  kind: Machine
+                  kind: KubeadmConfig
                 labelsFromPath:
-                  machine: ["metadata", "name"]
+                  kubeadmconfig: ["metadata", "name"]
                   namespace: ["metadata", "namespace"]
                 metrics:
                   - name: machine_cert_expiry_days

--- a/services/kube-prometheus-stack/71.0.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/71.0.0/defaults/cm.yaml
@@ -301,19 +301,19 @@ data:
               - alert: CertificateExpiringSoon
                 expr: |
                   min by(namespace,cluster)(
-                  (kube_customresource_machine_cert_expiry_days - time())/86400
+                  (kube_customresource_control_plane_cert_expiry_days - time())/86400
                   )
                   -
                   min by(namespace,cluster)(
-                  kube_customresource_rollout_trigger_days_before_cert_expiry)
+                  kube_customresource_renew_control_plane_certificates_before)
                   > 1
                   and
                   min by(namespace,cluster)(
-                  (kube_customresource_machine_cert_expiry_days - time())/86400
+                  (kube_customresource_control_plane_cert_expiry_days - time())/86400
                   )
                   -
                   min by(namespace,cluster)(
-                  kube_customresource_rollout_trigger_days_before_cert_expiry)
+                  kube_customresource_renew_control_plane_certificates_before)
                   <= 7
                 for: 1d
                 labels:
@@ -324,19 +324,19 @@ data:
               - alert: CertificateRollingOutSoon
                 expr: |
                   min by(namespace,cluster)(
-                  (kube_customresource_machine_cert_expiry_days - time())/86400
+                  (kube_customresource_control_plane_cert_expiry_days - time())/86400
                   )
                   -
                   min by(namespace,cluster)(
-                  kube_customresource_rollout_trigger_days_before_cert_expiry)
+                  kube_customresource_renew_control_plane_certificates_before)
                   > 0
                   and
                   min by(namespace,cluster)(
-                  (kube_customresource_machine_cert_expiry_days - time())/86400
+                  (kube_customresource_control_plane_cert_expiry_days - time())/86400
                   )
                   -
                   min by(namespace,cluster)(
-                  kube_customresource_rollout_trigger_days_before_cert_expiry)
+                  kube_customresource_renew_control_plane_certificates_before)
                   < 1
                 for: 1d
                 labels:
@@ -347,7 +347,7 @@ data:
               - alert: CertificateExpired
                 expr: |
                   (min by(namespace, cluster) (
-                    kube_customresource_machine_cert_expiry_days
+                    kube_customresource_control_plane_cert_expiry_days
                   ) - time()) / 86400 < 0.1
                 for: 1m
                 labels:
@@ -358,7 +358,7 @@ data:
               - alert: CertificateRenewed
                 expr: |
                   (min by(namespace,cluster) (
-                    kube_customresource_machine_cert_expiry_days
+                    kube_customresource_control_plane_cert_expiry_days
                   ) - time()) / 86400 == 365
                 for: 1d
                 labels:
@@ -550,7 +550,7 @@ data:
                   kubeadmcontrolplane: ["metadata", "name"]
                   namespace: ["metadata", "namespace"]
                 metrics:
-                  - name: rollout_trigger_days_before_cert_expiry
+                  - name: renew_control_plane_certificates_before
                     help: "Number of days before certificate expiry when a rollout is triggered"
                     each:
                       type: Gauge
@@ -564,7 +564,7 @@ data:
                   kubeadmconfig: ["metadata", "name"]
                   namespace: ["metadata", "namespace"]
                 metrics:
-                  - name: machine_cert_expiry_days
+                  - name: control_plane_cert_expiry_days
                     help: "Number of days until the certificate associated with the Machine expires"
                     each:
                       type: Gauge

--- a/services/kube-prometheus-stack/71.0.0/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/71.0.0/defaults/cm.yaml
@@ -300,37 +300,53 @@ data:
             rules:
               - alert: CertificateExpiringSoon
                 expr: |
-                  (min by(namespace) (
-                    kube_customresource_machine_cert_expiry_days
-                  ) - time()) / 86400 > 1 + scalar(kube_customresource_rollout_trigger_days_before_cert_expiry)
+                  min by(namespace,cluster)(
+                  (kube_customresource_machine_cert_expiry_days - time())/86400
+                  )
+                  -
+                  min by(namespace,cluster)(
+                  kube_customresource_rollout_trigger_days_before_cert_expiry)
+                  > 1
                   and
-                  (min by(namespace) (
-                  kube_customresource_machine_cert_expiry_days
-                  ) - time()) / 86400 <= 7 + scalar(kube_customresource_rollout_trigger_days_before_cert_expiry)
+                  min by(namespace,cluster)(
+                  (kube_customresource_machine_cert_expiry_days - time())/86400
+                  )
+                  -
+                  min by(namespace,cluster)(
+                  kube_customresource_rollout_trigger_days_before_cert_expiry)
+                  <= 7
                 for: 1d
                 labels:
                   severity: warning
                 annotations:
                   summary: "Certificate expiring soon"
-                  description: "Certificate will expire in less than 7 days"
+                  description: "Certificate will expire soon and rollout will happen in less than 7 days"
               - alert: CertificateRollingOutSoon
                 expr: |
-                  (min by(namespace) (
-                    kube_customresource_machine_cert_expiry_days
-                  ) - time()) / 86400 >= 1 + scalar(kube_customresource_rollout_trigger_days_before_cert_expiry)
+                  min by(namespace,cluster)(
+                  (kube_customresource_machine_cert_expiry_days - time())/86400
+                  )
+                  -
+                  min by(namespace,cluster)(
+                  kube_customresource_rollout_trigger_days_before_cert_expiry)
+                  > 0
                   and
-                  (min by(namespace) (
-                  kube_customresource_machine_cert_expiry_days
-                  ) - time()) / 86400 < 0 + scalar(kube_customresource_rollout_trigger_days_before_cert_expiry)
+                  min by(namespace,cluster)(
+                  (kube_customresource_machine_cert_expiry_days - time())/86400
+                  )
+                  -
+                  min by(namespace,cluster)(
+                  kube_customresource_rollout_trigger_days_before_cert_expiry)
+                  < 1
                 for: 1d
                 labels:
                   severity: info
                 annotations:
                   summary: "Certificate rolling out soon"
-                  description: "Certificate will expire within a day, rollout is expected"
+                  description: "Certificate will expire soon, rollout is expected with in a day"
               - alert: CertificateExpired
                 expr: |
-                  (min by(namespace) (
+                  (min by(namespace, cluster) (
                     kube_customresource_machine_cert_expiry_days
                   ) - time()) / 86400 < 0.1
                 for: 1m
@@ -341,7 +357,7 @@ data:
                   description: "Certificate has expired and was not renewed"
               - alert: CertificateRenewed
                 expr: |
-                  (min by(namespace) (
+                  (min by(namespace,cluster) (
                     kube_customresource_machine_cert_expiry_days
                   ) - time()) / 86400 == 365
                 for: 1d


### PR DESCRIPTION
**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-107084


**Special notes for your reviewer**:
machine_cert_expiry_days is exposed by extending kube-state-metrics using kubeadm config resource instead machine
