### PR TITLE
feat: Update images for Knative - env vars and queue-proxy

### DIFF
--- a/applications/knative/1.18.1/defaults/cm.yaml
+++ b/applications/knative/1.18.1/defaults/cm.yaml
@@ -51,6 +51,7 @@ data:
               queue-proxy: gcr.io/knative-releases/knative.dev/serving/cmd/queue:v1.18.1
               webhook/webhook: gcr.io/knative-releases/knative.dev/serving/cmd/webhook:v1.18.1
               cleanup-serving-/cleanup: gcr.io/knative-releases/knative.dev/serving/pkg/cleanup/cmd/cleanup:v1.18.1
+              QUEUE_SIDECAR_IMAGE: gcr.io/knative-releases/knative.dev/serving/cmd/queue:v1.18.1
           config:
             deployment:
               registriesSkippingTagResolving: "gcr.io"
@@ -92,12 +93,6 @@ data:
           registry:
             override:
               # Pin eventing images to specific tagged versions
-              aws-ddb-streams-source/aws-ddb-streams-source: gcr.io/knative-releases/aws-ddb-streams-source:v1.18.0
-              aws-s3-sink/aws-s3-sink: gcr.io/knative-releases/aws-s3-sink:v1.18.0
-              aws-s3-source/aws-s3-source: gcr.io/knative-releases/aws-s3-source:v1.18.0
-              aws-sns-sink/aws-sns-sink: gcr.io/knative-releases/aws-sns-sink:v1.18.0
-              aws-sqs-sink/aws-sqs-sink: gcr.io/knative-releases/aws-sqs-sink:v1.18.0
-              aws-sqs-source/aws-sqs-source: gcr.io/knative-releases/aws-sqs-source:v1.18.0
               mt-broker-filter/filter: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter:v1.18.1
               mt-broker-ingress/ingress: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress:v1.18.1
               eventing-controller/eventing-controller: gcr.io/knative-releases/knative.dev/eventing/cmd/controller:v1.18.1
@@ -108,8 +103,14 @@ data:
               pingsource-mt-adapter/dispatcher: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping:v1.18.1
               eventing-webhook/eventing-webhook: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook:v1.18.1
               storage-version-migration-eventing-/migrate: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate:v1.18.1
-              log-sink/log-sink: gcr.io/knative-releases/log-sink:v1.18.0
-              timer-source/timer-source: gcr.io/knative-releases/timer-source:v1.18.0
-              transform-jsonata/transform-jsonata: gcr.io/knative-releases/transform-jsonata:v1.18.0
               APISERVER_RA_IMAGE: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter:v1.18.1
+              AWS_DDB_STREAMS_SOURCE: gcr.io/knative-releases/aws-ddb-streams-source:v1.18.0
+              AWS_S3_SINK: gcr.io/knative-releases/aws-s3-sink:v1.18.0
+              AWS_S3_SOURCE: gcr.io/knative-releases/aws-s3-source:v1.18.0
+              AWS_SNS_SINK: gcr.io/knative-releases/aws-sns-sink:v1.18.0
+              AWS_SQS_SINK: gcr.io/knative-releases/aws-sqs-sink:v1.18.0
+              AWS_SQS_SOURCE: gcr.io/knative-releases/aws-sqs-source:v1.18.0
               DISPATCHER_IMAGE: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher:v1.18.1
+              LOG_SINK: gcr.io/knative-releases/log-sink:v1.18.0
+              TIMER_SOURCE: gcr.io/knative-releases/timer-source:v1.18.0
+              TRANSFORM_JSONATA: gcr.io/knative-releases/transform-jsonata:v1.18.0

--- a/applications/knative/1.18.1/defaults/cm.yaml
+++ b/applications/knative/1.18.1/defaults/cm.yaml
@@ -43,14 +43,14 @@ data:
           registry:
             override:
               # Pin serving images to specific tagged versions
-              storage-version-migration-serving-/migrate: "gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate:v1.18.0"
+              storage-version-migration-serving-/migrate: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate:v1.18.1
               activator/activator: gcr.io/knative-releases/knative.dev/serving/cmd/activator:v1.18.1
               autoscaler-hpa/autoscaler-hpa: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa:v1.18.1
               autoscaler/autoscaler: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler:v1.18.1
               controller/controller: gcr.io/knative-releases/knative.dev/serving/cmd/controller:v1.18.1
-              queue-proxy/queue-proxy: gcr.io/knative-releases/knative.dev/serving/cmd/queue:v1.18.1
+              queue-proxy: gcr.io/knative-releases/knative.dev/serving/cmd/queue:v1.18.1
               webhook/webhook: gcr.io/knative-releases/knative.dev/serving/cmd/webhook:v1.18.1
-              storage-version-migration-serving-/cleanup: "gcr.io/knative-releases/knative.dev/serving/pkg/cleanup/cmd/cleanup:v1.18.1"
+              cleanup-serving-/cleanup: gcr.io/knative-releases/knative.dev/serving/pkg/cleanup/cmd/cleanup:v1.18.1
           config:
             deployment:
               registriesSkippingTagResolving: "gcr.io"
@@ -98,7 +98,6 @@ data:
               aws-sns-sink/aws-sns-sink: gcr.io/knative-releases/aws-sns-sink:v1.18.0
               aws-sqs-sink/aws-sqs-sink: gcr.io/knative-releases/aws-sqs-sink:v1.18.0
               aws-sqs-source/aws-sqs-source: gcr.io/knative-releases/aws-sqs-source:v1.18.0
-              apiserver-source-adapter/apiserver-source-adapter: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter:v1.18.1
               mt-broker-filter/filter: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter:v1.18.1
               mt-broker-ingress/ingress: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress:v1.18.1
               eventing-controller/eventing-controller: gcr.io/knative-releases/knative.dev/eventing/cmd/controller:v1.18.1
@@ -106,11 +105,11 @@ data:
               imc-dispatcher/dispatcher: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher:v1.18.1
               job-sink/job-sink: gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink:v1.18.1
               mt-broker-controller/mt-broker-controller: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker:v1.18.1
-              mt-ping/mt-ping: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping:v1.18.1
+              pingsource-mt-adapter/dispatcher: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping:v1.18.1
               eventing-webhook/eventing-webhook: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook:v1.18.1
+              storage-version-migration-eventing-/migrate: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate:v1.18.1
               log-sink/log-sink: gcr.io/knative-releases/log-sink:v1.18.0
               timer-source/timer-source: gcr.io/knative-releases/timer-source:v1.18.0
               transform-jsonata/transform-jsonata: gcr.io/knative-releases/transform-jsonata:v1.18.0
-              storage-version-migration-eventing-/migrate: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate:v1.18.1
               APISERVER_RA_IMAGE: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter:v1.18.1
               DISPATCHER_IMAGE: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher:v1.18.1

--- a/applications/knative/1.18.1/extra-images.txt
+++ b/applications/knative/1.18.1/extra-images.txt
@@ -14,7 +14,7 @@ gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink:v1.18.1
 gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker:v1.18.1
 gcr.io/knative-releases/knative.dev/eventing/cmd/mtping:v1.18.1
 gcr.io/knative-releases/knative.dev/eventing/cmd/webhook:v1.18.1
-gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate:v1.18.0
+gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate:v1.18.1
 gcr.io/knative-releases/knative.dev/serving/cmd/activator:v1.18.1
 gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa:v1.18.1
 gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler:v1.18.1

--- a/hack/knative/README.md
+++ b/hack/knative/README.md
@@ -25,7 +25,7 @@ python3 hack/knative/extract-images.py --eventing-version <version> --serving-ve
 ### Options
 
 - `--eventing-version` (required): KNative eventing version (e.g., 1.18.1)
-- `--serving-version` (required): KNative serving version (e.g., 1.18.1)  
+- `--serving-version` (required): KNative serving version (e.g., 1.18.1)
 - `--k-apps-version` (optional): Output directory version (defaults to serving version)
 
 ### What it does

--- a/hack/knative/README.md
+++ b/hack/knative/README.md
@@ -1,412 +1,108 @@
 # KNative Image Management Scripts
 
-This directory contains automation scripts for managing KNative Docker images, registry overrides for air-gapped deployments, and license entries in the Kommander Applications repository.
+Two Python scripts for managing KNative Docker images in Kommander Applications:
 
-## Scripts Overview
-
-### `extract-images.py`
-Extracts Docker image references from KNative operator manifests and automatically generates registry overrides for air-gapped deployments. Features include:
-- Multi-version support for eventing and serving components
-- Automatic registry override generation with deployment/container name mapping
-- Environment variable image detection and special formatting
-- Reverse digest-to-tag lookup using Google Container Registry API
-- Automatic cm.yaml configuration file updates
-
-### `update-licenses.py`
-Updates the `licenses.d2iq.yaml` file with KNative images extracted by the first script, ensuring proper license compliance.
-
----
+1. `extract-images.py` - Extracts images from KNative operator manifests and generates registry overrides
+2. `update-licenses.py` - Updates license file with extracted KNative images
 
 ## Prerequisites
 
-### Python Environment Setup
 ```bash
-# Create and activate virtual environment
-python3 -m venv venv
-source venv/bin/activate  # On macOS/Linux
-# or
-venv\Scripts\activate     # On Windows
-
-# Install required dependencies
+# Install required dependency
 pip install docker-image-py
 ```
 
-### Required Dependencies
-- docker-image-py: For proper Docker image reference validation
-- Standard library: subprocess, re, json, argparse, pathlib
+## extract-images.py
 
----
+Downloads KNative operator manifests from GitHub, extracts Docker image references, and automatically updates the cm.yaml configuration file with registry overrides for air-gapped deployments.
 
-## Usage
-
-### Step 1: Extract KNative Images and Generate Registry Overrides
+### Usage
 
 ```bash
-# Activate virtual environment
-source venv/bin/activate
-
-# Extract images and generate registry overrides for specific versions
-python3 hack/knative/extract-images.py --eventing-version <eventing_version> --serving-version <serving_version> [--k-apps-version <k_apps_version>]
-
-# Examples:
-python3 hack/knative/extract-images.py --eventing-version 1.18.1 --serving-version 1.18.1
-python3 hack/knative/extract-images.py --eventing-version 1.18.1 --serving-version 1.18.1 --k-apps-version 1.18.1
-python3 hack/knative/extract-images.py --eventing-version 1.19.0 --serving-version 1.19.0
+python3 hack/knative/extract-images.py --eventing-version <version> --serving-version <version> [--k-apps-version <version>]
 ```
 
-**What it does:**
-- Fetches YAML manifests from knative/operator repository for both eventing and serving
-- Extracts Docker image references using multiple advanced patterns including environment variables
-- Validates image references using docker-image-py
-- Performs reverse digest-to-tag lookup using Google Container Registry API v2
-- Generates deployment/container name mappings for proper registry override format
-- Automatically updates cm.yaml with properly formatted registry overrides
-- Preserves existing config sections (deployment, istio, features, autoscaler)
-- Saves extracted images to applications/knative/{version}/extra-images.txt
+### Options
 
-**Output:**
-```
-applications/knative/1.18.1/extra-images.txt                    # Raw image list
-applications/knative/1.18.1/defaults/cm.yaml                   # Updated with registry overrides
-```
+- `--eventing-version` (required): KNative eventing version (e.g., 1.18.1)
+- `--serving-version` (required): KNative serving version (e.g., 1.18.1)  
+- `--k-apps-version` (optional): Output directory version (defaults to serving version)
 
-**New Registry Override Features:**
-- **Deployment/Container Format**: Uses proper `deployment-name/container-name` format instead of image paths
-- **Environment Variable Handling**: Environment variable images use env var names as keys (e.g., `APISERVER_RA_IMAGE`)
-- **No Duplicates**: Properly replaces existing registry sections without creating duplicates
-- **Config Preservation**: Maintains critical config sections like `registriesSkippingTagResolving`
-- **Comprehensive Mapping**: Covers both serving and eventing components with accurate deployment mappings
+### What it does
 
-### Step 2: Update License File
+1. Fetches YAML manifests from knative/operator GitHub repository
+2. Extracts Docker image references using regex patterns
+3. Converts digest references to tagged versions using Google Container Registry API
+4. Maps images to deployment/container names for registry overrides
+5. Updates applications/knative/{version}/defaults/cm.yaml with registry overrides
+6. Saves all images to applications/knative/{version}/extra-images.txt
+
+### Key features
+
+- Handles environment variable images (APISERVER_RA_IMAGE, DISPATCHER_IMAGE)
+- Converts SHA digest references to version tags
+- Prevents duplicate entries
+- Preserves existing configuration sections
+- Special handling for queue-proxy container naming
+
+### Output files
+
+- `applications/knative/{version}/extra-images.txt` - List of all extracted images
+- `applications/knative/{version}/defaults/cm.yaml` - Updated with registry overrides
+
+## update-licenses.py
+
+Updates the licenses.d2iq.yaml file with KNative images from the extracted image list.
+
+### Usage
 
 ```bash
-# Update licenses with extracted images
 python3 hack/knative/update-licenses.py <version>
-
-# Examples:
-python3 hack/knative/update-licenses.py 1.18.1
-python3 hack/knative/update-licenses.py 1.19.0
 ```
 
-**What it does:**
-- Reads the extra-images.txt file generated in Step 1
-- Completely replaces all existing KNative entries in licenses.d2iq.yaml
-- Processes ALL images from extra-images.txt without deduplication
-- Adds KNative operator images (not included in extra-images.txt)
-- Uses proper version-specific ref format for all entries
-- Maps images to correct GitHub repositories
+### Options
 
-**Output:**
-- Updates licenses.d2iq.yaml with current image digests and version refs
+- `version` (required): KNative version (e.g., 1.18.1)
 
----
+### What it does
 
-## Script Details
+1. Reads images from applications/knative/{version}/extra-images.txt
+2. Adds KNative operator images (not in extra-images.txt)
+3. Removes all existing KNative entries from licenses.d2iq.yaml
+4. Adds all images with proper license information and GitHub repository URLs
+5. Uses version-specific refs (knative-v{version} for regular images, knative-${image_tag} for operators)
 
-### `extract-images.py`
+### Repository mapping
 
-#### Major Features:
-- **Multi-version support**: Separate eventing and serving version specification
-- **Advanced image extraction**: Multiple patterns for standard images, digests, and environment variables
-- **Registry override generation**: Creates properly formatted registry overrides for air-gapped deployments
-- **Digest-to-tag conversion**: Uses Google Container Registry API v2 to convert digest references to tagged versions
-- **Automatic cm.yaml updates**: Updates configuration files with registry overrides while preserving existing config
-- **Environment variable detection**: Special handling for images defined in environment variables
-- **Docker validation**: Validates all extracted strings as proper Docker image references
-- **GitHub API integration**: Fetches live manifests from the official KNative operator repository
+- knative.dev/eventing/* -> https://github.com/knative/eventing
+- knative.dev/serving/* -> https://github.com/knative/serving
+- knative.dev/pkg/* -> https://github.com/knative/pkg
+- knative.dev/operator/* -> https://github.com/knative/operator
+- aws-*, timer-source, log-sink, transform-jsonata -> https://github.com/knative/eventing
 
-#### Command Line Arguments:
-```bash
---eventing-version  # Required: KNative eventing version (e.g., 1.18.1)
---serving-version   # Required: KNative serving version (e.g., 1.18.1)
---k-apps-version    # Optional: Kommander apps version (defaults to serving_version)
-```
-
-#### Image Extraction Patterns:
-1. **Standard image references**: `image: gcr.io/knative-releases/...`
-2. **Digest references**: `gcr.io/knative-releases/...@sha256:...` (converted to tagged versions)
-3. **Environment variable images**: Detected via pattern `name: IMAGE_NAME\nvalue: image-reference`
-4. **ConfigMap references**: Images referenced in ConfigMaps or other resources
-
-#### Registry Override Generation:
-- **Deployment/Container Format**: Converts image paths to `deployment-name/container-name` format
-- **Environment Variable Keys**: Environment variable images use env var names as keys
-- **Comprehensive Mappings**: Covers both serving and eventing components with accurate deployment mappings
-- **Config Preservation**: Maintains essential config sections like `registriesSkippingTagResolving`, `istio`, `features`
-
-#### Example Registry Override Output:
-```yaml
-serving:
-  manifest:
-    spec:
-      registry:
-        override:
-          # Pin serving images to specific tagged versions
-          activator/activator: gcr.io/knative-releases/knative.dev/serving/cmd/activator:v1.18.1
-          autoscaler/autoscaler: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler:v1.18.1
-          controller/controller: gcr.io/knative-releases/knative.dev/serving/cmd/controller:v1.18.1
-      config:
-        deployment:
-          registriesSkippingTagResolving: "gcr.io"
-        # ... other config preserved
-```
-
-#### Repository Structure:
-```
-cmd/operator/kodata/
-  knative-eventing/
-    {version}/
-      200-eventing-core.yaml
-      201-eventing-crds.yaml
-      ...
-  knative-serving/
-    {version}/
-      200-serving-core.yaml
-      201-serving-crds.yaml
-      ...
-```
-
-### `update-licenses.py`
-
-#### Features:
-- **Complete replacement**: Removes all existing KNative entries and rebuilds from scratch
-- **No deduplication**: Processes every image in extra-images.txt exactly as listed
-- **Version-aware**: Updates version references when new version is specified
-- **Operator integration**: Automatically includes KNative operator images
-- **Repository mapping**: Maps images to correct GitHub repositories
-- **Clean insertion**: Places all KNative entries after Velero images in consistent order
-
-#### Processing Logic:
-1. **Read source**: Loads all images from extra-images.txt
-2. **Add operators**: Includes operator images (not in extra-images.txt)
-3. **Clean slate**: Removes ALL existing KNative entries from license file
-4. **Rebuild**: Adds all images (operators first, then extra-images.txt content)
-5. **Version update**: Uses provided version for ref formatting
-
-#### Repository Mapping:
-| Image Path | GitHub Repository |
-|------------|------------------|
-| knative.dev/eventing/* | https://github.com/knative/eventing |
-| knative.dev/serving/* | https://github.com/knative/serving |
-| knative.dev/pkg/* | https://github.com/knative/pkg |
-| knative.dev/operator/* | https://github.com/knative/operator |
-| aws-*, timer-source, log-sink, transform-jsonata | https://github.com/knative/eventing |
-
-#### License Entry Format:
-```yaml
-# Operator images (use variable ref)
-- container_image: gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.19.0
-  sources:
-    - license_path: LICENSE
-      ref: knative-${image_tag}
-      url: https://github.com/knative/operator
-
-# Regular KNative images (use version-specific ref)
-- container_image: gcr.io/knative-releases/image@sha256:...
-  sources:
-    - license_path: LICENSE
-      ref: knative-v1.19.0
-      url: https://github.com/knative/eventing
-```
-
-#### Image Processing:
-- **Total images**: 30 (2 operator + 28 from extra-images.txt)
-- **Operator images**: Always added first with `knative-${image_tag}` ref
-- **Extra images**: Processed in order from extra-images.txt with `knative-v{version}` ref
-- **Duplicates**: If extra-images.txt contains duplicates, all are included in license file
-
----
-
-## Workflow Example
-
-Complete workflow for updating KNative images to version 1.19.0:
+## Complete workflow
 
 ```bash
-# 1. Set up environment
-source venv/bin/activate
+# 1. Extract images and generate registry overrides
+python3 hack/knative/extract-images.py --eventing-version 1.19.0 --serving-version 1.19.0 --k-apps-version 1.19.0
 
-# 2. Extract images and generate registry overrides
-python3 hack/knative/extract-images.py --eventing-version 1.19.0 --serving-version 1.19.0
-# Output:
-#   - applications/knative/1.19.0/extra-images.txt (extracted images)
-#   - applications/knative/1.19.0/defaults/cm.yaml (updated with registry overrides)
-
-# 3. Update license file
+# 2. Update license file
 python3 hack/knative/update-licenses.py 1.19.0
-# Output: Updated licenses.d2iq.yaml (30 total images: 2 operator + 28 extra)
-
-# 4. Validate results (optional)
-make validate-licenses
 ```
-
-### Expected Output:
-```
-Extract Images Script:
-  Extracting Docker images from KNative operator manifests
-  Eventing version: 1.19.0
-  Serving version: 1.19.0
-  ======================================================================
-  Found 28 images in eventing and serving manifests
-  Generated registry overrides with deployment/container format
-  Updated applications/knative/1.19.0/defaults/cm.yaml (preserved config sections)
-
-Update Licenses Script:
-  Found 28 images in extra-images.txt
-  Removed 30 existing KNative entries
-  Added 30 KNative entries after Velero
-  Updated licenses.d2iq.yaml:
-    - Operator images: 2
-    - Extra images: 28
-    - Used version: knative-v1.19.0
-```
-
----
-
-## File Structure
-
-```
-hack/knative/
-  README.md                    # This documentation
-  extract-images.py            # Image extraction script
-  update-licenses.py           # License update script
-
-applications/knative/
-  {version}/
-    extra-images.txt         # Generated image list
-
-licenses.d2iq.yaml               # Updated license file
-```
-
----
 
 ## Troubleshooting
 
-### Registry Override Issues
+**Script fails with "Could not find tag for digest"**
+- Script automatically generates fallback tags and continues
 
-**Problem**: Config sections are missing after running extract-images.py
-**Solution**: The script now preserves all non-registry-override content in cm.yaml using line-by-line processing. Check that your cm.yaml has the expected config sections intact.
+**Registry overrides in wrong format**
+- Update to latest script version for proper deployment/container format
 
-**Problem**: Registry overrides in wrong format
-**Solution**: Ensure you're using the latest version of extract-images.py. The script now generates overrides in the correct deployment/container format:
-```yaml
-registry:
-  override:
-    eventing-controller/eventing-controller: my-registry.com/gcr.io/knative-releases/knative.dev/eventing/cmd/controller:v1.19.0
-    eventing-webhook/eventing-webhook: my-registry.com/gcr.io/knative-releases/knative.dev/eventing/cmd/webhook:v1.19.0
-```
+**Duplicate images**
+- Script now deduplicates automatically
 
-**Problem**: Duplicate registry sections being created
-**Solution**: The script now detects existing registry override sections and updates them in place instead of creating duplicates.
+**Environment variable images not detected**
+- Check YAML manifests use *_IMAGE pattern for environment variables
 
-### Image Extraction Issues
-
-**Problem**: Script fails with "Could not find tag for digest"
-**Solution**: Some images may not have tags in the GCR API. The script will log these cases and continue processing other images.
-
-**Problem**: Environment variable images not detected
-**Solution**: Check that environment variables follow the pattern `*_IMAGE` in the YAML manifests. The script looks for this specific pattern and treats them specially.
-
-**Problem**: GitHub API rate limiting
-**Solution**: Set up a GitHub token in your environment to increase rate limits:
-```bash
-export GITHUB_TOKEN=your_token_here
-```
-
-### License Update Issues
-
-**Problem**: Wrong number of images in licenses.d2iq.yaml
-**Solution**: Verify that extra-images.txt exists and contains the expected number of images. The update-licenses.py script counts operator images (typically 2) plus extracted images.
-
-**Problem**: Images not found in correct order
-**Solution**: The script inserts KNative entries after Velero entries in the license file. Ensure Velero entries exist as landmarks.
-
-### Common Issues
-
-**Problem**: Virtual environment not activated
-**Solution**:
-```bash
-# Activate the virtual environment
-source venv/bin/activate
-```
-
-**Problem**: Missing dependencies
-**Solution**: Install the required dependencies:
-```bash
-pip install requests pyyaml
-```
-
-**Problem**: Invalid KNative version
-**Error**: `applications/knative/1.99.0/extra-images.txt not found`
-**Solution**: Check available versions at: https://github.com/knative/operator/releases
-
-**Problem**: Network issues fetching manifests
-**Error**: `Error fetching https://api.github.com/repos/knative/operator/contents/...`
-**Solution**:
-- Check internet connectivity
-- Verify GitHub API access
-
-**Problem**: File not found errors
-**Solution**: Run scripts from the repository root directory, not from the hack/knative/ directory.
-
-**Problem**: License validation failures
-**Solution**:
-```bash
-# Run license validation to check for issues
-make validate-licenses
-```
-
-### Debug Information:
-
-Both scripts provide verbose output showing:
-- Files being processed
-- Images being extracted/updated
-- Success/failure counts
-- Final statistics
-
----
-
-## Development Notes
-
-### Script Architecture:
-- **Simplified design**: Clean replacement strategy eliminates complex update logic
-- **Error handling**: Graceful failure with informative messages
-- **Validation**: Multiple layers of image reference validation
-- **Logging**: Detailed progress reporting with counts and statistics
-- **Source of truth**: Uses extra-images.txt as definitive image list
-
-### Key Principles:
-- **No deduplication**: Processes exactly what's in extra-images.txt
-- **Clean replacement**: Remove all, then add all (no selective updates)
-- **Version consistency**: All images use same version reference format
-- **Predictable output**: Same input always produces same result
-
-### Maintenance:
-- Scripts are version-agnostic and should work with future KNative releases
-- GitHub API integration uses public endpoints (no authentication required)
-- Regular expression patterns may need updates if KNative changes manifest structure
-
-### Testing:
-```bash
-# Test with known good version
-python3 hack/knative/extract-images.py 1.18.1
-python3 hack/knative/update-licenses.py 1.18.1
-
-# Verify no errors and check counts
-echo $?  # Should return 0
-
-# Expected: 28 images in extra-images.txt + 2 operator images = 30 total
-grep -c "gcr.io/knative-releases/" licenses.d2iq.yaml  # Should show 30
-
-# Verify all images from extra-images.txt are included
-wc -l applications/knative/1.18.1/extra-images.txt  # Should show 28
-```
-
-### Version Update Testing:
-```bash
-# Test version updating (1.18.1 → 1.19.0)
-python3 hack/knative/update-licenses.py 1.19.0
-
-# Verify version refs updated
-grep -c "knative-v1.19.0" licenses.d2iq.yaml  # Should show 28
-grep -c "knative-\${image_tag}" licenses.d2iq.yaml  # Should show 2 (operators)
-```
+**License validation failures**
+- Run `make validate-licenses` to check for issues

--- a/hack/knative/extract-images.py
+++ b/hack/knative/extract-images.py
@@ -53,7 +53,7 @@ def run_curl(url):
         return None
 
 
-def reverse_lookup_tag_from_digest(image_ref):
+def reverse_lookup_tag_from_digest(image_ref, default_tag=None):
     """Reverse lookup to find the actual tag for a digest-based image reference."""
     if '@sha256:' not in image_ref:
         return image_ref  # Already a tagged image
@@ -82,12 +82,18 @@ def reverse_lookup_tag_from_digest(image_ref):
         content = run_curl(api_url)
         if not content:
             print(f"    Warning: Could not fetch tags for {repo_path}")
+            if default_tag:
+                print(f"    Using default tag: v{default_tag}")
+                return f"{base_image}:v{default_tag}"
             return image_ref
 
         try:
             tags_data = json.loads(content)
             if 'manifest' not in tags_data:
                 print(f"    Warning: No manifest data found for {repo_path}")
+                if default_tag:
+                    print(f"    Using default tag: v{default_tag}")
+                    return f"{base_image}:v{default_tag}"
                 return image_ref
 
             # Check if our digest exists in the manifest mapping
@@ -106,20 +112,33 @@ def reverse_lookup_tag_from_digest(image_ref):
                     return f"{base_image}:{tag}"
 
             print(f"    Warning: No matching tag found for digest {digest[:12]}...")
+            if default_tag:
+                print(f"    Using default tag: v{default_tag}")
+                return f"{base_image}:v{default_tag}"
             return image_ref
 
         except json.JSONDecodeError as e:
             print(f"    Warning: Error parsing tags response for {repo_path}: {e}")
+            if default_tag:
+                print(f"    Using default tag: v{default_tag}")
+                return f"{base_image}:v{default_tag}"
             return image_ref
 
     except Exception as e:
         print(f"    Warning: Error in reverse lookup for {image_ref}: {e}")
+        if default_tag:
+            print(f"    Using default tag: v{default_tag}")
+            # Parse the base image from the original reference
+            base_image = image_ref.split('@sha256:')[0]
+            return f"{base_image}:v{default_tag}"
         return image_ref
 
-def extract_images_from_yaml(yaml_content):
-    """Extract Docker image references from YAML content and do reverse lookup for actual tags."""
+def extract_images_from_yaml(yaml_content, component_name, default_version=None):
+    """Extract Docker image references from YAML content with component context and container/job mapping."""
     images = set()
     env_var_images = {}  # {env_var_name: image_reference}
+    component_images = {}  # {image: {"component": "serving/eventing", "container_context": "deployment/container or job/container"}}
+    env_only_images = set()  # Track images that only appear as environment variables
 
     # Pattern 1: Standard image references
     image_pattern = r'^\s*image:\s*["\']?([^"\'\s#]+)["\']?\s*(?:#.*)?$'
@@ -135,118 +154,228 @@ def extract_images_from_yaml(yaml_content):
     for env_name, image_ref in env_matches:
         if is_valid_docker_image(image_ref):
             # Do reverse lookup to find actual tag
-            actual_image = reverse_lookup_tag_from_digest(image_ref)
+            actual_image = reverse_lookup_tag_from_digest(image_ref, default_version)
             env_var_images[env_name] = actual_image
+            env_only_images.add(actual_image)  # Track as env-only initially
+            # Add to images set but do NOT add to component_images since it's env-only
+            images.add(actual_image)
             print(f"    Found env var image: {env_name} -> {actual_image}")
 
-    for line in yaml_content.split('\n'):
-        # Check for standard image references
-        match = re.match(image_pattern, line)
-        if match:
-            image = match.group(1)
-            if is_valid_docker_image(image):
-                # Do reverse lookup to find actual tag
-                actual_image = reverse_lookup_tag_from_digest(image)
-                images.add(actual_image)
+    # Split YAML content by document separators to handle multiple manifests
+    # Handle both single and consecutive document separators
+    yaml_documents = re.split(r'\n---+\n', yaml_content)
+    
+    for doc_index, yaml_doc in enumerate(yaml_documents):
+        if not yaml_doc.strip():
+            continue
+            
+        # Extract deployment/job context from each YAML document
+        lines = yaml_doc.split('\n')
+        current_context = {"kind": None, "metadata_name": None, "generate_name": None, "container_name": None}
+        
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            
+            # Track current resource context
+            if line.startswith('kind:'):
+                current_context["kind"] = line.split(':', 1)[1].strip()
+            elif line.strip().startswith('name:') and current_context["kind"]:
+                # Only capture metadata name, not container names
+                indent = len(line) - len(line.lstrip())
+                if indent <= 4:  # Top-level metadata (allowing for some indentation)
+                    current_context["metadata_name"] = line.split(':', 1)[1].strip()
+            elif line.strip().startswith('generateName:') and current_context["kind"]:
+                # Capture generateName for jobs
+                indent = len(line) - len(line.lstrip())
+                if indent <= 4:  # Top-level metadata
+                    current_context["generate_name"] = line.split(':', 1)[1].strip()
+            elif line.strip().startswith('- name:') and 'containers:' in yaml_doc[max(0, yaml_doc.find(line) - 200):yaml_doc.find(line)]:
+                # Container name in containers section
+                current_context["container_name"] = line.split(':', 1)[1].strip()
 
-        # Check for digest patterns
-        sha256_matches = re.findall(sha256_pattern, line)
-        for match in sha256_matches:
-            if is_valid_docker_image(match):
-                # Do reverse lookup to find actual tag
-                actual_image = reverse_lookup_tag_from_digest(match)
-                images.add(actual_image)
+            # Check for standard image references
+            match = re.match(image_pattern, line)
+            if match:
+                image = match.group(1)
+                if is_valid_docker_image(image):
+                    # Convert digest images to tagged versions, or keep tagged images as-is
+                    if '@sha256:' in image:
+                        final_image = reverse_lookup_tag_from_digest(image, default_version)
+                    else:
+                        final_image = image
+                    
+                    # Add the final image (preferring tagged versions)
+                    images.add(final_image)
+                    
+                    # Remove from env-only set since it also appears as a container image
+                    env_only_images.discard(final_image)
+                    
+                    # Generate container context for the final image
+                    container_context = generate_container_context(
+                        final_image, 
+                        current_context, 
+                        component_name
+                    )
+                    component_images[final_image] = {
+                        "component": component_name,
+                        "container_context": container_context
+                    }
 
-    return sorted(images), env_var_images
+            # Check for digest patterns
+            sha256_matches = re.findall(sha256_pattern, line)
+            for match in sha256_matches:
+                if is_valid_docker_image(match):
+                    # Convert digest to tagged version
+                    tagged_image = reverse_lookup_tag_from_digest(match, default_version)
+                    
+                    # Only add if we haven't already added this image
+                    if tagged_image not in images:
+                        images.add(tagged_image)
+                        
+                        # Remove from env-only set since it also appears as a container image
+                        env_only_images.discard(tagged_image)
+                        
+                        # Generate container context for tagged image
+                        container_context = generate_container_context(
+                            tagged_image, 
+                            current_context, 
+                            component_name
+                        )
+                        component_images[tagged_image] = {
+                            "component": component_name,
+                            "container_context": container_context
+                        }
+
+            i += 1
+
+    return sorted(images), env_var_images, component_images, env_only_images
+
+def generate_container_context(image, current_context, component_name):
+    """Generate the container context (deployment/container or job/container) for registry overrides."""
+    # Extract image path for analysis
+    if 'gcr.io/knative-releases/' in image:
+        image_path = image.replace('gcr.io/knative-releases/', '').split(':')[0]
+    else:
+        image_path = image.split(':')[0]
+
+    # Handle storage version migration and cleanup jobs specially
+    if 'storageversion' in image_path or 'cleanup' in image_path:
+        if current_context.get("kind") == "Job":
+            metadata_name = current_context.get("metadata_name", "") or ""
+            generate_name = current_context.get("generate_name", "") or ""
+            container_name = current_context.get("container_name", "") or ""
+            
+            # Use generateName if available, otherwise fall back to metadata_name
+            job_name_base = generate_name if generate_name else metadata_name
+            
+            print(f"      Processing job: kind={current_context.get('kind')}, name={metadata_name}, generateName={generate_name}, container={container_name}")
+            print(f"      Job name base: {job_name_base}")
+            print(f"      Image path: {image_path}")
+            
+            # Generate proper job-based override key based on generateName pattern
+            if job_name_base:
+                if "storage-version-migration-serving-" in job_name_base:
+                    return f"storage-version-migration-serving-/{container_name}"
+                elif "cleanup-serving-" in job_name_base:
+                    return f"cleanup-serving-/{container_name}"
+                elif "storage-version-migration-eventing-" in job_name_base:
+                    return f"storage-version-migration-eventing-/{container_name}"
+                elif "cleanup-eventing-" in job_name_base:
+                    return f"cleanup-eventing-/{container_name}"
+                elif "serving" in job_name_base:
+                    if "cleanup" in image_path:
+                        return f"cleanup-serving-/{container_name}"
+                    else:
+                        return f"storage-version-migration-serving-/{container_name}"
+                elif "eventing" in job_name_base:
+                    if "cleanup" in image_path:
+                        return f"cleanup-eventing-/{container_name}"
+                    else:
+                        return f"storage-version-migration-eventing-/{container_name}"
+            
+            # Fallback based on component and image path
+            if component_name == "knative-serving":
+                if "cleanup" in image_path:
+                    return "cleanup-serving-/cleanup"
+                else:
+                    return "storage-version-migration-serving-/migrate"
+            else:  # knative-eventing
+                if "cleanup" in image_path:
+                    return "cleanup-eventing-/cleanup"
+                else:
+                    return "storage-version-migration-eventing-/migrate"
+
+    # Handle standard deployments
+    deployment_name = current_context.get("metadata_name", "") or ""
+    container_name = current_context.get("container_name", "") or ""
+    
+    if deployment_name and container_name:
+        return f"{deployment_name}/{container_name}"
+    
+    # Fallback to image-based mapping for known patterns
+    return generate_fallback_context(image_path, component_name)
+
+def generate_fallback_context(image_path, component_name):
+    """Generate fallback container context based on image path analysis."""
+    # Extract last component for unknown images
+    image_name = image_path.split('/')[-1] if '/' in image_path else image_path
+    return f"{image_name}/{image_name}"
 
 
-def generate_registry_overrides(all_images, all_env_var_images, eventing_version, serving_version):
-    """Generate registry override configuration for cm.yaml."""
+def generate_registry_overrides(all_images, all_env_var_images, all_component_images, all_env_only_images, eventing_version, serving_version):
+    """Generate registry override configuration for cm.yaml using component context."""
     serving_overrides = []
     eventing_overrides = []
+    
+    # Track override keys to avoid duplicates
+    serving_keys = set()
+    eventing_keys = set()
 
-    # Mapping from image paths to deployment/container names
-    # Based on KNative operator deployment structure
-    serving_image_mappings = {
-        'knative.dev/serving/cmd/activator': 'activator/activator',
-        'knative.dev/serving/cmd/autoscaler': 'autoscaler/autoscaler',
-        'knative.dev/serving/cmd/autoscaler-hpa': 'autoscaler-hpa/autoscaler-hpa',
-        'knative.dev/serving/cmd/controller': 'controller/controller',
-        'knative.dev/serving/cmd/webhook': 'webhook/webhook',
-        'knative.dev/serving/cmd/queue': 'queue-proxy/queue-proxy',
-        'knative.dev/serving/pkg/cleanup/cmd/cleanup': 'storage-version-migration/migrate',
-        'knative.dev/pkg/apiextensions/storageversion/cmd/migrate': 'storage-version-migration/migrate',
-    }
-
-    eventing_image_mappings = {
-        'knative.dev/eventing/cmd/controller': 'eventing-controller/eventing-controller',
-        'knative.dev/eventing/cmd/webhook': 'eventing-webhook/eventing-webhook',
-        'knative.dev/eventing/cmd/apiserver_receive_adapter': 'apiserver-source-adapter/apiserver-source-adapter',
-        'knative.dev/eventing/cmd/jobsink': 'job-sink/job-sink',
-        'knative.dev/eventing/cmd/mtping': 'mt-ping/mt-ping',
-        'knative.dev/eventing/cmd/in_memory/channel_controller': 'imc-controller/controller',
-        'knative.dev/eventing/cmd/in_memory/channel_dispatcher': 'imc-dispatcher/dispatcher',
-        'knative.dev/eventing/cmd/broker/filter': 'mt-broker-filter/filter',
-        'knative.dev/eventing/cmd/broker/ingress': 'mt-broker-ingress/ingress',
-        'knative.dev/eventing/cmd/mtchannel_broker': 'mt-broker-controller/mt-broker-controller',
-        # Standalone source images - these use their simple names
-        'aws-ddb-streams-source': 'aws-ddb-streams-source/aws-ddb-streams-source',
-        'aws-s3-sink': 'aws-s3-sink/aws-s3-sink',
-        'aws-s3-source': 'aws-s3-source/aws-s3-source',
-        'aws-sns-sink': 'aws-sns-sink/aws-sns-sink',
-        'aws-sqs-sink': 'aws-sqs-sink/aws-sqs-sink',
-        'aws-sqs-source': 'aws-sqs-source/aws-sqs-source',
-        'log-sink': 'log-sink/log-sink',
-        'timer-source': 'timer-source/timer-source',
-        'transform-jsonata': 'transform-jsonata/transform-jsonata',
-    }
-
-    # Process regular images
+    # Process regular images using component context
     for image in sorted(all_images):
-        if '@sha256:' in image:
-            continue  # Skip digest-based images that weren't converted
+        if image not in all_component_images:
+            continue  # Skip images without component context
+            
+        # Skip images that only appear as environment variables
+        if image in all_env_only_images:
+            continue  # This image should only be processed as an environment variable
 
-        # Extract the image path after gcr.io/knative-releases/
-        if 'gcr.io/knative-releases/' not in image:
-            continue
+        component_info = all_component_images[image]
+        component = component_info["component"]
+        container_context = component_info["container_context"]
+        
+        # Use the converted tagged image if available, otherwise use the original
+        display_image = image
+        
+        # Special case for queue-proxy: use just "queue-proxy" instead of "queue-proxy/queue-proxy" or "queue/queue"
+        if 'queue' in image and (container_context == "queue-proxy/queue-proxy" or container_context == "queue/queue"):
+            container_context = "queue-proxy"
+        
+        # Create override entry
+        override_entry = f"              {container_context}: {display_image}"
 
-        image_path = image.replace('gcr.io/knative-releases/', '')
+        if component == "knative-serving":
+            if container_context not in serving_keys:
+                serving_overrides.append(override_entry)
+                serving_keys.add(container_context)
+        elif component == "knative-eventing":
+            if container_context not in eventing_keys:
+                eventing_overrides.append(override_entry)
+                eventing_keys.add(container_context)
 
-        # Split into path and tag
-        if ':' in image_path:
-            path, tag = image_path.rsplit(':', 1)
-        else:
-            continue
-
-        # Look up the deployment/container name mapping
-        deployment_container = None
-        if path in serving_image_mappings:
-            deployment_container = serving_image_mappings[path]
-            serving_overrides.append(f"              {deployment_container}: {image}")
-        elif path in eventing_image_mappings:
-            deployment_container = eventing_image_mappings[path]
-            eventing_overrides.append(f"              {deployment_container}: {image}")
-        else:
-            # For unknown images, try to extract the last component as both deployment and container
-            image_name = path.split('/')[-1] if '/' in path else path
-            deployment_container = f"{image_name}/{image_name}"
-            # Determine if it's serving or eventing based on the path
-            if 'knative.dev/serving' in path or 'knative.dev/pkg' in path:
-                serving_overrides.append(f"              {deployment_container}: {image}")
-            else:
-                eventing_overrides.append(f"              {deployment_container}: {image}")
-
-    # Process environment variable images (they keep the env var name as the key)
+    # Process environment variable images
     for env_name, image in sorted(all_env_var_images.items()):
-        if '@sha256:' in image:
-            continue  # Skip digest-based images that weren't converted
-
         # Environment variable images use the env var name as the key
-        # Most env var images are eventing-related, but we can determine by the image path
-        if 'knative.dev/serving' in image or 'knative.dev/pkg' in image:
-            serving_overrides.append(f"              {env_name}: {image}")
+        # Determine component based on image path
+        if 'knative.dev/serving' in image or ('knative.dev/pkg' in image and 'serving' in env_name.lower()):
+            if env_name not in serving_keys:
+                serving_overrides.append(f"              {env_name}: {image}")
+                serving_keys.add(env_name)
         else:
-            eventing_overrides.append(f"              {env_name}: {image}")
+            if env_name not in eventing_keys:
+                eventing_overrides.append(f"              {env_name}: {image}")
+                eventing_keys.add(env_name)
 
     print("\n" + "="*70)
     print("REGISTRY OVERRIDE CONFIGURATION")
@@ -400,26 +529,42 @@ def get_yaml_files_from_github_dir(repo_path, version):
         print(f"Error parsing JSON from {api_url}: {e}")
         return []
 
-def download_and_extract_images(files, component_name):
-    """Download YAML files and extract images."""
+def download_and_extract_images(files, component_name, default_version=None):
+    """Download YAML files and extract images with component context."""
     all_images = set()
     all_env_var_images = {}
+    all_component_images = {}
+    all_env_only_images = set()
 
     print(f"\nProcessing {component_name} manifests...")
 
     for file_info in files:
         print(f"  Processing: {file_info['name']}")
+        
+        # Special debug for post-install jobs
+        if "post-install" in file_info['name']:
+            print(f"    DEBUG: Found post-install file: {file_info['name']}")
 
         yaml_content = run_curl(file_info['download_url'])
         if yaml_content:
-            images, env_var_images = extract_images_from_yaml(yaml_content)
+            # Special debug for post-install jobs content
+            if "post-install" in file_info['name']:
+                print(f"    DEBUG: YAML content length: {len(yaml_content)}")
+                yaml_documents = re.split(r'\n---+\n', yaml_content)
+                print(f"    DEBUG: Found {len(yaml_documents)} documents")
+                
+            images, env_var_images, component_images, env_only_images = extract_images_from_yaml(yaml_content, component_name, default_version)
             all_images.update(images)
             all_env_var_images.update(env_var_images)
+            all_component_images.update(component_images)
+            all_env_only_images.update(env_only_images)
 
             if images:
                 print(f"    Found {len(images)} images")
                 for img in images:
-                    print(f"      {img}")
+                    context_info = component_images.get(img, {})
+                    container_context = context_info.get("container_context", "unknown")
+                    print(f"      {img} -> {container_context}")
 
             if env_var_images:
                 print(f"    Found {len(env_var_images)} env var images")
@@ -428,7 +573,7 @@ def download_and_extract_images(files, component_name):
         else:
             print(f"    Error downloading {file_info['name']}")
 
-    return all_images, all_env_var_images
+    return all_images, all_env_var_images, all_component_images, all_env_only_images
 
 def main():
     parser = argparse.ArgumentParser(description='Extract Docker images from KNative operator manifests')
@@ -449,15 +594,19 @@ def main():
 
     all_images = set()
     all_env_var_images = {}
+    all_component_images = {}
+    all_env_only_images = set()
 
     # Process knative-eventing
     print("Fetching knative-eventing file list...")
     eventing_files = get_yaml_files_from_github_dir("knative-eventing", eventing_version)
     if eventing_files:
         print(f"Found {len(eventing_files)} eventing files")
-        eventing_images, eventing_env_vars = download_and_extract_images(eventing_files, "knative-eventing")
+        eventing_images, eventing_env_vars, eventing_component_images, eventing_env_only = download_and_extract_images(eventing_files, "knative-eventing", eventing_version)
         all_images.update(eventing_images)
         all_env_var_images.update(eventing_env_vars)
+        all_component_images.update(eventing_component_images)
+        all_env_only_images.update(eventing_env_only)
     else:
         print("No knative-eventing files found")
 
@@ -466,9 +615,11 @@ def main():
     serving_files = get_yaml_files_from_github_dir("knative-serving", serving_version)
     if serving_files:
         print(f"Found {len(serving_files)} serving files")
-        serving_images, serving_env_vars = download_and_extract_images(serving_files, "knative-serving")
+        serving_images, serving_env_vars, serving_component_images, serving_env_only = download_and_extract_images(serving_files, "knative-serving", serving_version)
         all_images.update(serving_images)
         all_env_var_images.update(serving_env_vars)
+        all_component_images.update(serving_component_images)
+        all_env_only_images.update(serving_env_only)
     else:
         print("No knative-serving files found")
 
@@ -485,7 +636,7 @@ def main():
             f.write(f"{image}\n")
 
     # Generate registry overrides configuration
-    serving_overrides, eventing_overrides = generate_registry_overrides(all_images, all_env_var_images, eventing_version, serving_version)
+    serving_overrides, eventing_overrides = generate_registry_overrides(all_images, all_env_var_images, all_component_images, all_env_only_images, eventing_version, serving_version)
 
     # Optionally update cm.yaml automatically
     try:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -350,7 +350,7 @@ resources:
       - license_path: LICENSE
         ref: knative-v1.18.1
         url: https://github.com/knative/eventing
-  - container_image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate:v1.18.0
+  - container_image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate:v1.18.1
     sources:
       - license_path: LICENSE
         ref: release-1.18


### PR DESCRIPTION
**What problem does this PR solve?**:

Update images for Knative

- Updated the images that are found in ENV variables and are defined in values.yaml configmaps as data string.
- Update the `queue-proxy` image. The cache image and has a [specific override](https://github.com/knative/operator/blob/8954073cb2affffdb82041c1c2e805c34119ebc5/pkg/reconciler/common/images.go#L148) that is based on name.
- Update script and readme.

**Which issue(s) does this PR fix?**:

https://jira.nutanix.com/browse/NCN-109043

**Special notes for your reviewer**:

Tested deployment on a local cluster - validated tags for the images that are deployed.


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
