### PR TITLE
feat: Add pod anti-affinity rules for eventing-webhook deployment

### DIFF
--- a/applications/knative/1.18.1/defaults/cm.yaml
+++ b/applications/knative/1.18.1/defaults/cm.yaml
@@ -69,6 +69,23 @@ data:
       namespace: knative-eventing
       manifest:
         spec:
+          deployments:
+            - name: eventing-webhook
+              replicas: 3
+              podTemplate:
+                spec:
+                  affinity:
+                    podAntiAffinity:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        - weight: 1
+                          podAffinityTerm:
+                            labelSelector:
+                              matchLabels:
+                                app: eventing-webhook
+                            topologyKey: kubernetes.io/hostname
+          podDisruptionBudgets:
+            - name: eventing-webhook
+              maxUnavailable: 1
           # The version of Knative Eventing to install - you can upgrade one version at a time
           # See https://knative.dev/docs/install/operator/knative-with-operators/#installing-a-specific-version-of-eventing
           version: "1.18.1"


### PR DESCRIPTION
**What problem does this PR solve?**:

Made adjustments to the Knative `eventing-webhook` deployment:

- Added a `podDisruptionBudgets` override in the config. This is set to `maxUnavailable: 1` to be consistent with our original Knative chart. This setting allows the replicas to be scaled from 1 to n and will still allow nodes to drain.
- Added `replicas: 3` as a default. Consistent with the idea, Knative would remain available during an upgrade and eventing is generally a HA component.
- Added preferred `podAntiAffinity` to spread pods among nodes.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://jira.nutanix.com/browse/NCN-108946

**Special notes for your reviewer**:

Tested by draining nodes in a dev cluster.


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
