### PR TITLE
ci: use new slack webhook config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,10 +82,9 @@ jobs:
       - name: Send slack message if any of the release jobs failed
         if: ${{contains(needs.*.result, 'failure') }}
         uses: slackapi/slack-github-action@v2.1.0
-        env:
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-          SLACK_WEBHOOK_URL: ${{ endsWith(github.ref_name, '-dev') && secrets.DKP_TESTING_ALERTMANAGER_SLACK_URL || secrets.SLACK_WEBHOOK_NTNX_NCNDKPSHIPIT }}
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_NTNX_NCNDKPSHIPIT }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "blocks": [
@@ -109,10 +108,9 @@ jobs:
       - name: Send slack message when all release jobs completed successfully
         if: ${{ !contains(needs.*.result, 'failure') && !endsWith(github.ref_name, '-dev') }} # No need to send a message on daily releases.
         uses: slackapi/slack-github-action@v2.1.0
-        env:
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NTNX_NCNDKPSHIPIT }}
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_NTNX_NCNDKPSHIPIT }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "blocks": [


### PR DESCRIPTION
**What problem does this PR solve?**:

#3506 bumped the slack send message action which introduced some breaking changes (see https://github.com/slackapi/slack-github-action/issues/372#issuecomment-2518209779 )  in the action config.

https://github.com/slackapi/slack-github-action/blob/v2.1.0/action.yml#L37-L42

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

Fixes this error:
https://github.com/mesosphere/kommander-applications/actions/runs/15615724298/job/44018612388
```
Run slackapi/slack-github-action@v2.1.0
Error: Missing input! The webhook type must be 'incoming-webhook' or 'webhook-trigger'.
SlackError: Missing input! The webhook type must be 'incoming-webhook' or 'webhook-trigger'.
    at Config.validate (file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/src/config.js:177:1)
    at new Config (file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/src/config.js:124:1)
    at send (file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/src/send.js:13:1)
    at file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/src/index.js:9:1
    at Function.__nccwpck_require__.a (file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/webpack/runtime/async module:49:1)
    at Object.9722 (file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/dist/index.js:45784:21)
    at __nccwpck_require__ (file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/webpack/bootstrap:21:1)
    at file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/webpack/startup:4:1
    at ModuleJob.run (node:internal/modules/esm/module_job:263:25)
    at ModuleLoader.import (node:internal/modules/esm/loader:540:24)

file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/src/config.js:177
          throw new SlackError(
^
SlackError: Missing input! The webhook type must be 'incoming-webhook' or 'webhook-trigger'.
    at Config.validate (file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/src/config.js:177:1)
    at new Config (file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/src/config.js:124:1)
    at send (file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/src/send.js:13:1)
    at file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/src/index.js:9:1
    at Function.__nccwpck_require__.a (file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/webpack/runtime/async module:49:1)
    at Object.9722 (file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/dist/index.js:45784:21)
    at __nccwpck_require__ (file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/webpack/bootstrap:21:1)
    at file:///runner/_work/_actions/slackapi/slack-github-action/v2.1.0/webpack/startup:4:1
    at ModuleJob.run (node:internal/modules/esm/module_job:263:25)
    at ModuleLoader.import (node:internal/modules/esm/loader:540:24)
```

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
