### PR TITLE
refactor: Migrate Prometheus thanos traefik to OCIRepository

### DIFF
--- a/applications/prometheus-thanos-traefik/0.0.3/prometheus-thanos-traefik.yaml
+++ b/applications/prometheus-thanos-traefik/0.0.3/prometheus-thanos-traefik.yaml
@@ -1,18 +1,25 @@
 ---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: thanos-traefik
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: "${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/thanos-traefik"
+  ref:
+    tag: 0.0.2
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: prometheus-thanos-traefik
   namespace: ${releaseNamespace}
 spec:
-  chart:
-    spec:
-      chart: thanos-traefik
-      sourceRef:
-        kind: HelmRepository
-        name: mesosphere.github.io-charts-staging
-        namespace: kommander-flux
-      version: 0.0.2
+  chartRef:
+    kind: OCIRepository
+    name: thanos-traefik
+    namespace: ${releaseNamespace}
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:
Migrate Prometheus thanos traefik to OCIRepository

helm pull oci://ghcr.io/mesosphere/charts/thanos-traefik --version 0.0.2
Pulled: ghcr.io/mesosphere/charts/thanos-traefik:0.0.2
Digest: sha256:41b11a92d6be909e974d60e3bc103f3d63ba715443673bb221ec47e787bcbbf6

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-108423