### PR TITLE
refactor: migrate knative chart to OCIRepository

### DIFF
--- a/applications/knative/1.18.1/knative-deployment.yaml
+++ b/applications/knative/1.18.1/knative-deployment.yaml
@@ -19,10 +19,10 @@ spec:
   dependsOn:
     - name: knative-operator
       namespace: ${releaseNamespace}
-  chartref:
-      kind: OCIRepository
-      name: knative
-      namespace: ${releaseNamespace}
+  chartRef:
+    kind: OCIRepository
+    name: knative
+    namespace: ${releaseNamespace}
   interval: 15s
   install:
     crds: CreateReplace

--- a/applications/knative/1.18.1/knative-deployment.yaml
+++ b/applications/knative/1.18.1/knative-deployment.yaml
@@ -1,3 +1,15 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: knative
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: "${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/knative"
+  ref:
+    tag: 1.18.1
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -7,14 +19,10 @@ spec:
   dependsOn:
     - name: knative-operator
       namespace: ${releaseNamespace}
-  chart:
-    spec:
-      chart: knative
-      sourceRef:
-        kind: HelmRepository
-        name: mesosphere.github.io-charts-staging
-        namespace: kommander-flux
-      version: 1.18.1
+  chartref:
+      kind: OCIRepository
+      name: knative
+      namespace: ${releaseNamespace}
   interval: 15s
   install:
     crds: CreateReplace

--- a/applications/knative/1.18.1/knative-operator.yaml
+++ b/applications/knative/1.18.1/knative-operator.yaml
@@ -1,3 +1,15 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: knative-operator
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: "${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/knative-operator"
+  ref:
+    tag: 1.18.1
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -7,14 +19,10 @@ spec:
   dependsOn:
     - name: istio
       namespace: ${releaseNamespace}
-  chart:
-    spec:
-      chart: knative-operator
-      sourceRef:
-        kind: HelmRepository
-        name: knative-github-io
-        namespace: kommander-flux
-      version: 1.18.1
+  chartRef:
+    kind: OCIRepository
+    name: knative-operator
+    namespace: ${releaseNamespace}
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:
migrate knative chart to OCIRepository

helm pull oci://ghcr.io/mesosphere/charts/knative --version 1.18.1         
Pulled: ghcr.io/mesosphere/charts/knative:1.18.1
Digest: sha256:856d8966f8e9cc8dbd2b6d98f3f48c5564f001334c5a4b017222382345c81859

helm pull oci://ghcr.io/mesosphere/charts/knative-operator --version 1.18.1
Pulled: ghcr.io/mesosphere/charts/knative-operator:1.18.1
Digest: sha256:86c9ca011e1efc16addf631054b2ace29de7e79073834773436f28fdb5363ee3

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-108194