### PR TITLE
refactor: migrate traefik-forward-auth chart to OCIRepository

### DIFF
--- a/applications/traefik-forward-auth-mgmt/0.3.15/traefik-forward-auth-mgmt.yaml
+++ b/applications/traefik-forward-auth-mgmt/0.3.15/traefik-forward-auth-mgmt.yaml
@@ -1,3 +1,14 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: traefik-forward-auth
+  namespace: kommander-flux
+spec:
+  interval: 1m
+  url: ${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/traefik-forward-auth
+  ref:
+    version: 0.3.10
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -11,13 +22,10 @@ spec:
       name: dex
     - namespace: ${releaseNamespace}
       name: kommander
-  chart:
-    spec:
-      chart: traefik-forward-auth
-      sourceRef:
-        kind: HelmRepository
-        name: mesosphere.github.io-charts-staging
-        namespace: kommander-flux
+  chartRef:
+    kind: OCIRepository
+    name: traefik-forward-auth
+    namespace: {releaseNamespace}
       version: 0.3.10
   interval: 15s
   install:

--- a/applications/traefik-forward-auth-mgmt/0.3.15/traefik-forward-auth-mgmt.yaml
+++ b/applications/traefik-forward-auth-mgmt/0.3.15/traefik-forward-auth-mgmt.yaml
@@ -2,12 +2,12 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: traefik-forward-auth
-  namespace: kommander-flux
+  namespace: ${releaseNamespace}
 spec:
   interval: 1m
   url: ${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/traefik-forward-auth
   ref:
-    version: 0.3.10
+    tag: 0.3.10
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -25,8 +25,7 @@ spec:
   chartRef:
     kind: OCIRepository
     name: traefik-forward-auth
-    namespace: {releaseNamespace}
-      version: 0.3.10
+    namespace: ${releaseNamespace}
   interval: 15s
   install:
     crds: CreateReplace

--- a/applications/traefik-forward-auth/0.3.15/traefik-forward-auth.yaml
+++ b/applications/traefik-forward-auth/0.3.15/traefik-forward-auth.yaml
@@ -1,3 +1,14 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: traefik-forward-auth
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: ${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/traefik-forward-auth
+  ref:
+    tag: 0.3.10
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -7,14 +18,10 @@ spec:
   dependsOn:
     - namespace: ${workspaceNamespace}
       name: traefik
-  chart:
-    spec:
-      chart: traefik-forward-auth
-      sourceRef:
-        kind: HelmRepository
-        name: mesosphere.github.io-charts-staging
-        namespace: kommander-flux
-      version: 0.3.10
+  chartRef:
+    kind: OCIRepository
+    name: traefik-forward-auth
+    namespace: ${releaseNamespace}
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:

OCi migration of traefik-forward-auth helm chart
**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
