### PR TITLE
refactor: migrate kommander-cert-federation to OCI

### DIFF
--- a/common/build/kommander-cert-federation.yaml
+++ b/common/build/kommander-cert-federation.yaml
@@ -9,18 +9,25 @@
 #  1) CI tooling to build a complete airgapped bundle and 2)
 #  2) Ensure cert federation chart is downloaded when a user runs `dkp create chart-bundle`.
 ---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kommander-cert-federation
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: "${ociRegistryURL:=oci://ghcr.io}/mesosphere/charts/kommander-cert-federation"
+  ref:
+    tag: "0.0.13"
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ${notPopulatedAnywhereAsThisIsOnlyForAirgappedBundle}
   namespace: ${releaseNamespace}
 spec:
-  chart:
-    spec:
-      chart: kommander-cert-federation
-      sourceRef:
-        kind: HelmRepository
-        name: mesosphere.github.io-charts-stable
-        namespace: kommander-flux
-      version: "0.0.13"
+  chartRef:
+    kind: OCIRepository
+    name: kommander-cert-federation
+    namespace: ${releaseNamespace}
   interval: 15s


### PR DESCRIPTION
**What problem does this PR solve?**:
```
sandhya.ravi@GT9X7CVF5F kommander-cert-fed % helm pull oci://ghcr.io/mesosphere/charts/kommander-cert-federation:0.0.13
Pulled: ghcr.io/mesosphere/charts/kommander-cert-federation:0.0.13
Digest: sha256:3b2496ec8713e174098daa159210f99e6877686f80ae84aa28f07b0da910dd25
```

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-108525


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
