### PR TITLE
fix: remove outdated GHA runners

### DIFF
--- a/.github/workflows/create-dev-tag.yml
+++ b/.github/workflows/create-dev-tag.yml
@@ -19,9 +19,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
-    runs-on:
-    - self-hosted
-    - small
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/flux-update-scheduled-check.yml
+++ b/.github/workflows/flux-update-scheduled-check.yml
@@ -8,9 +8,7 @@ jobs:
   flux-schedule-check:
     if: github.ref == 'refs/heads/main'
     name: Flux Update Schedule Check
-    runs-on:
-      - self-hosted
-      - small
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,9 +13,7 @@ permissions:
 
 jobs:
   pre-commit:
-    runs-on:
-    - self-hosted
-    - small
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/manifest-validation.yml
+++ b/.github/workflows/manifest-validation.yml
@@ -12,15 +12,10 @@ jobs:
   manifest-validation:
     name: Manifest validation
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
-    runs-on:
-      - self-hosted
-      - small
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      #- uses: webfactory/ssh-agent@v0.9.0
-       # with:
-        #  ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY }}
 
       - name: Install NIX
         uses: cachix/install-nix-action@v31

--- a/.github/workflows/publish-appversions.yml
+++ b/.github/workflows/publish-appversions.yml
@@ -9,9 +9,7 @@ jobs:
   publish-test:
     name: Publish docs test
     if: ${{ github.event_name == 'workflow_dispatch' }}
-    runs-on:
-    - self-hosted
-    - small
+    runs-on: ubuntu-latest
     steps:
       - name: Repository dispatch
         run: |
@@ -25,9 +23,7 @@ jobs:
   publish-tag:
     name: Publish docs with tag
     if: ${{ startsWith(github.ref_name, 'v') }}
-    runs-on:
-    - self-hosted
-    - small
+    runs-on: ubuntu-latest
     steps:
       - name: Repository dispatch
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,7 @@ permissions:
 jobs:
   release:
     name: Release
-    runs-on:
-      - self-hosted
-      - medium
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -71,9 +69,7 @@ jobs:
           devbox run -- just release-server
 
   send_message:
-    runs-on:
-      - self-hosted
-      - small
+    runs-on: ubuntu-latest
     needs:
       - "release"
     if: ${{ always() }}


### PR DESCRIPTION
**What problem does this PR solve?**:
We're using outdated runners that are not maintained or updated anymore. This should address issues with installing devbox.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
