### PR TITLE
chore: Split HelmRelease and OCIRepository in their own respective files

### DIFF
--- a/applications/nkp-insights-management/1.6.2/helmrelease/helmrelease.yaml
+++ b/applications/nkp-insights-management/1.6.2/helmrelease/helmrelease.yaml
@@ -1,15 +1,4 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: nkp-insights-management
-  namespace: ${releaseNamespace}
-spec:
-  interval: 1m
-  ref:
-    tag: 1.6.2
-  url: ${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/nkp-insights-management
----
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/applications/nkp-insights-management/1.6.2/helmrelease/kustomization.yaml
+++ b/applications/nkp-insights-management/1.6.2/helmrelease/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ocirepository.yaml
   - helmrelease.yaml

--- a/applications/nkp-insights-management/1.6.2/helmrelease/ocirepository.yaml
+++ b/applications/nkp-insights-management/1.6.2/helmrelease/ocirepository.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: nkp-insights-management
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  ref:
+    tag: 1.6.2
+  url: ${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/nkp-insights-management

--- a/applications/nkp-insights/1.6.2/helmrelease/helmrelease.yaml
+++ b/applications/nkp-insights/1.6.2/helmrelease/helmrelease.yaml
@@ -1,15 +1,4 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: nkp-insights
-  namespace: ${releaseNamespace}
-spec:
-  interval: 1m
-  ref:
-    tag: 1.6.2
-  url: ${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/nkp-insights
----
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/applications/nkp-insights/1.6.2/helmrelease/kustomization.yaml
+++ b/applications/nkp-insights/1.6.2/helmrelease/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ocirepository.yaml
   - helmrelease.yaml

--- a/applications/nkp-insights/1.6.2/helmrelease/ocirepository.yaml
+++ b/applications/nkp-insights/1.6.2/helmrelease/ocirepository.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: nkp-insights
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  ref:
+    tag: 1.6.2
+  url: ${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/nkp-insights


### PR DESCRIPTION
**What problem does this PR solve?**:

Redo of #3756 

Split out contents of `OCIRepository` into its own file so that Insights' release tooling can easily apply new changes to separate files.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-108441

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
