### PR TITLE
feat: bump flux oci mirror to 0.2.4

### DIFF
--- a/applications/kommander-flux/2.6.1/mirror/flux-oci-mirror.yaml
+++ b/applications/kommander-flux/2.6.1/mirror/flux-oci-mirror.yaml
@@ -48,7 +48,7 @@ spec:
         - args:
             - -config-dir
             - /config
-          image: mesosphere/flux-oci-mirror:v0.2.3
+          image: mesosphere/flux-oci-mirror:v0.2.4
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10

--- a/hack/flux/update-flux-oci-mirror.sh
+++ b/hack/flux/update-flux-oci-mirror.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="v0.2.3"
+VERSION="v0.2.4"
 
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -1,10 +1,10 @@
 ignore:
   - docker.io/mesosphere/trivy-bundles:0.64.1-20250707T225137Z
-  # - container_image: docker.io/mesosphere/flux-oci-mirror:v0.2.3
+  # - container_image: docker.io/mesosphere/flux-oci-mirror:v0.2.4
   #   sources:
   #     - url: https://github.com/nutanix-cloud-native/flux-oci-mirror
   #       ref: ${image_tag}
-  - docker.io/mesosphere/flux-oci-mirror:v0.2.3
+  - docker.io/mesosphere/flux-oci-mirror:v0.2.4
 
 resources:
   - container_image: docker.io/fluent/fluent-bit:4.0.5

--- a/make/flux.mk
+++ b/make/flux.mk
@@ -2,3 +2,8 @@
 flux-update: ## Updates flux manifests
 flux-update: ; $(info $(M) updating flux manifests)
 	$(REPO_ROOT)/hack/flux/update-flux.sh
+
+.PHONY: flux-oci-mirror-update
+flux-oci-mirror-update: ## Updates flux oci mirror manifests
+flux-oci-mirror-update: ; $(info $(M) updating flux oci mirorr manifests)
+	$(REPO_ROOT)/hack/flux/update-flux-oci-mirror.sh


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumps flux oci mirror to 0.2.4

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
