### PR TITLE
feat: bump kubectl version to 1.31.9

### DIFF
--- a/apptests/appscenarios/contants.go
+++ b/apptests/appscenarios/contants.go
@@ -21,5 +21,5 @@ const (
 
 	// Velero constants
 	kubetoolsImageRepository = "bitnami/kubectl"
-	kubetoolsImageTag        = "1.31.4"
+	kubetoolsImageTag        = "1.31.9"
 )

--- a/common/build/list-images-values.yaml
+++ b/common/build/list-images-values.yaml
@@ -1,3 +1,3 @@
 secretName: unused
 commonName: unused
-kubectlImage: bitnami/kubectl:1.31.4
+kubectlImage: bitnami/kubectl:1.31.9

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -521,7 +521,7 @@ resources:
       - url: https://github.com/NVIDIA/cuda-samples
         ref: v12.5
         license_path: LICENSE
-  - container_image: docker.io/bitnami/kubectl:1.31.4
+  - container_image: docker.io/bitnami/kubectl:1.31.9
     sources:
       - url: https://github.com/kubernetes/kubectl
         ref: v0${image_tag#1}

--- a/services/ai-navigator-app/0.2.10/defaults/cm.yaml
+++ b/services/ai-navigator-app/0.2.10/defaults/cm.yaml
@@ -95,4 +95,4 @@ data:
     tolerations: []
 
     affinity: {}
-    kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.4}
+    kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.9}

--- a/services/dex/2.14.1/defaults/cm.yaml
+++ b/services/dex/2.14.1/defaults/cm.yaml
@@ -7,7 +7,7 @@ data:
   values.yaml: |-
     ---
     priorityClassName: "dkp-critical-priority"
-    kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.4}"
+    kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.9}"
     image: mesosphere/dex
     imageTag: v2.41.1-d2iq.2
     resources:

--- a/services/git-operator/0.1.3/kustomization.yaml
+++ b/services/git-operator/0.1.3/kustomization.yaml
@@ -27,4 +27,4 @@ patches:
     name: git-operator-git-webserver
 images:
   - name: bitnami/kubectl
-    newTag: 1.31.4
+    newTag: 1.31.9

--- a/services/grafana-loki/0.79.5/grafana-loki-pre-install-jobs/pre-install.yaml
+++ b/services/grafana-loki/0.79.5/grafana-loki-pre-install-jobs/pre-install.yaml
@@ -46,7 +46,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: pre-install
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.4}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.9}"
           command:
             - sh
             - -c

--- a/services/harbor/1.16.2/defaults/harbor.yaml
+++ b/services/harbor/1.16.2/defaults/harbor.yaml
@@ -117,7 +117,7 @@ data:
       enabled: false
       transformations:
         priorityClassName: dkp-high-priority
-        kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.4}
+        kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.9}
         harbor:
           enabled: true
           cmName: harbor-cosi-overrides
@@ -131,4 +131,4 @@ data:
       targetSecretName: "harbor-s3-credentials"
       reloader: true
 
-      kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.4}
+      kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.9}

--- a/services/harbor/1.16.2/pre-install/pre-install-jobs.yaml
+++ b/services/harbor/1.16.2/pre-install/pre-install-jobs.yaml
@@ -69,7 +69,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: generate-harbor-admin-password
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.4}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.9}"
           command:
             - bash
             - -c
@@ -96,7 +96,7 @@ spec:
                 --from-literal=HARBOR_ADMIN_PASSWORD=$(tr -dc 'A-Za-z0-9!?%=' < /dev/urandom | head -c 20) | \
                 kubectl apply --server-side -f -
         - name: generate-valkey-password
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.4}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.9}"
           command:
             - bash
             - -c

--- a/services/istio/1.23.3/defaults/cm.yaml
+++ b/services/istio/1.23.3/defaults/cm.yaml
@@ -30,7 +30,7 @@ data:
           prometheus.kommander.d2iq.io/select: "true"
     global:
       image: ${kubetoolsImageRepository:=bitnami/kubectl}
-      tag: ${kubetoolsImageTag:=1.31.4}
+      tag: ${kubetoolsImageTag:=1.31.9}
       priorityClassName: "dkp-critical-priority"
     operator:
       # expose metrics for prometheus scraping

--- a/services/knative/1.17.0/defaults/cm.yaml
+++ b/services/knative/1.17.0/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
     global:
       priorityClassName: "dkp-high-priority"
       image: ${kubetoolsImageRepository:=bitnami/kubectl}
-      tag: ${kubetoolsImageTag:=1.31.4}
+      tag: ${kubetoolsImageTag:=1.31.9}
     eventing:
       enabled: false
     eventing-sources:

--- a/services/kommander/0.14.1/dynamic-helmreleases/cluster-observer/list-images-values.yaml
+++ b/services/kommander/0.14.1/dynamic-helmreleases/cluster-observer/list-images-values.yaml
@@ -1,2 +1,2 @@
 hooks:
-  kubectlImage: "bitnami/kubectl:1.31.4"
+  kubectlImage: "bitnami/kubectl:1.31.9"

--- a/services/kube-prometheus-stack/69.1.3/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/69.1.3/defaults/cm.yaml
@@ -30,7 +30,7 @@ data:
     mesosphereResources:
       create: true
       hooks:
-        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.4}"
+        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.9}"
       rules:
         # addon alert rules are defaulted to false to prevent potential misfires if addons
         # are disabled.

--- a/services/kubecost/2.5.2/defaults/cm.yaml
+++ b/services/kubecost/2.5.2/defaults/cm.yaml
@@ -286,7 +286,7 @@ data:
           credentialsSecretName: federated-store
       transformations:
         priorityClassName: dkp-high-priority
-        kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.4}
+        kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.9}
         kubecost:
           enabled: true
   # Overrides for kubecost to run in primary mode for multi cluster setup with object storage.

--- a/services/kubecost/2.5.2/pre-install/pre-install-jobs.yaml
+++ b/services/kubecost/2.5.2/pre-install/pre-install-jobs.yaml
@@ -65,7 +65,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: create-kubecost-cluster-info-configmap
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.4}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.9}"
           command:
             - bash
             - -c

--- a/services/kubefed/0.11.1/defaults/cm.yaml
+++ b/services/kubefed/0.11.1/defaults/cm.yaml
@@ -38,7 +38,7 @@ data:
       postInstallJob:
         repository: bitnami
         image: kubectl
-        tag: 1.31.4
+        tag: 1.31.9
       webhook:
         annotations:
           secret.reloader.stakater.com/reload: "kubefed-root-ca"

--- a/services/kubetunnel/0.0.39/defaults/cm.yaml
+++ b/services/kubetunnel/0.0.39/defaults/cm.yaml
@@ -17,7 +17,7 @@ data:
     hooks:
       kubectlImage:
         repository: "${kubetoolsImageRepository:=bitnami/kubectl}"
-        tag: "${kubetoolsImageTag:=1.31.4}"
+        tag: "${kubetoolsImageTag:=1.31.9}"
     controller:
       manager:
         resources:

--- a/services/nkp-insights-management/1.4.4/defaults/cm.yaml
+++ b/services/nkp-insights-management/1.4.4/defaults/cm.yaml
@@ -34,7 +34,7 @@ data:
     insightsCRIngress:
       globalRateLimitAverageQPS: 100
       globalRateLimitBurst: 100
-    kubectlImage: bitnami/kubectl:1.31.4
+    kubectlImage: bitnami/kubectl:1.31.9
     managementCM:
       backendTokenTTL: 1h
       insightsTTL: 72h

--- a/services/nkp-insights/1.4.4/defaults/cm.yaml
+++ b/services/nkp-insights/1.4.4/defaults/cm.yaml
@@ -302,7 +302,7 @@ data:
             cpu: 100m
             memory: 512Mi
       schedule: '@every 35m'
-    kubectlImage: bitnami/kubectl:1.31.4
+    kubectlImage: bitnami/kubectl:1.31.9
     nova:
       baseEvaluationTimeout: 1m
       enabled: true

--- a/services/project-grafana-loki/0.79.5/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.79.5/defaults/cm.yaml
@@ -27,7 +27,7 @@ data:
     ####################################################################
 
     # this is used in object-bucket-claims overrides
-    kubectlImage: bitnami/kubectl:1.31.4
+    kubectlImage: bitnami/kubectl:1.31.9
 
     loki:
       ingesterFullname: loki-ingester

--- a/services/rook-ceph-cluster/1.16.2/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.16.2/defaults/cm.yaml
@@ -244,7 +244,7 @@ data:
           memory: "100Mi"
 
     # this is used in object-bucket-claims overrides
-    kubectlImage: bitnami/kubectl:1.31.4
+    kubectlImage: bitnami/kubectl:1.31.9
 
     #################################################################
     ## BEGIN NKP specific config overrides                         ##

--- a/services/rook-ceph-cluster/1.16.2/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.16.2/pre-install/ceph-crd-check.yaml
@@ -47,7 +47,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: pre-install
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.4}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.9}"
           command:
             - sh
             - -c
@@ -57,7 +57,7 @@ spec:
                 sleep 30
               done
         - name: pre-upgrade
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.4}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.9}"
           command:
             - sh
             - -c

--- a/services/thanos/15.7.24/jobs/jobs.yaml
+++ b/services/thanos/15.7.24/jobs/jobs.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.4}"
+          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.31.9}"
           command:
             - sh
             - "-c"

--- a/services/velero/8.3.0/defaults/cm.yaml
+++ b/services/velero/8.3.0/defaults/cm.yaml
@@ -57,4 +57,4 @@ data:
       image:
         # If we don't override the version here, upstream chart will pull an image dynamically based on k8s cluster version.
         # which makes it harder to build airgapped tar bundles. So to make bundle collection predictable, we override the tag here.
-        tag: "${kubetoolsImageTag:=1.31.4}"
+        tag: "${kubetoolsImageTag:=1.31.9}"

--- a/services/velero/8.3.0/velero-pre-install.yaml
+++ b/services/velero/8.3.0/velero-pre-install.yaml
@@ -19,4 +19,4 @@ spec:
     substitute:
       releaseNamespace: ${releaseNamespace}
       kubetoolsImageRepository: ${kubetoolsImageRepository:=bitnami/kubectl}
-      kubetoolsImageTag: ${kubetoolsImageTag:=1.31.4}
+      kubetoolsImageTag: ${kubetoolsImageTag:=1.31.9}


### PR DESCRIPTION
**What problem does this PR solve?**:
bump the k8s 1.31 to latest patch 1.31.9

release 2.14.1


**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-107606


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
