### PR TITLE
chore: Split nkp-insights HelmRelease and OCIRepository

### DIFF
--- a/applications/nkp-insights-management/1.6.2/helmrelease/helmrelease.yaml
+++ b/applications/nkp-insights-management/1.6.2/helmrelease/helmrelease.yaml
@@ -1,15 +1,4 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: nkp-insights-management
-  namespace: ${releaseNamespace}
-spec:
-  interval: 1m
-  ref:
-    tag: 1.6.2
-  url: ${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/nkp-insights-management
----
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/applications/nkp-insights-management/1.6.2/helmrelease/kustomization.yaml
+++ b/applications/nkp-insights-management/1.6.2/helmrelease/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ocirepository.yaml
   - helmrelease.yaml

--- a/applications/nkp-insights-management/1.6.2/helmrelease/ocirepository.yaml
+++ b/applications/nkp-insights-management/1.6.2/helmrelease/ocirepository.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: nkp-insights-management
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  ref:
+    tag: 1.6.2
+  url: ${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/nkp-insights-management

--- a/applications/nkp-insights/1.6.2/helmrelease/helmrelease.yaml
+++ b/applications/nkp-insights/1.6.2/helmrelease/helmrelease.yaml
@@ -1,15 +1,4 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: nkp-insights
-  namespace: ${releaseNamespace}
-spec:
-  interval: 1m
-  ref:
-    tag: 1.6.2
-  url: ${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/nkp-insights
----
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/applications/nkp-insights/1.6.2/helmrelease/kustomization.yaml
+++ b/applications/nkp-insights/1.6.2/helmrelease/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ocirepository.yaml
   - helmrelease.yaml

--- a/applications/nkp-insights/1.6.2/helmrelease/ocirepository.yaml
+++ b/applications/nkp-insights/1.6.2/helmrelease/ocirepository.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: nkp-insights
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  ref:
+    tag: 1.6.2
+  url: ${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/nkp-insights


### PR DESCRIPTION
Reverts mesosphere/kommander-applications#3776

Basically brings back https://github.com/mesosphere/kommander-applications/pull/3765 to try it again. kommander CI started failing on charts-bundle step when this got merged