### PR TITLE
refactor: chartmuseum oci migration

### DIFF
--- a/applications/chartmuseum/3.10.4/chartmuseum.yaml
+++ b/applications/chartmuseum/3.10.4/chartmuseum.yaml
@@ -1,18 +1,25 @@
 ---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: chartmuseum
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: "${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/chartmuseum"
+  ref:
+    tag: 3.10.4
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: chartmuseum
   namespace: ${releaseNamespace}
 spec:
-  chart:
-    spec:
-      chart: applications/chartmuseum/3.10.4/chartmuseum-3.10.4.tgz
-      sourceRef:
-        kind: GitRepository
-        name: management
-        namespace: kommander-flux
-      version: "3.10.4"
+  chartRef:
+    kind: OCIRepository
+    name: chartmuseum
+    namespace: ${releaseNamespace}
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:
chartmuseum oci migration

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-108191

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
