### PR TITLE
feat: add oci url list in kommander configmap

### DIFF
--- a/applications/kommander/0.16.0/defaults/cm.yaml
+++ b/applications/kommander/0.16.0/defaults/cm.yaml
@@ -129,4 +129,4 @@ data:
         - "cilium-hubble-relay-traefik"
     catalogCollections:
     - registry: ghcr.io
-      repository: nroshanrai/nkp-partner-catalog
+      repository: nutanix-cloud-native/nkp-partner-catalog


### PR DESCRIPTION
**What problem does this PR solve?**:
- add `catalogOciRepositories` key-value in kommander default configmap
- this will help to point the k8s ocirepository object to this oci repository https://github.com/orgs/nutanix-cloud-native/packages/container/package/nkp-partner-catalog
**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
