### PR TITLE
fix: Revert "Create applications symlink to services"

### DIFF
--- a/applications
+++ b/applications
@@ -1,1 +1,0 @@
-services


### PR DESCRIPTION
Reverts mesosphere/kommander-applications#3591

It is causing installs to fail -- reverting for now, will probably just have to rename services to applications altogether.