### PR TITLE
fix: use pull_request target for GHA

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,6 +1,6 @@
 name: "Automerge"
 on:
-  pull_request_target:
+  pull_request:
     types:
       - labeled
       - unlabeled

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,13 +1,9 @@
 on:
-  pull_request_target:
+  pull_request:
     types:
       - labeled
       - closed
   workflow_dispatch: {}
-
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
   backport:


### PR DESCRIPTION
**What problem does this PR solve?**:
Don't use `pull_request_target` for GHA.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-107016

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
There are 2 workflows updates.

`automerge.yaml`: the `pull_request_target` trigger couldn't work properly as the token is missing the `pull-request: write` permission necessary for approving a PR.

`backport.yaml`: implication will be that it won't be possible to run backport action on PRs that are coming from a fork.

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
