### PR TITLE
refactor: update redis-exporter with bitnamilegacy

### DIFF
--- a/applications/harbor/1.17.1/defaults/valkey.yaml
+++ b/applications/harbor/1.17.1/defaults/valkey.yaml
@@ -13,13 +13,13 @@ data:
     image:
       registry: docker.io
       repository: bitnamilegacy/valkey
-      tag: 8.1.3
+      tag: 8.1.3-debian-12-r2
     sentinel:
       enabled: true
       image:
         registry: docker.io
         repository: bitnamilegacy/valkey-sentinel
-        tag: 8.1.3
+        tag: 8.1.3-debian-12-r2
       primarySet: harbor
     auth:
       enabled: true
@@ -45,8 +45,8 @@ data:
       enabled: true
       image:
         registry: docker.io
-        repository: oliver006/redis_exporter
-        tag: v1.74.0
+        repository: bitnamilegacy/redis_exporter
+        tag: v1.74.0-debian-12-r3
       service:
         enabled: true
         extraPorts:

--- a/applications/harbor/1.17.1/defaults/valkey.yaml
+++ b/applications/harbor/1.17.1/defaults/valkey.yaml
@@ -46,7 +46,7 @@ data:
       image:
         registry: docker.io
         repository: bitnamilegacy/redis_exporter
-        tag: 1.74.0-debian-12-r3
+        tag: 1.74.0-debian-12-r2
       service:
         enabled: true
         extraPorts:

--- a/applications/harbor/1.17.1/defaults/valkey.yaml
+++ b/applications/harbor/1.17.1/defaults/valkey.yaml
@@ -46,7 +46,7 @@ data:
       image:
         registry: docker.io
         repository: bitnamilegacy/redis_exporter
-        tag: v1.74.0-debian-12-r3
+        tag: 1.74.0-debian-12-r3
       service:
         enabled: true
         extraPorts:

--- a/applications/harbor/1.17.1/defaults/valkey.yaml
+++ b/applications/harbor/1.17.1/defaults/valkey.yaml
@@ -45,8 +45,8 @@ data:
       enabled: true
       image:
         registry: docker.io
-        repository: bitnamilegacy/redis_exporter
-        tag: 1.74.0-debian-12-r2
+        repository: bitnamilegacy/redis-exporter
+        tag: 1.74.0-debian-12-r3
       service:
         enabled: true
         extraPorts:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -595,17 +595,17 @@ resources:
       - url: https://github.com/goharbor/harbor
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: docker.io/bitnamilegacy/valkey:8.1.3-debian-12-r2
+  - container_image: bitnamilegacy/valkey:8.1.3-debian-12-r2
     sources:
       - url: https://github.com/valkey-io/valkey
         ref: ${image_tag%%-debian-*}
         license_path: COPYING
-  - container_image: docker.io/bitnamilegacy/valkey-sentinel:8.1.3-debian-12-r2
+  - container_image: bitnamilegacy/valkey-sentinel:8.1.3-debian-12-r2
     sources:
       - url: https://github.com/valkey-io/valkey
         ref: ${image_tag%%-debian-*}
         license_path: COPYING
-  - container_image: docker.io/bitnamilegacy/redis_exporter:v1.74.0-debian-12-r3
+  - container_image: bitnamilegacy/redis_exporter:1.74.0-debian-12-r3
     sources:
       - url: https://github.com/oliver006/redis_exporter
         ref: ${image_tag%%-debian-*}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -608,7 +608,7 @@ resources:
   - container_image: docker.io/bitnamilegacy/redis_exporter:v1.74.0-debian-12-r3
     sources:
       - url: https://github.com/oliver006/redis_exporter
-        ref: v${image_tag%%-debian-*}
+        ref: ${image_tag%%-debian-*}
         license_path: LICENSE
   - container_image: ghcr.io/nutanix-cloud-native/cosi-driver-nutanix:v0.6.0
     sources:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -605,7 +605,7 @@ resources:
       - url: https://github.com/valkey-io/valkey
         ref: ${image_tag%%-debian-*}
         license_path: COPYING
-  - container_image: bitnamilegacy/redis_exporter:1.74.0-debian-12-r3
+  - container_image: bitnamilegacy/redis_exporter:1.74.0-debian-12-r2
     sources:
       - url: https://github.com/oliver006/redis_exporter
         ref: v${image_tag%%-debian-*}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -605,7 +605,7 @@ resources:
       - url: https://github.com/valkey-io/valkey
         ref: ${image_tag%%-debian-*}
         license_path: COPYING
-  - container_image: docker.io/bitnamilegacy/redis_exporter:1.74.0-debian-12-r3
+  - container_image: docker.io/bitnamilegacy/redis_exporter:v1.74.0-debian-12-r3
     sources:
       - url: https://github.com/oliver006/redis_exporter
         ref: v${image_tag%%-debian-*}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -595,20 +595,20 @@ resources:
       - url: https://github.com/goharbor/harbor
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: docker.io/bitnamilegacy/valkey:8.1.3
+  - container_image: docker.io/bitnamilegacy/valkey:8.1.3-debian-12-r2
     sources:
       - url: https://github.com/valkey-io/valkey
-        ref: ${image_tag}
+        ref: ${image_tag%%-debian-*}
         license_path: COPYING
-  - container_image: docker.io/bitnamilegacy/valkey-sentinel:8.1.3
+  - container_image: docker.io/bitnamilegacy/valkey-sentinel:8.1.3-debian-12-r2
     sources:
       - url: https://github.com/valkey-io/valkey
-        ref: ${image_tag}
+        ref: ${image_tag%%-debian-*}
         license_path: COPYING
-  - container_image: docker.io/oliver006/redis_exporter:v1.74.0
+  - container_image: docker.io/bitnamilegacy/redis_exporter:1.74.0-debian-12-r3
     sources:
       - url: https://github.com/oliver006/redis_exporter
-        ref: ${image_tag}
+        ref: v${image_tag%%-debian-*}
         license_path: LICENSE
   - container_image: ghcr.io/nutanix-cloud-native/cosi-driver-nutanix:v0.6.0
     sources:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -608,7 +608,7 @@ resources:
   - container_image: bitnamilegacy/redis_exporter:1.74.0-debian-12-r3
     sources:
       - url: https://github.com/oliver006/redis_exporter
-        ref: ${image_tag%%-debian-*}
+        ref: v${image_tag%%-debian-*}
         license_path: LICENSE
   - container_image: ghcr.io/nutanix-cloud-native/cosi-driver-nutanix:v0.6.0
     sources:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -605,7 +605,7 @@ resources:
       - url: https://github.com/valkey-io/valkey
         ref: ${image_tag%%-debian-*}
         license_path: COPYING
-  - container_image: bitnamilegacy/redis_exporter:1.74.0-debian-12-r2
+  - container_image: bitnamilegacy/redis-exporter:1.74.0-debian-12-r3
     sources:
       - url: https://github.com/oliver006/redis_exporter
         ref: v${image_tag%%-debian-*}


### PR DESCRIPTION
**What problem does this PR solve?**:
update redis-exporter with bitnamilegacy


```
sandhya.ravi@GT9X7CVF5F charts % docker pull bitnamilegacy/redis-exporter:1.74.0-debian-12-r3
1.74.0-debian-12-r3: Pulling from bitnamilegacy/redis-exporter
dbf75f05c48e: Pull complete 
Digest: sha256:26d147a5cef36c1f0c3a9ab4ed0633d1318b233f09aa4e771a943beae3edede1
Status: Downloaded newer image for bitnamilegacy/redis-exporter:1.74.0-debian-12-r3
docker.io/bitnamilegacy/redis-exporter:1.74.0-debian-12-r3
```

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-108757


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
