### PR TITLE
refactor: rename the unique named ocirepos

### DIFF
--- a/applications/centralized-grafana/71.0.1/centralized-grafana.yaml
+++ b/applications/centralized-grafana/71.0.1/centralized-grafana.yaml
@@ -1,7 +1,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: ${releaseName}-kube-prometheus-stack
+  name: ${releaseName}-chart
   namespace: ${releaseNamespace}
 spec:
   interval: 10m
@@ -17,7 +17,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: ${releaseName}-kube-prometheus-stack
+    name: ${releaseName}-chart
     namespace: ${releaseNamespace}
   interval: 15s
   install:

--- a/applications/cosi-driver-nutanix/0.6.0/cosi-resources-nutanix.yaml
+++ b/applications/cosi-driver-nutanix/0.6.0/cosi-resources-nutanix.yaml
@@ -1,7 +1,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: ${releaseName}-cosi-bucket-kit
+  name: ${releaseName}-chart
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
@@ -17,7 +17,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: ${releaseName}-cosi-bucket-kit
+    name: ${releaseName}-chart
     namespace: ${releaseNamespace}
   interval: 15s
   dependsOn:

--- a/applications/gateway-api-crds/1.9.0/gateway-api-crds.yaml
+++ b/applications/gateway-api-crds/1.9.0/gateway-api-crds.yaml
@@ -1,7 +1,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: ${releaseName}-traefik-crds
+  name: ${releaseName}-chart
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
@@ -18,7 +18,7 @@ spec:
   interval: 6h
   chartRef:
     kind: OCIRepository
-    name: ${releaseName}-traefik-crds
+    name: ${releaseName}-chart
     namespace: ${releaseNamespace}
   valuesFrom:
     - kind: ConfigMap

--- a/applications/grafana-loki/0.80.4/grafana-loki-helmrelease/grafana-loki.yaml
+++ b/applications/grafana-loki/0.80.4/grafana-loki-helmrelease/grafana-loki.yaml
@@ -3,7 +3,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: ${releaseName}-loki-distributed
+  name: ${releaseName}-chart
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
@@ -19,7 +19,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: ${releaseName}-loki-distributed
+    name: ${releaseName}-chart
     namespace: ${releaseNamespace}
   interval: 15s
   timeout: 15m

--- a/applications/karma-traefik/0.0.3/karma-traefik.yaml
+++ b/applications/karma-traefik/0.0.3/karma-traefik.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: ${releaseName}-thanos-traefik
+  name: ${releaseName}-chart
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
@@ -18,7 +18,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: ${releaseName}-thanos-traefik
+    name: ${releaseName}-chart
     namespace: ${releaseNamespace}
   interval: 15s
   install:

--- a/applications/project-grafana-logging/8.15.2/project-grafana.yaml
+++ b/applications/project-grafana-logging/8.15.2/project-grafana.yaml
@@ -3,7 +3,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: ${releaseName}-grafana
+  name: ${releaseName}-chart
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
@@ -19,7 +19,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: ${releaseName}-grafana
+    name: ${releaseName}-chart
     namespace: ${releaseNamespace}
   interval: 15s
   install:

--- a/applications/project-grafana-loki/0.80.4/object-bucket-claims.yaml
+++ b/applications/project-grafana-loki/0.80.4/object-bucket-claims.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: ${releaseName}-object-bucket-claim
+  name: ${releaseName}-chart
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
@@ -18,7 +18,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: ${releaseName}-object-bucket-claim
+    name: ${releaseName}-chart
     namespace: ${releaseNamespace}
   interval: 15s
   install:

--- a/applications/project-grafana-loki/0.80.4/project-grafana-loki.yaml
+++ b/applications/project-grafana-loki/0.80.4/project-grafana-loki.yaml
@@ -3,7 +3,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: ${releaseName}-loki-distributed
+  name: ${releaseName}-chart
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
@@ -19,7 +19,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: ${releaseName}-loki-distributed
+    name: ${releaseName}-chart
     namespace: ${releaseNamespace}
   timeout: 15m
   interval: 15s

--- a/applications/prometheus-thanos-traefik/0.0.3/prometheus-thanos-traefik.yaml
+++ b/applications/prometheus-thanos-traefik/0.0.3/prometheus-thanos-traefik.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: ${releaseName}-thanos-traefik
+  name: ${releaseName}-chart
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
@@ -18,7 +18,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: ${releaseName}-thanos-traefik
+    name: ${releaseName}-chart
     namespace: ${releaseNamespace}
   interval: 15s
   install:

--- a/applications/rook-ceph-cluster/1.17.6/objectbucketclaims/cosi-bucket.yaml
+++ b/applications/rook-ceph-cluster/1.17.6/objectbucketclaims/cosi-bucket.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: ${releaseName}-cosi-bucket-kit
+  name: ${releaseName}-chart
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
@@ -18,7 +18,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: ${releaseName}-cosi-bucket-kit
+    name: ${releaseName}-chart
     namespace: ${releaseNamespace}
   interval: 15s
   install:

--- a/applications/rook-ceph-cluster/1.17.6/objectbucketclaims/helmrelease.yaml
+++ b/applications/rook-ceph-cluster/1.17.6/objectbucketclaims/helmrelease.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: ${releaseName}-object-bucket-claim
+  name: ${releaseName}-chart
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
@@ -18,7 +18,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: ${releaseName}-object-bucket-claim
+    name: ${releaseName}-chart
     namespace: ${releaseNamespace}
   timeout: 20m
   interval: 15s

--- a/applications/traefik-forward-auth-mgmt/0.3.15/traefik-forward-auth-mgmt.yaml
+++ b/applications/traefik-forward-auth-mgmt/0.3.15/traefik-forward-auth-mgmt.yaml
@@ -1,7 +1,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: ${releaseName}-traefik-forward-auth
+  name: ${releaseName}-chart
   namespace: ${releaseNamespace}
 spec:
   interval: 1m
@@ -24,7 +24,7 @@ spec:
       name: kommander
   chartRef:
     kind: OCIRepository
-    name: ${releaseName}-traefik-forward-auth
+    name: ${releaseName}-chart
     namespace: ${releaseNamespace}
   interval: 15s
   install:


### PR DESCRIPTION
**What problem does this PR solve?**:
related, now we have some HR having repo name like:

```
traefik-forward-auth-mgmt-traefik-forward-auth 
prometheus-thanos-traefik-thanos-traefik
```

i propose to change to sth like:
```
${releaseName}-chart 
-> traefik-forward-auth-mgmt-chart
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
