### PR TITLE
fix: rook-ceph wait script for OCI repository version

### DIFF
--- a/applications/rook-ceph-cluster/1.17.5/pre-install.yaml
+++ b/applications/rook-ceph-cluster/1.17.5/pre-install.yaml
@@ -19,4 +19,4 @@ spec:
     substitute:
       releaseNamespace: ${releaseNamespace}
       # Update the following version whenever ceph-cluster service is bumped.
-      desiredCephOperatorVersion: v1.17.5
+      desiredCephOperatorVersion: 1.17.5

--- a/applications/rook-ceph-cluster/1.17.5/pre-install/ceph-crd-check.yaml
+++ b/applications/rook-ceph-cluster/1.17.5/pre-install/ceph-crd-check.yaml
@@ -64,7 +64,7 @@ spec:
             - |
               # If there is a HelmRelease managed by NKP in same namespace when this job is being ran, it *might* be an
               # upgrade scenario. If there is no such helm release, there is no way this is an upgrade scenario.
-              # Iff there is such a helmrelease, wait for it to be healthy and be of the same version.
+              # If there is such a helmrelease, wait for it to be healthy and be of the same version.
               #
               # This is done here to avoid having an explicit dependency against NKP shipped ceph operator while still
               # being able to allow us to wait for NKP shipped ceph operator if there is one.
@@ -83,8 +83,8 @@ spec:
 
               echo "Waiting for ceph operator to complete its upgrade..."
               while true; do
-                cephOperatorVersion=$(kubectl get helmreleases.helm.toolkit.fluxcd.io -n ${releaseNamespace} rook-ceph -ogo-template={{.status.lastAttemptedRevision}})
-                if [[ $cephOperatorVersion == ${desiredCephOperatorVersion} ]]; then
+                cephOperatorVersion=$(kubectl get helmreleases.helm.toolkit.fluxcd.io -n ${releaseNamespace} rook-ceph -ogo-template={{.status.lastAttemptedRevision}} | cut -d '+' -f 1)
+                if [[ "$cephOperatorVersion" == "${desiredCephOperatorVersion}" ]]; then
                   echo "Ceph operator is at same version as desired cluster version (${desiredCephOperatorVersion}). Exiting..."
                   break
                 fi


### PR DESCRIPTION
**What problem does this PR solve?**:
By using OCI repository the last attempted version now contains helm chart artifact SHA.

```
Ceph operator is at 1.17.5+82c0fb0fd927 version and desired version is v1.17.5. Continuing to wait...
```

This condition thus will never resolve correctly.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
