### PR TITLE
fix: bump flux oci mirror to 0.2.5

### DIFF
--- a/applications/kommander-flux/2.6.1/mirror/flux-oci-mirror.yaml
+++ b/applications/kommander-flux/2.6.1/mirror/flux-oci-mirror.yaml
@@ -48,7 +48,7 @@ spec:
         - args:
             - -config-dir
             - /config
-          image: mesosphere/flux-oci-mirror:v0.2.4
+          image: mesosphere/flux-oci-mirror:v0.2.5
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10

--- a/hack/flux/update-flux-oci-mirror.sh
+++ b/hack/flux/update-flux-oci-mirror.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="v0.2.4"
+VERSION="v0.2.5"
 
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT


### PR DESCRIPTION
**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
