### PR TITLE
refactor: Migrate istio to OCI

### DIFF
--- a/applications/istio/1.23.4/helmrelease/helmrelease.yaml
+++ b/applications/istio/1.23.4/helmrelease/helmrelease.yaml
@@ -1,3 +1,15 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: istio
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: "${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/istio"
+  ref:
+    tag: 1.23.3
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -7,14 +19,10 @@ spec:
   dependsOn:
     - name: kube-prometheus-stack
       namespace: ${releaseNamespace}
-  chart:
-    spec:
-      chart: istio
-      sourceRef:
-        kind: HelmRepository
-        name: mesosphere.github.io-charts-staging
-        namespace: kommander-flux
-      version: 1.23.3
+  chartRef:
+    kind: OCIRepository
+    name: istio
+    namespace: ${releaseNamespace}
   interval: 15s
   install:
     crds: CreateReplace


### PR DESCRIPTION
**What problem does this PR solve?**:
Migrate istio to OCI

```
sandhya.ravi@GT9X7CVF5F istio-oci % helm pull oci://ghcr.io/mesosphere/charts/istio:1.23.3                 
Pulled: ghcr.io/mesosphere/charts/istio:1.23.3
Digest: sha256:4dfa13927768da39e2f2a5281b102bfa9d78b8176c5053f9cabaa24b4f3fdd50
```

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-108452


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
