### PR TITLE
fix(grafana): Disable preinstalled plugins

### DIFF
--- a/applications/centralized-grafana/71.0.1/defaults/cm.yaml
+++ b/applications/centralized-grafana/71.0.1/defaults/cm.yaml
@@ -74,7 +74,7 @@ data:
         users:
           auto_assign_org_role: Admin
         plugins:
-          allow_loading_unsigned_plugins: "grafana-piechart-panel"
+          preinstall_disabled: true
         dashboards:
           default_home_dashboard_path: "/tmp/dashboards/global-overview.json"
         analytics:

--- a/applications/grafana-logging/8.15.2/defaults/cm.yaml
+++ b/applications/grafana-logging/8.15.2/defaults/cm.yaml
@@ -55,7 +55,7 @@ data:
       users:
         auto_assign_org_role: Admin
       plugins:
-        allow_loading_unsigned_plugins: "grafana-piechart-panel"
+        preinstall_disabled: true
       analytics:
         reporting_enabled: false
         check_for_updates: false

--- a/applications/kube-prometheus-stack/71.0.1/defaults/cm.yaml
+++ b/applications/kube-prometheus-stack/71.0.1/defaults/cm.yaml
@@ -511,7 +511,7 @@ data:
         users:
           auto_assign_org_role: Admin
         plugins:
-          allow_loading_unsigned_plugins: "grafana-piechart-panel"
+          preinstall_disabled: true
         dashboards:
           default_home_dashboard_path: "/tmp/dashboards/k8s-resources-cluster.json"
         analytics:

--- a/applications/project-grafana-logging/8.15.2/defaults/cm.yaml
+++ b/applications/project-grafana-logging/8.15.2/defaults/cm.yaml
@@ -55,7 +55,7 @@ data:
       users:
         auto_assign_org_role: Admin
       plugins:
-        allow_loading_unsigned_plugins: "grafana-piechart-panel"
+        preinstall_disabled: true
       analytics:
         reporting_enabled: false
         check_for_updates: false


### PR DESCRIPTION
**What problem does this PR solve?**:
In airgapped clusters, grafana was failing to load plugins (new feature in grafana) and was essentially unusable.
ref https://github.com/grafana/grafana/issues/106871#issuecomment-3035054121 

Also in https://github.com/mesosphere/kommander-applications/commit/a9c1d9e6d64f05fea491e360ca079e422ab193a7 we removed piechart plugin, just cleaning up the unused field here

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-108951

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
