### PR TITLE
fix: unique name for cosi bucket kit

### DIFF
--- a/applications/harbor/1.17.1/cosi-storage/cosi-bucket.yaml
+++ b/applications/harbor/1.17.1/cosi-storage/cosi-bucket.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: cosi-bucket-kit
+  name: harbor-cosi-bucket-kit
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
@@ -18,7 +18,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: cosi-bucket-kit
+    name: harbor-cosi-bucket-kit
     namespace: ${releaseNamespace}
   interval: 15s
   install:

--- a/applications/kubecost/2.8.1/cosi-storage/cosi-bucket.yaml
+++ b/applications/kubecost/2.8.1/cosi-storage/cosi-bucket.yaml
@@ -1,7 +1,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: cosi-bucket-kit
+  name: kubecost-cosi-bucket-kit
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
@@ -17,7 +17,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: cosi-bucket-kit
+    name: kubecost-cosi-bucket-kit
     namespace: ${releaseNamespace}
   interval: 15s
   install:


### PR DESCRIPTION
**What problem does this PR solve?**:
cosi bucket kit chart is being reinstalled for 2 different versions:

```

  Conditions:
    Last Transition Time:  2025-08-04T09:14:44Z
    Message:               stored artifact for digest '0.0.5@sha256:d4d9add4a45f28f2d0873f69d129e7c00332635950c2d1bead6cea40228c1125'
    Observed Generation:   39
    Reason:                Succeeded
    Status:                True
    Type:                  Ready
    Last Transition Time:  2025-08-04T09:14:44Z
    Message:               stored artifact for digest '0.0.5@sha256:d4d9add4a45f28f2d0873f69d129e7c00332635950c2d1bead6cea40228c1125'
    Observed Generation:   39
    Reason:                Succeeded
    Status:                True
    Type:                  ArtifactInStorage
  Observed Generation:     39
  URL:                     http://source-controller.kommander-flux.svc.cluster.local./ocirepository/kommander/cosi-bucket-kit/latest.tar.gz
Events:
  Type    Reason            Age                   From               Message
  ----    ------            ----                  ----               -------
  Normal  ArtifactUpToDate  21m (x630 over 12h)   source-controller  artifact up-to-date with remote revision: '0.0.5@sha256:d4d9add4a45f28f2d0873f69d129e7c00332635950c2d1bead6cea40228c1125'
  Normal  NewArtifact       17m (x17 over 12h)    source-controller  stored artifact with revision '0.0.5@sha256:d4d9add4a45f28f2d0873f69d129e7c00332635950c2d1bead6cea40228c1125' from 'oci://ghcr.io/mesosphere/charts/cosi-bucket-kit'
  Normal  ArtifactUpToDate  2m13s (x13 over 17m)  source-controller  artifact up-to-date with remote revision: '0.0.8@sha256:5ea02b9058c24139e9a3e80c7732354bc4be1dc1d523466a516a8157836c9963'
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
