### PR TITLE
fix: Correct storage version migration image paths in ConfigMap

### DIFF
--- a/applications/knative/1.18.1/defaults/cm.yaml
+++ b/applications/knative/1.18.1/defaults/cm.yaml
@@ -43,14 +43,14 @@ data:
           registry:
             override:
               # Pin serving images to specific tagged versions
-              storage-version-migration/migrate: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate:v1.18.0
+              storage-version-migration-serving-/migrate: "gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate:v1.18.0"
               activator/activator: gcr.io/knative-releases/knative.dev/serving/cmd/activator:v1.18.1
               autoscaler-hpa/autoscaler-hpa: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa:v1.18.1
               autoscaler/autoscaler: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler:v1.18.1
               controller/controller: gcr.io/knative-releases/knative.dev/serving/cmd/controller:v1.18.1
               queue-proxy/queue-proxy: gcr.io/knative-releases/knative.dev/serving/cmd/queue:v1.18.1
               webhook/webhook: gcr.io/knative-releases/knative.dev/serving/cmd/webhook:v1.18.1
-              storage-version-migration/migrate: gcr.io/knative-releases/knative.dev/serving/pkg/cleanup/cmd/cleanup:v1.18.1
+              storage-version-migration-serving-/cleanup: "gcr.io/knative-releases/knative.dev/serving/pkg/cleanup/cmd/cleanup:v1.18.1"
           config:
             deployment:
               registriesSkippingTagResolving: "gcr.io"
@@ -111,5 +111,6 @@ data:
               log-sink/log-sink: gcr.io/knative-releases/log-sink:v1.18.0
               timer-source/timer-source: gcr.io/knative-releases/timer-source:v1.18.0
               transform-jsonata/transform-jsonata: gcr.io/knative-releases/transform-jsonata:v1.18.0
+              storage-version-migration-eventing-/migrate: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate:v1.18.1
               APISERVER_RA_IMAGE: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter:v1.18.1
               DISPATCHER_IMAGE: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher:v1.18.1


### PR DESCRIPTION
**What problem does this PR solve?**:

- Pin Knative images for `storage-version-migration` with current names.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://jira.nutanix.com/browse/NCN-108950

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
