### PR TITLE
feat: update fluent-bit to 4.0.5

### DIFF
--- a/applications/fluent-bit/0.50.0/defaults/cm.yaml
+++ b/applications/fluent-bit/0.50.0/defaults/cm.yaml
@@ -10,7 +10,7 @@ data:
     image:
       # Pull from docker hub rather than cr.fluentbit.io to avoid rate limiting.
       repository: docker.io/fluent/fluent-bit
-      tag: 3.2.10
+      tag: 4.0.5
 
     priorityClassName: "dkp-critical-priority"
     resources:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -7,7 +7,7 @@ ignore:
   - docker.io/mesosphere/flux-oci-mirror:v0.2.3
 
 resources:
-  - container_image: docker.io/fluent/fluent-bit:3.2.10
+  - container_image: docker.io/fluent/fluent-bit:4.0.5
     sources:
       - license_path: LICENSE
         ref: v${image_tag}


### PR DESCRIPTION
**What problem does this PR solve?**:
update fluent-bit to 4.0.5

```
bhargavreddy.hastava@J4R3KVQRXK kommander % trivy image docker.io/fluent/fluent-bit:4.0.5
2025-07-25T15:07:02+05:30	INFO	[vulndb] Need to update DB
2025-07-25T15:07:02+05:30	INFO	[vulndb] Downloading vulnerability DB...
2025-07-25T15:07:02+05:30	INFO	[vulndb] Downloading artifact...	repo="mirror.gcr.io/aquasec/trivy-db:2"
67.06 MiB / 67.06 MiB [-------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 6.00 MiB p/s 11s
2025-07-25T15:07:17+05:30	INFO	[vulndb] Artifact successfully downloaded	repo="mirror.gcr.io/aquasec/trivy-db:2"
2025-07-25T15:07:17+05:30	INFO	[vuln] Vulnerability scanning is enabled
2025-07-25T15:07:17+05:30	INFO	[secret] Secret scanning is enabled
2025-07-25T15:07:17+05:30	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-07-25T15:07:17+05:30	INFO	[secret] Please see also https://trivy.dev/v0.62/docs/scanner/secret#recommendation for faster secret detection
2025-07-25T15:07:21+05:30	INFO	Detected OS	family="debian" version="12.11"
2025-07-25T15:07:21+05:30	INFO	[debian] Detecting vulnerabilities...	os_version="12" pkg_num=45
2025-07-25T15:07:21+05:30	INFO	Number of language-specific files	num=0
2025-07-25T15:07:21+05:30	WARN	Using severities from other vendors for some vulnerabilities. Read https://trivy.dev/v0.62/docs/scanner/vulnerability#severity-selection for details.

Report Summary

┌──────────────────────────────────────────────────┬────────┬─────────────────┬─────────┐
│                      Target                      │  Type  │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────────────┼────────┼─────────────────┼─────────┤
│ docker.io/fluent/fluent-bit:4.0.5 (debian 12.11) │ debian │       46        │    -    │
└──────────────────────────────────────────────────┴────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


docker.io/fluent/fluent-bit:4.0.5 (debian 12.11)

Total: 46 (UNKNOWN: 1, LOW: 38, MEDIUM: 4, HIGH: 2, CRITICAL: 1)

┌──────────────────┬──────────────────┬──────────┬──────────────┬────────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│     Library      │  Vulnerability   │ Severity │    Status    │ Installed Version  │ Fixed Version │                            Title                             │
├──────────────────┼──────────────────┼──────────┼──────────────┼────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ gcc-12-base      │ CVE-2022-27943   │ LOW      │ affected     │ 12.2.0-14+deb12u1  │               │ binutils: libiberty/rust-demangle.c in GNU GCC 11.2 allows   │
│                  │                  │          │              │                    │               │ stack exhaustion in demangle_const                           │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2022-27943                   │
├──────────────────┤                  │          │              │                    ├───────────────┤                                                              │
│ libatomic1       │                  │          │              │                    │               │                                                              │
│                  │                  │          │              │                    │               │                                                              │
│                  │                  │          │              │                    │               │                                                              │
├──────────────────┼──────────────────┼──────────┤              ├────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libc6            │ CVE-2025-4802    │ HIGH     │              │ 2.36-9+deb12u10    │               │ glibc: static setuid binary dlopen may incorrectly search    │
│                  │                  │          │              │                    │               │ LD_LIBRARY_PATH                                              │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2025-4802                    │
│                  ├──────────────────┼──────────┤              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2010-4756    │ LOW      │              │                    │               │ glibc: glob implementation can cause excessive CPU and       │
│                  │                  │          │              │                    │               │ memory consumption due to...                                 │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2010-4756                    │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2018-20796   │          │              │                    │               │ glibc: uncontrolled recursion in function                    │
│                  │                  │          │              │                    │               │ check_dst_limits_calc_pos_1 in posix/regexec.c               │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2018-20796                   │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2019-1010022 │          │              │                    │               │ glibc: stack guard protection bypass                         │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2019-1010022                 │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2019-1010023 │          │              │                    │               │ glibc: running ldd on malicious ELF leads to code execution  │
│                  │                  │          │              │                    │               │ because of...                                                │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2019-1010023                 │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2019-1010024 │          │              │                    │               │ glibc: ASLR bypass using cache of thread stack and heap      │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2019-1010024                 │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2019-1010025 │          │              │                    │               │ glibc: information disclosure of heap addresses of           │
│                  │                  │          │              │                    │               │ pthread_created thread                                       │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2019-1010025                 │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2019-9192    │          │              │                    │               │ glibc: uncontrolled recursion in function                    │
│                  │                  │          │              │                    │               │ check_dst_limits_calc_pos_1 in posix/regexec.c               │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2019-9192                    │
│                  ├──────────────────┼──────────┤              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-8058    │ UNKNOWN  │              │                    │               │ The regcomp function in the GNU C library version from 2.4   │
│                  │                  │          │              │                    │               │ to...                                                        │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2025-8058                    │
├──────────────────┼──────────────────┼──────────┤              ├────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libcurl4         │ CVE-2024-2379    │ LOW      │              │ 7.88.1-10+deb12u12 │               │ curl: QUIC certificate check bypass with wolfSSL             │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2024-2379                    │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2025-0725    │          │              │                    │               │ libcurl: Buffer Overflow in libcurl via zlib Integer         │
│                  │                  │          │              │                    │               │ Overflow                                                     │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2025-0725                    │
├──────────────────┼──────────────────┤          │              ├────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libgcc-s1        │ CVE-2022-27943   │          │              │ 12.2.0-14+deb12u1  │               │ binutils: libiberty/rust-demangle.c in GNU GCC 11.2 allows   │
│                  │                  │          │              │                    │               │ stack exhaustion in demangle_const                           │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2022-27943                   │
├──────────────────┼──────────────────┤          │              ├────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libgcrypt20      │ CVE-2018-6829    │          │              │ 1.10.1-3           │               │ libgcrypt: ElGamal implementation doesn't have semantic      │
│                  │                  │          │              │                    │               │ security due to incorrectly encoded plaintexts...            │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2018-6829                    │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2024-2236    │          │              │                    │               │ libgcrypt: vulnerable to Marvin Attack                       │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2024-2236                    │
├──────────────────┼──────────────────┤          │              ├────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libgnutls30      │ CVE-2011-3389    │          │              │ 3.7.9-2+deb12u5    │               │ HTTPS: block-wise chosen-plaintext attack against SSL/TLS    │
│                  │                  │          │              │                    │               │ (BEAST)                                                      │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2011-3389                    │
├──────────────────┼──────────────────┤          │              ├────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libgomp1         │ CVE-2022-27943   │          │              │ 12.2.0-14+deb12u1  │               │ binutils: libiberty/rust-demangle.c in GNU GCC 11.2 allows   │
│                  │                  │          │              │                    │               │ stack exhaustion in demangle_const                           │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2022-27943                   │
├──────────────────┼──────────────────┼──────────┤              ├────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libgssapi-krb5-2 │ CVE-2025-3576    │ MEDIUM   │              │ 1.20.1-2+deb12u3   │               │ krb5: Kerberos RC4-HMAC-MD5 Checksum Vulnerability Enabling  │
│                  │                  │          │              │                    │               │ Message Spoofing via MD5 Collisions                          │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2025-3576                    │
│                  ├──────────────────┼──────────┤              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2018-5709    │ LOW      │              │                    │               │ krb5: integer overflow in dbentry->n_key_data in             │
│                  │                  │          │              │                    │               │ kadmin/dbutil/dump.c                                         │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2018-5709                    │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2024-26458   │          │              │                    │               │ krb5: Memory leak at /krb5/src/lib/rpc/pmap_rmt.c            │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2024-26458                   │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2024-26461   │          │              │                    │               │ krb5: Memory leak at /krb5/src/lib/gssapi/krb5/k5sealv3.c    │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2024-26461                   │
├──────────────────┼──────────────────┼──────────┤              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│ libk5crypto3     │ CVE-2025-3576    │ MEDIUM   │              │                    │               │ krb5: Kerberos RC4-HMAC-MD5 Checksum Vulnerability Enabling  │
│                  │                  │          │              │                    │               │ Message Spoofing via MD5 Collisions                          │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2025-3576                    │
│                  ├──────────────────┼──────────┤              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2018-5709    │ LOW      │              │                    │               │ krb5: integer overflow in dbentry->n_key_data in             │
│                  │                  │          │              │                    │               │ kadmin/dbutil/dump.c                                         │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2018-5709                    │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2024-26458   │          │              │                    │               │ krb5: Memory leak at /krb5/src/lib/rpc/pmap_rmt.c            │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2024-26458                   │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2024-26461   │          │              │                    │               │ krb5: Memory leak at /krb5/src/lib/gssapi/krb5/k5sealv3.c    │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2024-26461                   │
├──────────────────┼──────────────────┼──────────┤              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│ libkrb5-3        │ CVE-2025-3576    │ MEDIUM   │              │                    │               │ krb5: Kerberos RC4-HMAC-MD5 Checksum Vulnerability Enabling  │
│                  │                  │          │              │                    │               │ Message Spoofing via MD5 Collisions                          │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2025-3576                    │
│                  ├──────────────────┼──────────┤              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2018-5709    │ LOW      │              │                    │               │ krb5: integer overflow in dbentry->n_key_data in             │
│                  │                  │          │              │                    │               │ kadmin/dbutil/dump.c                                         │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2018-5709                    │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2024-26458   │          │              │                    │               │ krb5: Memory leak at /krb5/src/lib/rpc/pmap_rmt.c            │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2024-26458                   │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2024-26461   │          │              │                    │               │ krb5: Memory leak at /krb5/src/lib/gssapi/krb5/k5sealv3.c    │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2024-26461                   │
├──────────────────┼──────────────────┼──────────┤              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│ libkrb5support0  │ CVE-2025-3576    │ MEDIUM   │              │                    │               │ krb5: Kerberos RC4-HMAC-MD5 Checksum Vulnerability Enabling  │
│                  │                  │          │              │                    │               │ Message Spoofing via MD5 Collisions                          │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2025-3576                    │
│                  ├──────────────────┼──────────┤              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2018-5709    │ LOW      │              │                    │               │ krb5: integer overflow in dbentry->n_key_data in             │
│                  │                  │          │              │                    │               │ kadmin/dbutil/dump.c                                         │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2018-5709                    │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2024-26458   │          │              │                    │               │ krb5: Memory leak at /krb5/src/lib/rpc/pmap_rmt.c            │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2024-26458                   │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2024-26461   │          │              │                    │               │ krb5: Memory leak at /krb5/src/lib/gssapi/krb5/k5sealv3.c    │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2024-26461                   │
├──────────────────┼──────────────────┼──────────┤              ├────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libldap-2.5-0    │ CVE-2023-2953    │ HIGH     │              │ 2.5.13+dfsg-5      │               │ openldap: null pointer dereference in ber_memalloc_x         │
│                  │                  │          │              │                    │               │ function                                                     │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2023-2953                    │
│                  ├──────────────────┼──────────┤              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2015-3276    │ LOW      │              │                    │               │ openldap: incorrect multi-keyword mode cipherstring parsing  │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2015-3276                    │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2017-14159   │          │              │                    │               │ openldap: Privilege escalation via PID file manipulation     │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2017-14159                   │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2017-17740   │          │              │                    │               │ openldap: contrib/slapd-modules/nops/nops.c attempts to free │
│                  │                  │          │              │                    │               │ stack buffer allowing remote attackers to cause...           │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2017-17740                   │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2020-15719   │          │              │                    │               │ openldap: Certificate validation incorrectly matches name    │
│                  │                  │          │              │                    │               │ against CN-ID                                                │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2020-15719                   │
├──────────────────┼──────────────────┤          │              ├────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libssl3          │ CVE-2025-27587   │          │              │ 3.0.16-1~deb12u1   │               │ OpenSSL 3.0.0 through 3.3.2 on the PowerPC architecture is   │
│                  │                  │          │              │                    │               │ vulnerable ......                                            │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2025-27587                   │
├──────────────────┼──────────────────┤          │              ├────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libstdc++6       │ CVE-2022-27943   │          │              │ 12.2.0-14+deb12u1  │               │ binutils: libiberty/rust-demangle.c in GNU GCC 11.2 allows   │
│                  │                  │          │              │                    │               │ stack exhaustion in demangle_const                           │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2022-27943                   │
├──────────────────┼──────────────────┤          │              ├────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libsystemd0      │ CVE-2013-4392    │          │              │ 254.26-1~bpo12+1   │               │ systemd: TOCTOU race condition when updating file            │
│                  │                  │          │              │                    │               │ permissions and SELinux security contexts...                 │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2013-4392                    │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-31437   │          │              │                    │               │ An issue was discovered in systemd 253. An attacker can      │
│                  │                  │          │              │                    │               │ modify a...                                                  │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2023-31437                   │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-31438   │          │              │                    │               │ An issue was discovered in systemd 253. An attacker can      │
│                  │                  │          │              │                    │               │ truncate a...                                                │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2023-31438                   │
│                  ├──────────────────┤          │              │                    ├───────────────┼──────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-31439   │          │              │                    │               │ An issue was discovered in systemd 253. An attacker can      │
│                  │                  │          │              │                    │               │ modify the...                                                │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2023-31439                   │
├──────────────────┼──────────────────┼──────────┼──────────────┼────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ zlib1g           │ CVE-2023-45853   │ CRITICAL │ will_not_fix │ 1:1.2.13.dfsg-1    │               │ zlib: integer overflow and resultant heap-based buffer       │
│                  │                  │          │              │                    │               │ overflow in zipOpenNewFileInZip4_6                           │
│                  │                  │          │              │                    │               │ https://avd.aquasec.com/nvd/cve-2023-45853                   │
└──────────────────┴──────────────────┴──────────┴──────────────┴────────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
bhargavreddy.hastava@J4R3KVQRXK kommander %     
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

       https://jira.nutanix.com/browse/NCN-108621
**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
