### PR TITLE
feat: update cosi-driver-nutanix to OCI

### DIFF
--- a/applications/cosi-driver-nutanix/0.6.0/cosi-driver-nutanix.yaml
+++ b/applications/cosi-driver-nutanix/0.6.0/cosi-driver-nutanix.yaml
@@ -1,3 +1,13 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cosi-driver-nutanix
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1h0m0s
+  url: ${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/cosi-driver-nutanix
+  ref:
+    tag: 0.6.0
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -5,14 +15,10 @@ metadata:
   name: cosi-driver-nutanix
   namespace: ${releaseNamespace}
 spec:
-  chart:
-    spec:
-      chart: cosi-driver-nutanix
-      sourceRef:
-        kind: HelmRepository
-        name: mesosphere.github.io-charts-staging
-        namespace: kommander-flux
-      version: 0.6.0
+  chartRef:
+    kind: OCIRepository
+    name: cosi-driver-nutanix
+    namespace: ${releaseNamespace}
   interval: 15s
   install:
     crds: CreateReplace

--- a/applications/cosi-driver-nutanix/0.6.0/cosi-resources-nutanix.yaml
+++ b/applications/cosi-driver-nutanix/0.6.0/cosi-resources-nutanix.yaml
@@ -1,17 +1,24 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cosi-bucket-kit
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: "${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/cosi-bucket-kit"
+  ref:
+    tag: 0.0.5
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: cosi-resources-nutanix
   namespace: ${releaseNamespace}
 spec:
-  chart:
-    spec:
-      chart: cosi-bucket-kit
-      sourceRef:
-        kind: HelmRepository
-        name: mesosphere.github.io-charts-stable
-        namespace: kommander-flux
-      version: 0.0.5
+  chartRef:
+    kind: OCIRepository
+    name: cosi-bucket-kit
+    namespace: ${releaseNamespace}
   interval: 15s
   dependsOn:
     # This dependency is not honored during Upgrade, only during Install.


### PR DESCRIPTION
What problem does this PR solve?:

bump cost-analyzer chart to 2.8.0
OCI migration of cosi-driver-nutanix
OCI migration of cosi-bucket-kit

Which issue(s) does this PR fix?:

Jira: https://jira.nutanix.com/browse/NCN-108249
Special notes for your reviewer:

Does this PR introduce a user-facing change?:

Checklist

If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).