### PR TITLE
build: bring back list-oci-artifacts.sh

### DIFF
--- a/hack/list-oci-artifacts.sh
+++ b/hack/list-oci-artifacts.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+REPO_ROOT="$(realpath "$(dirname "${SCRIPT_DIR}")")"
+readonly REPO_ROOT
+pushd "${REPO_ROOT}" &>/dev/null
+
+trap_add() {
+  local -r sig="${2:?Signal required}"
+  local -r hdls="$(trap -p "${sig}" | cut --fields=2 --delimiter=\')"
+  # shellcheck disable=SC2064 # Quotes are required here to properly expand when adding the new trap.
+  trap "${hdls}${hdls:+;}${1:?Handler required}" "${sig}"
+}
+
+# Dummy variables to satisfy substitution vars used by Flux. Almost all of these do not affect the image being bundled,
+# hence have values such as "unused" or are actually empty.
+# If a substitution var is missed here, this script will fail below because `envsubst -no-unset` flag ensures that all
+# necessary variables are set. In that case, the missing variables should be evaluated and added to this list as
+# appropriate.
+declare -rx releaseNamespace=unused \
+            kommanderChartVersion="${kommanderChartVersion:-}" \
+            ociRegistryURL="${ociRegistryURL:-}"
+
+IMAGES_FILE="$(realpath "$(mktemp .helm-list-images-XXXXXX)")"
+readonly IMAGES_FILE
+trap_add "rm --force ${IMAGES_FILE}" EXIT
+
+for dir in $(find . -path "./apptests/*" -prune -o -type f -name "*.yaml" -print0 | xargs --null --max-lines=1 --no-run-if-empty -- grep --files-with-matches '^kind: OCIRepository' | grep --only-matching "\(.*\)/" | sort --unique); do
+  pushd "${dir}" &>/dev/null
+  while IFS= read -r ocirepo_path; do
+    >&2 echo "+ ${dir}${ocirepo_path}"
+     envsubst -no-unset -no-digit < "${ocirepo_path}" | \
+      yq -r --no-doc 'select(.kind == "OCIRepository") | .spec.url + ":" + .spec.ref.tag' | \
+      >&2 tee -a "${IMAGES_FILE}"
+  done < <(grep --recursive --max-count=1 --files-with-matches '^kind: OCIRepository')
+  popd &>/dev/null
+done
+
+sort --unique "$IMAGES_FILE" | sed 's|^oci://||'


### PR DESCRIPTION
**What problem does this PR solve?**:
looks like this script is used in kommander 
https://github.com/mesosphere/kommander/actions/runs/16149152984/job/45578958488#step:16:1579

https://github.com/mesosphere/kommander/blob/8d6f9b58be39b6c7b29a8dc063b00b0c588d3179/make/release.mk#L84

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
