### PR TITLE
feat: add external secrets operator app

### DIFF
--- a/.github/service-labeler.yaml
+++ b/.github/service-labeler.yaml
@@ -42,6 +42,10 @@ services/external-dns:
 - changed-files:
   - any-glob-to-any-file:
     - services/external-dns/**
+services/external-secrets:
+- changed-files:
+  - any-glob-to-any-file:
+    - services/external-secrets/**
 services/fluent-bit:
 - changed-files:
   - any-glob-to-any-file:

--- a/common/helm-repositories/external-secrets.yaml
+++ b/common/helm-repositories/external-secrets.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: charts.external-secrets.io
+  namespace: kommander-flux
+spec:
+  interval: 10m
+  timeout: 1m
+  url: "${helmMirrorURL:=https://charts.external-secrets.io}"

--- a/common/helm-repositories/kustomization.yaml
+++ b/common/helm-repositories/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - cert-manager.yaml
   - cloudnative-pg.yaml
   - dashboard.yaml
+  - external-secrets.yaml
   - fluent.yaml
   - gatekeeper.yaml
   - grafana.yaml

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -651,3 +651,8 @@ resources:
       - url: https://github.com/nutanix-cloud-native/cosi-driver-nutanix
         ref: ${image_tag}
         license_path: LICENSE
+  - container_image: ghcr.io/external-secrets/external-secrets:v0.17.0
+    sources:
+      - url: https://github.com/external-secrets/external-secrets
+        ref: ${image_tag}
+        license_path: LICENSE

--- a/services/external-secrets/0.17.0/defaults/cm.yaml
+++ b/services/external-secrets/0.17.0/defaults/cm.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: external-secrets-0.17.0-config-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    installCRDs: true
+
+    priorityClassName: dkp-critical-priority
+    image:
+      repository: ghcr.io/external-secrets/external-secrets
+      favour: "distroless"
+
+    # Use cert manager for webhook TLS.
+    certController:
+      create: false
+
+    webhook:
+      image:
+        repository: ghcr.io/external-secrets/external-secrets
+        favour: "distroless"
+      priorityClassName: dkp-critical-priority
+      create: true
+      certManager:
+        enabled: true
+        cert:
+          create: true
+          issuerRef:
+            kind: ClusterIssuer
+            name: kommander-ca
+
+    serviceMonitor:
+      enabled: true
+      additionalLabels: {}
+
+    grafanaDashboard:
+      enabled: true

--- a/services/external-secrets/0.17.0/defaults/kustomization.yaml
+++ b/services/external-secrets/0.17.0/defaults/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cm.yaml

--- a/services/external-secrets/0.17.0/external-secrets-namespace.yaml
+++ b/services/external-secrets/0.17.0/external-secrets-namespace.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: external-secrets-namespace
+  namespace: ${releaseNamespace}
+spec:
+  force: false
+  prune: false
+  wait: true
+  interval: 6h
+  retryInterval: 1m
+  timeout: 1m
+  path: ./services/external-secrets/0.17.0/external-secrets-namespace
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux

--- a/services/external-secrets/0.17.0/external-secrets-namespace/external-secrets.yaml
+++ b/services/external-secrets/0.17.0/external-secrets-namespace/external-secrets.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: external-secrets

--- a/services/external-secrets/0.17.0/kustomization.yaml
+++ b/services/external-secrets/0.17.0/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secrets-namespace.yaml
+  - release.yaml

--- a/services/external-secrets/0.17.0/metadata.yaml
+++ b/services/external-secrets/0.17.0/metadata.yaml
@@ -1,0 +1,9 @@
+type: internal
+scope:
+  - workspace
+licensing:
+  - Starter
+  - Pro
+  - Ultimate
+  - Essential
+  - Enterprise

--- a/services/external-secrets/0.17.0/release.yaml
+++ b/services/external-secrets/0.17.0/release.yaml
@@ -1,0 +1,28 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: external-secrets-release
+  namespace: ${releaseNamespace}
+spec:
+  force: false
+  prune: true
+  wait: true
+  interval: 6h
+  retryInterval: 1m
+  path: ./services/external-secrets/0.17.0/release
+  dependsOn:
+    - name: external-secrets-namespace
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 1m
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: substitution-vars
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: external-secrets
+      namespace: ${releaseNamespace}

--- a/services/external-secrets/0.17.0/release/kustomization.yaml
+++ b/services/external-secrets/0.17.0/release/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yaml

--- a/services/external-secrets/0.17.0/release/release.yaml
+++ b/services/external-secrets/0.17.0/release/release.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-secrets
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: external-secrets
+      sourceRef:
+        kind: HelmRepository
+        name: charts.external-secrets.io
+        namespace: kommander-flux
+      version: "0.17.0"
+  interval: 15s
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+  targetNamespace: external-secrets
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+  releaseName: external-secrets
+  valuesFrom:
+    - kind: ConfigMap
+      name: external-secrets-0.17.0-config-defaults
+    - kind: ConfigMap
+      name: external-secrets-overrides
+      optional: true

--- a/services/external-secrets/metadata.yaml
+++ b/services/external-secrets/metadata.yaml
@@ -1,0 +1,9 @@
+type: internal
+scope:
+  - workspace
+licensing:
+  - Starter
+  - Pro
+  - Ultimate
+  - Essential
+  - Enterprise


### PR DESCRIPTION
**What problem does this PR solve?**:
Adds external-secrets operator app

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-107784

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
