### PR TITLE
refactor: migrate kube-oidc-proxy to OCI

### DIFF
--- a/applications/kube-oidc-proxy/0.3.6/kube-oidc-proxy.yaml
+++ b/applications/kube-oidc-proxy/0.3.6/kube-oidc-proxy.yaml
@@ -1,4 +1,15 @@
 ---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kube-oidc-proxy
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: "${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/kube-oidc-proxy"
+  ref:
+    tag: 0.3.4
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -14,14 +25,10 @@ spec:
   # The dependency is not added yet because it would break default installation
   # into management cluster ns.
   # JIRA: https://jira.d2iq.com/browse/D2IQ-78147
-  chart:
-    spec:
-      chart: kube-oidc-proxy
-      sourceRef:
-        kind: HelmRepository
-        name: mesosphere.github.io-charts-staging
-        namespace: kommander-flux
-      version: 0.3.4
+  chartRef:
+    kind: OCIRepository
+    name: kube-oidc-proxy
+    namespace: ${releaseNamespace}
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:
migrate kube-oidc-proxy to OCI
https://github.com/mesosphere/kommander-applications/pkgs/container/charts%2Fkube-oidc-proxy

```
sandhya.ravi@GT9X7CVF5F oci-ghcr % helm pull oci://ghcr.io/mesosphere/charts/kube-oidc-proxy:0.3.4                          
Pulled: ghcr.io/mesosphere/charts/kube-oidc-proxy:0.3.4
Digest: sha256:89112ff2b328423f56491d3f01e0b6d6ef0d1aa325ffa225c955cf80c76ba495
```

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-108250


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
