### PR TITLE
fix: Add additional spec.template.labels patch

### DIFF
--- a/applications/knative/1.18.1/knative-operator.yaml
+++ b/applications/knative/1.18.1/knative-operator.yaml
@@ -67,3 +67,11 @@ spec:
               - op: replace
                 path: /spec/template/metadata/labels/app.kubernetes.io~1version
                 value: 1.18.1
+          - target:
+              version: apps/v1
+              kind: Deployment
+              labelSelector: "app.kubernetes.io/version"
+            patch: |
+              - op: replace
+                path: /spec/template/labels/app.kubernetes.io~1version
+                value: 1.18.1

--- a/applications/knative/1.18.1/knative-operator.yaml
+++ b/applications/knative/1.18.1/knative-operator.yaml
@@ -67,11 +67,6 @@ spec:
               - op: replace
                 path: /spec/template/metadata/labels/app.kubernetes.io~1version
                 value: 1.18.1
-          - target:
-              version: apps/v1
-              kind: Deployment
-              labelSelector: "app.kubernetes.io/version"
-            patch: |
               - op: replace
                 path: /spec/template/labels/app.kubernetes.io~1version
                 value: 1.18.1


### PR DESCRIPTION
**What problem does this PR solve?**:

Follow on to #3800 which addressed 26/28 of the previous issues.

However we still have the following failure when knative is deployed on the daily cluster v0.0.0-dev.0 build.
```
  Warning  InstallFailed  56m   helm-controller  Helm install failed for release knative-operator/knative with chart knative-operator@1.18.1+86c9ca011e1e: 2 errors occurred:
           * Deployment.apps "knative-operator" is invalid: spec.template.labels: Invalid value: "1.18.1+86c9ca011e1e": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
           * Deployment.apps "operator-webhook" is invalid: spec.template.labels: Invalid value: "1.18.1+86c9ca011e1e": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```
This PR attempts to fix these last two breaks.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-108562

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
