### PR TITLE
feat: add prometheus/promethes:v3.3.0

### DIFF
--- a/applications/kube-prometheus-stack/71.0.0/defaults/cm.yaml
+++ b/applications/kube-prometheus-stack/71.0.0/defaults/cm.yaml
@@ -18,11 +18,6 @@ data:
           registry: quay.io
           repository: prometheus-operator/prometheus-config-reloader
           tag: v0.82.2
-      prometheus:
-        image:
-          registry: quay.io
-          repository: prometheus/prometheus
-          tag: v3.3.0
       admissionWebhooks:
         patch:
           priorityClassName: "dkp-critical-priority"
@@ -187,6 +182,10 @@ data:
                   - image-automation-controller
                   - image-reflector-controller
       prometheusSpec:
+        image:
+          registry: quay.io
+          repository: prometheus/prometheus
+          tag: v3.3.0
         priorityClassName: "dkp-critical-priority"
         logLevel: warn
         serviceMonitorNamespaceSelector: {}  # all namespaces

--- a/applications/kube-prometheus-stack/71.0.0/defaults/cm.yaml
+++ b/applications/kube-prometheus-stack/71.0.0/defaults/cm.yaml
@@ -605,6 +605,11 @@ data:
                       gauge:
                         path: ["metadata", "annotations", "machine.cluster.x-k8s.io/certificates-expiry"]
       prometheus:
+        enabled: true
+        image:
+          registry: quay.io
+          repository: prometheus/prometheus
+          tag: v3.3.0
         monitor:
           additionalLabels:
             prometheus.kommander.d2iq.io/select: "true"
@@ -619,6 +624,7 @@ data:
         image:
           tag: v0.19.1
       prometheus:
+
         monitor:
           scheme: https
           bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/applications/kube-prometheus-stack/71.0.0/defaults/cm.yaml
+++ b/applications/kube-prometheus-stack/71.0.0/defaults/cm.yaml
@@ -197,8 +197,7 @@ data:
         externalLabels:
           cluster: $(CLUSTER_ID)
         image:
-          registry: quay.io
-          repository: prometheus/prometheus
+          repository: quay.io/prometheus/prometheus
           tag: v3.3.0
         containers:
           - name: config-reloader

--- a/applications/kube-prometheus-stack/71.0.0/defaults/cm.yaml
+++ b/applications/kube-prometheus-stack/71.0.0/defaults/cm.yaml
@@ -197,7 +197,8 @@ data:
         externalLabels:
           cluster: $(CLUSTER_ID)
         image:
-          repository: quay.io/prometheus/prometheus
+          registry: quay.io
+          repository: prometheus/prometheus
           tag: v3.3.0
         containers:
           - name: config-reloader

--- a/applications/kube-prometheus-stack/71.0.0/defaults/cm.yaml
+++ b/applications/kube-prometheus-stack/71.0.0/defaults/cm.yaml
@@ -182,10 +182,6 @@ data:
                   - image-automation-controller
                   - image-reflector-controller
       prometheusSpec:
-        image:
-          registry: quay.io
-          repository: prometheus/prometheus
-          tag: v3.3.0
         priorityClassName: "dkp-critical-priority"
         logLevel: warn
         serviceMonitorNamespaceSelector: {}  # all namespaces
@@ -200,6 +196,10 @@ data:
           version: v0.30.1
         externalLabels:
           cluster: $(CLUSTER_ID)
+        image:
+          registry: quay.io
+          repository: prometheus/prometheus
+          tag: v3.3.0
         containers:
           - name: config-reloader
             envFrom:
@@ -605,11 +605,6 @@ data:
                       gauge:
                         path: ["metadata", "annotations", "machine.cluster.x-k8s.io/certificates-expiry"]
       prometheus:
-        enabled: true
-        image:
-          registry: quay.io
-          repository: prometheus/prometheus
-          tag: v3.3.0
         monitor:
           additionalLabels:
             prometheus.kommander.d2iq.io/select: "true"
@@ -624,7 +619,6 @@ data:
         image:
           tag: v0.19.1
       prometheus:
-
         monitor:
           scheme: https
           bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/applications/kube-prometheus-stack/71.0.0/defaults/cm.yaml
+++ b/applications/kube-prometheus-stack/71.0.0/defaults/cm.yaml
@@ -18,6 +18,11 @@ data:
           registry: quay.io
           repository: prometheus-operator/prometheus-config-reloader
           tag: v0.82.2
+      prometheus:
+        image:
+          registry: quay.io
+          repository: prometheus/prometheus
+          tag: v3.3.0
       admissionWebhooks:
         patch:
           priorityClassName: "dkp-critical-priority"

--- a/applications/kube-prometheus-stack/71.0.0/helmrelease/extra-images.txt
+++ b/applications/kube-prometheus-stack/71.0.0/helmrelease/extra-images.txt
@@ -1,3 +1,4 @@
 {{ .Values.global.imageRegistry | default .Values.prometheusOperator.image.registry }}/{{ .Values.prometheusOperator.image.repository }}:{{ .Values.prometheusOperator.image.tag | default .Chart.AppVersion }}
 {{ .Values.global.imageRegistry | default .Values.prometheusOperator.prometheusConfigReloader.image.registry }}/{{ .Values.prometheusOperator.prometheusConfigReloader.image.repository }}:{{ .Values.prometheusOperator.prometheusConfigReloader.image.tag | default .Chart.AppVersion }}
 {{ .Values.global.imageRegistry | default .Values.prometheusOperator.thanosImage.registry }}/{{ .Values.prometheusOperator.thanosImage.repository }}:{{ .Values.prometheusOperator.thanosImage.tag }}
+{{ .Values.global.imageRegistry | default .Values.prometheus.prometheusSpec.image.registry }}/{{ .Values.prometheus.prometheusSpec.image.repository }}:{{ .Values.prometheus.prometheusSpec.image.tag }}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -447,6 +447,12 @@ resources:
         notice_path: NOTICE
         ref: ${image_tag}
         url: https://github.com/prometheus/prometheus
+  - container_image: quay.io/prometheus/prometheus:v3.3.0
+    sources:
+      - license_path: LICENSE
+        notice_path: NOTICE
+        ref: ${image_tag}
+        url: https://github.com/prometheus/prometheus
   - container_image: quay.io/thanos/thanos:v0.39.2
     sources:
       - license_path: LICENSE


### PR DESCRIPTION
**What problem does this PR solve?**:

include prometheus/promethes:v3.3.0 image in license file  with v3.4.1, as few components (e.g., Kubecost, Grafana) might still reference to v3.3.0. 
**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-108800


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
