### PR TITLE
fix: use ociRegistryURL only for registry

### DIFF
--- a/applications/external-dns/8.5.1/external-dns.yaml
+++ b/applications/external-dns/8.5.1/external-dns.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
-  url: "${ociRegistryURL:=oci://docker.io/bitnamicharts}/external-dns"
+  url: "${ociRegistryURL:=oci://docker.io}/bitnamicharts/external-dns"
   ref:
     tag: 8.5.0
 ---

--- a/applications/grafana-logging/8.15.1/grafana.yaml
+++ b/applications/grafana-logging/8.15.1/grafana.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
-  url: "${ociRegistryURL:=oci://ghcr.io/grafana/helm-charts}/grafana"
+  url: "${ociRegistryURL:=oci://ghcr.io}/grafana/helm-charts/grafana"
   ref:
     tag: 8.15.0
 ---

--- a/applications/grafana-loki/0.80.4/grafana-loki-helmrelease/grafana-loki.yaml
+++ b/applications/grafana-loki/0.80.4/grafana-loki-helmrelease/grafana-loki.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
-  url: "${ociRegistryURL:=oci://ghcr.io/grafana/helm-charts}/loki-distributed"
+  url: "${ociRegistryURL:=oci://ghcr.io}/grafana/helm-charts/loki-distributed"
   ref:
     tag: 0.80.3
 ---

--- a/applications/kommander-appmanagement/0.16.0/kommander-appmanagement.yaml
+++ b/applications/kommander-appmanagement/0.16.0/kommander-appmanagement.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
-  url: "${ociRegistryURL:=oci://docker.io/mesosphere}/kommander-appmanagement-chart"
+  url: "${ociRegistryURL:=oci://docker.io}/mesosphere/kommander-appmanagement-chart"
   ref:
     tag: "${kommanderChartVersion:=v2.16.0-dev}"
 ---

--- a/applications/kommander/0.16.0/kommander.yaml
+++ b/applications/kommander/0.16.0/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
-  url: "${ociRegistryURL:=oci://docker.io/mesosphere}/kommander-chart"
+  url: "${ociRegistryURL:=oci://docker.io}/mesosphere/kommander-chart"
   ref:
     tag: "${kommanderChartVersion:=v2.16.0-dev}"
 ---

--- a/applications/project-grafana-logging/8.15.1/project-grafana.yaml
+++ b/applications/project-grafana-logging/8.15.1/project-grafana.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
-  url: "${ociRegistryURL:=oci://ghcr.io/grafana/helm-charts}/grafana"
+  url: "${ociRegistryURL:=oci://ghcr.io}/grafana/helm-charts/grafana"
   ref:
     tag: 8.15.0
 ---

--- a/applications/project-grafana-loki/0.80.4/project-grafana-loki.yaml
+++ b/applications/project-grafana-loki/0.80.4/project-grafana-loki.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
-  url: "${ociRegistryURL:=oci://ghcr.io/grafana/helm-charts}/loki-distributed"
+  url: "${ociRegistryURL:=oci://ghcr.io}/grafana/helm-charts/loki-distributed"
   ref:
     tag: 0.80.3
 ---

--- a/applications/thanos/15.8.1/thanos.yaml
+++ b/applications/thanos/15.8.1/thanos.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
-  url: "${ociRegistryURL:=oci://docker.io/bitnamicharts}/thanos"
+  url: "${ociRegistryURL:=oci://docker.io}/bitnamicharts/thanos"
   ref:
     tag: 15.8.0
 ---

--- a/hack/release/pkg/chartversion/chartversion.go
+++ b/hack/release/pkg/chartversion/chartversion.go
@@ -48,7 +48,7 @@ func UpdateChartVersions(kommanderApplicationsRepo, chartVersion string) error {
 		subVars := map[string]string{
 			"kommanderChartVersion": chartVersion,
 			"releaseNamespace":      "${releaseNamespace}",
-			"ociRegistryURL":        "${ociRegistryURL:=oci://docker.io/mesosphere}",
+			"ociRegistryURL":        "${ociRegistryURL:=oci://docker.io}",
 		}
 		updatedFile, err := parsedFile.Execute(func(s string) string {
 			return subVars[s]


### PR DESCRIPTION
**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
