### PR TITLE
fix: Remove pullthrough as registry path for ai-navigator-rag

### DIFF
--- a/applications/ai-navigator-rag/0.6.1/defaults/cm.yaml
+++ b/applications/ai-navigator-rag/0.6.1/defaults/cm.yaml
@@ -13,5 +13,5 @@ data:
       enabled: false
     image:
       chatbot:
-        repository: "pullthrough.infra.nkp.sh/mesosphere/ai-navigator-rag"
+        repository: "mesosphere/ai-navigator-rag"
       tag: "0.6.1"


### PR DESCRIPTION
**What problem does this PR solve?**:
Using `pullthrough.infra.nkp.sh` cause a failure when building images for [Kommmander GHA](https://github.com/mesosphere/kommander/actions/runs/16738046081/job/47380794785#step:13:827) 

Revert this addition which landed in #3841 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
