### PR TITLE
refactor: migrate kubecost chart to OCIRepository

### DIFF
--- a/applications/kubecost/2.7.3/cosi-storage/cosi-bucket.yaml
+++ b/applications/kubecost/2.7.3/cosi-storage/cosi-bucket.yaml
@@ -1,17 +1,24 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cosi-bucket-kit
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: "${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/cosi-bucket-kit"
+  ref:
+    tag: 0.0.5
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kubecost-cosi-storage
   namespace: ${releaseNamespace}
 spec:
-  chart:
-    spec:
-      chart: cosi-bucket-kit
-      sourceRef:
-        kind: HelmRepository
-        name: mesosphere.github.io-charts-stable
-        namespace: kommander-flux
-      version: 0.0.5
+  chartRef:
+    kind: OCIRepository
+    name: cosi-bucket-kit
+    namespace: ${releaseNamespace}
   interval: 15s
   install:
     crds: CreateReplace

--- a/applications/kubecost/2.7.3/release/release.yaml
+++ b/applications/kubecost/2.7.3/release/release.yaml
@@ -1,17 +1,24 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cost-analyzer
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: "${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/cost-analyzer"
+  ref:
+    tag: 2.7.2
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kubecost
   namespace: ${releaseNamespace}
 spec:
-  chart:
-    spec:
-      chart: cost-analyzer
-      sourceRef:
-        kind: HelmRepository
-        name: kubecost
-        namespace: kommander-flux
-      version: 2.7.2
+  chartRef:
+    kind: OCIRepository
+    name: cost-analyzer
+    namespace: ${releaseNamespace}
   interval: 15s
   install:
     crds: CreateReplace

--- a/common/helm-repositories/kustomization.yaml
+++ b/common/helm-repositories/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
   - jaegertracing.yaml
   - knative-operator.yaml
   - kube-logging.yaml
-  - kubecost.yaml
   - kubefed.yaml
   - kubetunnel.yaml
   - mesosphere-repos.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:
cost-analyzer helm chart oci migration

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-108195


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
