### PR TITLE
fix: NCN-108862 adds ubuntu prebuilt driver container for pro

### DIFF
--- a/applications/nvidia-gpu-operator/25.3.1/helmrelease/extra-images.txt
+++ b/applications/nvidia-gpu-operator/25.3.1/helmrelease/extra-images.txt
@@ -5,4 +5,7 @@ nvcr.io/nvidia/cloud-native/dcgm:{{ .Values.dcgm.version }}
 nvcr.io/nvidia/k8s/dcgm-exporter:{{ .Values.dcgmExporter.version }}
 nvcr.io/nvidia/k8s-device-plugin:{{ .Values.devicePlugin.version }}
 nvcr.io/nvidia/cloud-native/k8s-mig-manager:{{ .Values.migManager.version }}
+# This corresponds to the kernel version 5.15.0-139-generic that the ubuntu pro images that we ship.
+# When the kernel changes this should change too.
+nvcr.io/nvidia/driver:535-5.15.0-139-generic-ubuntu22.04
 nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -505,7 +505,7 @@ resources:
   - container_image: nvcr.io/nvidia/driver:535-5.15.0-139-generic-ubuntu22.04
     sources:
       - license_path: LICENSE
-        ref: 535-5.15.0-139-generic-ubuntu22.04
+        ref: ${image_tag%-535-5.15.0-139-generic-ubuntu22.04}
         url: https://github.com/NVIDIA/gpu-driver-container
   - container_image: quay.io/ceph/ceph:v19.2.2
     sources:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -502,7 +502,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag%-ubuntu20.04}
         url: https://github.com/NVIDIA/mig-parted
-  - container_image: nvcr.io/nvidia/driver
+  - container_image: nvcr.io/nvidia/driver:535-5.15.0-139-generic-ubuntu22.04
     sources:
       - license_path: LICENSE
         ref: 535-5.15.0-139-generic-ubuntu22.04

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -505,7 +505,8 @@ resources:
   - container_image: nvcr.io/nvidia/driver:535-5.15.0-139-generic-ubuntu22.04
     sources:
       - license_path: LICENSE
-        ref: ${image_tag%-535-5.15.0-139-generic-ubuntu22.04}
+        ref: main
+        directory: /ubuntu22.04/precompiled
         url: https://github.com/NVIDIA/gpu-driver-container
   - container_image: quay.io/ceph/ceph:v19.2.2
     sources:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -502,6 +502,11 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag%-ubuntu20.04}
         url: https://github.com/NVIDIA/mig-parted
+  - container_image: nvcr.io/nvidia/driver
+    sources:
+      - license_path: LICENSE
+        ref: 535-5.15.0-139-generic-ubuntu22.04
+        url: https://github.com/NVIDIA/gpu-driver-container
   - container_image: quay.io/ceph/ceph:v19.2.2
     sources:
       - license_path: COPYING


### PR DESCRIPTION
**What problem does this PR solve?**:
For the Ubuntu OOTB OS, we need to add the nvidia precompiled drivers to the NKP airgap package. 

This will be required to allow NKP customers to use GPU workloads in airgap scenarios in combination with Ubuntu OOTB OS



**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-108862


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
