### PR TITLE
fix: enable HR replacement on upgrade

### DIFF
--- a/applications/kommander/0.16.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
+++ b/applications/kommander/0.16.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: ${namespace}
   labels:
     kommander.mesosphere.io/cluster-id: ${clusterID}
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
 spec:
   chart:
     spec:


### PR DESCRIPTION
**What problem does this PR solve?**:
currently workspace upgrade encounters https://github.com/mesosphere/kommander-cli/actions/runs/16372808039/job/46265185838#step:12:5312

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
