### PR TITLE
fix: PostRenderer patches GVK format was incorrect

### DIFF
--- a/applications/knative/1.18.1/knative-operator.yaml
+++ b/applications/knative/1.18.1/knative-operator.yaml
@@ -60,13 +60,11 @@ spec:
                 path: /metadata/labels/app.kubernetes.io~1version
                 value: 1.18.1
           - target:
-              version: apps/v1
+              version: v1
+              group: apps
               kind: Deployment
               labelSelector: "app.kubernetes.io/version"
             patch: |
               - op: replace
                 path: /spec/template/metadata/labels/app.kubernetes.io~1version
-                value: 1.18.1
-              - op: replace
-                path: /spec/template/labels/app.kubernetes.io~1version
                 value: 1.18.1


### PR DESCRIPTION
**What problem does this PR solve?**:

Follow up to #3808 and #3800. [Patches](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/) don't use the GVK format that we use everywhere else.

The patch from #3808 was deleted as once the GVK fix was applied, this patch started causing failures and is removed in this PR.

We have the daily cluster successfully installing KNative with a hand-edited HelmRelease:
```
k get helmrelease knative-operator -n kommander -o yaml
apiVersion: helm.toolkit.fluxcd.io/v2
kind: HelmRelease
metadata:
  creationTimestamp: "2025-07-25T15:55:38Z"
  finalizers:
  - finalizers.fluxcd.io
  generation: 7
  labels:
    kustomize.toolkit.fluxcd.io/name: knative
    kustomize.toolkit.fluxcd.io/namespace: kommander
  name: knative-operator
  namespace: kommander
  resourceVersion: "1076685"
  uid: 772e0422-85c9-4127-8775-b21eaf51cbdf
spec:
  chartRef:
    kind: OCIRepository
    name: knative-operator
    namespace: kommander
  dependsOn:
  - name: istio
    namespace: kommander
  install:
    crds: CreateReplace
    createNamespace: true
    remediation:
      retries: 30
  interval: 15s
  postRenderers:
  - kustomize:
      patches:
      - patch: |
          - op: replace
            path: /metadata/labels/app.kubernetes.io~1version
            value: 1.18.1
        target:
          labelSelector: app.kubernetes.io/version
      - patch: |
          - op: replace
            path: /spec/template/metadata/labels/app.kubernetes.io~1version
            value: 1.18.1
        target:
          kind: Deployment
          labelSelector: app.kubernetes.io/version
          group: apps
          version: v1
  releaseName: knative
  targetNamespace: knative-operator
  upgrade:
    crds: CreateReplace
    remediation:
      retries: 30
  valuesFrom:
  - kind: ConfigMap
    name: knative-1.18.1-config-defaults
  - kind: ConfigMap
    name: knative-config-overrides
    optional: true
  - kind: ConfigMap
    name: knative-overrides
    optional: true
status:
  conditions:
  - lastTransitionTime: "2025-07-25T16:02:08Z"
    message: Helm install succeeded for release knative-operator/knative.v1 with chart
      knative-operator@1.18.1+86c9ca011e1e
    observedGeneration: 7
    reason: InstallSucceeded
    status: "True"
    type: Ready
  - lastTransitionTime: "2025-07-25T16:02:08Z"
    message: Helm install succeeded for release knative-operator/knative.v1 with chart
      knative-operator@1.18.1+86c9ca011e1e
    observedGeneration: 7
    reason: InstallSucceeded
    status: "True"
    type: Released
  history:
  - chartName: knative-operator
    chartVersion: 1.18.1+86c9ca011e1e
    configDigest: sha256:43bcc90ea7b426cc29df01acc3da9528cf9e0cd6282ab1da7186115031de6851
    digest: sha256:3681cb98b930db5052d628408218814a36b05123a84aaec1bae6cd88dba69238
    firstDeployed: "2025-07-25T16:00:52Z"
    lastDeployed: "2025-07-25T16:00:52Z"
    name: knative
    namespace: knative-operator
    ociDigest: sha256:86c9ca011e1efc16addf631054b2ace29de7e79073834773436f28fdb5363ee3
    status: deployed
    version: 1
  lastAttemptedConfigDigest: sha256:43bcc90ea7b426cc29df01acc3da9528cf9e0cd6282ab1da7186115031de6851
  lastAttemptedGeneration: 7
  lastAttemptedReleaseAction: install
  lastAttemptedRevision: 1.18.1+86c9ca011e1e
  lastAttemptedRevisionDigest: sha256:86c9ca011e1efc16addf631054b2ace29de7e79073834773436f28fdb5363ee3
  observedGeneration: 7
  observedPostRenderersDigest: sha256:904f3f11128f933b677934ad7638f986784b1037932a2545f39d60e0cba77a09
  storageNamespace: kommander
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-108562

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
