### PR TITLE
fix: rook ceph cluster job dependency

### DIFF
--- a/services/rook-ceph-cluster/1.17.1/rook-ceph-cluster.yaml
+++ b/services/rook-ceph-cluster/1.17.1/rook-ceph-cluster.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   dependsOn:
     # There can only be one operator per cluster, just ensure CRDs are present, no need to wait for actual operator Deployment.
-    - name: rook-ceph-cluster-prereq-jobs-v1.17.0
+    - name: rook-ceph-cluster-prereq-jobs-v1.17.1
       namespace: ${workspaceNamespace}
   force: false
   prune: true


### PR DESCRIPTION
**What problem does this PR solve?**:
Dependency wasn't bumped which blocks the rook ceph cluster app installation

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
