### PR TITLE
fix: ocirepository to root app definition

### DIFF
--- a/applications/grafana-loki/0.80.4/_repository.yaml
+++ b/applications/grafana-loki/0.80.4/_repository.yaml
@@ -1,0 +1,12 @@
+# Source: https://github.com/grafana/helm-charts/pkgs/container/helm-charts%2Floki-distributed
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: loki-distributed
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: "${ociRegistryURL:=oci://ghcr.io}/grafana/helm-charts/loki-distributed"
+  ref:
+    tag: 0.80.3

--- a/applications/grafana-loki/0.80.4/grafana-loki-helmrelease/grafana-loki.yaml
+++ b/applications/grafana-loki/0.80.4/grafana-loki-helmrelease/grafana-loki.yaml
@@ -1,15 +1,3 @@
-# Source: https://github.com/grafana/helm-charts/pkgs/container/helm-charts%2Floki-distributed
----
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: loki-distributed
-  namespace: ${releaseNamespace}
-spec:
-  interval: 1m
-  url: "${ociRegistryURL:=oci://ghcr.io}/grafana/helm-charts/loki-distributed"
-  ref:
-    tag: 0.80.3
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/applications/grafana-loki/0.80.4/kustomization.yaml
+++ b/applications/grafana-loki/0.80.4/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - grafana-loki-helmrelease.yaml
   - grafana-dashboards
   - grafana-dashboards-logging
+  - _repository.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:
Temporarily we need to have all ocirepository definitions in the app root repository definition - its because of  how `k-cli` discovers charts. We'll be able to relax this requirement when k-cli chart discovery is not used anymore.

The name is prefixed with `_` because k-cli uses golang `filepath.WalkDir` which uses lexical ordering when visiting files.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-107844


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
