### PR TITLE
fix(kommander): Add external-secrets dependency

### DIFF
--- a/applications/kommander/0.16.0/kommander.yaml
+++ b/applications/kommander/0.16.0/kommander.yaml
@@ -21,6 +21,8 @@ spec:
       # NOTE: The `kubefed` app is not installing the HelmRelease directly.
       # That's how its HelmRelease name is simply `kubefed`
       name: kubefed
+    - namespace: ${releaseNamespace}
+      name: external-secrets
   chartRef:
     kind: OCIRepository
     name: kommander-chart


### PR DESCRIPTION
**What problem does this PR solve?**:
We have controllers in kommander that reconcile ESO resources, and other controllers that depend on ESO (creates ESO resources). When kommander comes up before ESO is deployed (ESO CRDs don't exist) we might see the kommander-cm pod crashloop. Even if it does not end up crashing, there are a lot of error logs in the controller until ESO is up.

```
2025-07-30T22:39:39.627Z	ERROR	controller-runtime.source.EventHandler	if kind is a CRD, it should be installed before calling Start	{"kind": "SecretStore.external-secrets.io", "error": "no matches for kind \"SecretStore\" in version \"external-secrets.io/v1\""}
sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1.1
	sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/source/kind.go:71
k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2
	k8s.io/apimachinery@v0.33.2/pkg/util/wait/loop.go:87
k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext
	k8s.io/apimachinery@v0.33.2/pkg/util/wait/loop.go:88
k8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel
	k8s.io/apimachinery@v0.33.2/pkg/util/wait/poll.go:33
sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1
	sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/source/kind.go:64
2025-07-30T22:39:39.627Z	INFO	Stopping and waiting for webhooks
2025-07-30T22:39:39.627Z	INFO	Stopping and waiting for HTTP servers
2025-07-30T22:39:39.666Z	INFO	shutting down server	{"name": "pprof", "addr": "127.0.0.1:8081"}
2025-07-30T22:39:39.667Z	INFO	controller-runtime.metrics	Shutting down metrics server with timeout of 1 minute
2025-07-30T22:39:39.667Z	INFO	Wait completed, proceeding to shutdown the manager
2025-07-30T22:39:39.667Z	ERROR	setup	problem running manager	{"error": "failed to wait for SecretStoreSyncController caches to sync kind source: *v1.SecretStore: timed out waiting for cache to be synced for Kind *v1.SecretStore"}
github.com/mesosphere/kommander/v2/common/pkg/log.(*logger).Error
	github.com/mesosphere/kommander/v2/common/pkg/log/logger.go:53
main.main
	./main.go:629
runtime.main
	runtime/proc.go:283
```

```
2025-07-30T22:40:03.999Z	ERROR	controllers.SecretStoreController	Reconciler error	{"reconcileID": "2a4ccb9e-b308-41a4-a26b-4e9abb18d809", "error": "no matches for kind \"SecretStore\" in version \"external-secrets.io/v1\""}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:347
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:294
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
	sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:255
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-108743

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
