### PR TITLE
fix: remove grafana cpu limit & use recommended memory for limit

### DIFF
--- a/applications/centralized-grafana/75.16.1/defaults/cm.yaml
+++ b/applications/centralized-grafana/75.16.1/defaults/cm.yaml
@@ -102,7 +102,6 @@ data:
         port: 80
       resources:
         limits:
-          cpu: 2000m
           memory: 10922Mi
         requests:
           cpu: 200m

--- a/applications/grafana-logging/9.3.1/defaults/cm.yaml
+++ b/applications/grafana-logging/9.3.1/defaults/cm.yaml
@@ -68,13 +68,11 @@ data:
         servicemonitor.kommander.mesosphere.io/path: "dkp__logging__grafana__metrics"
 
     resources:
-      # keep request = limit to keep this container in guaranteed class
       limits:
-        cpu: 300m
-        memory: 200Mi
+        memory: 512Mi
       requests:
         cpu: 200m
-        memory: 200Mi
+        memory: 256Mi
 
     readinessProbe:
       httpGet:

--- a/applications/kube-prometheus-stack/75.16.1/defaults/cm.yaml
+++ b/applications/kube-prometheus-stack/75.16.1/defaults/cm.yaml
@@ -489,11 +489,10 @@ data:
           searchNamespace: ALL
         resources:
           limits:
-            cpu: 150m
-            memory: 100Mi
+            memory: 512Mi
           requests:
-            cpu: 150m
-            memory: 100Mi
+            cpu: 200m
+            memory: 256Mi
       grafana.ini:
         log:
           level: warn

--- a/applications/project-grafana-logging/9.3.1/defaults/cm.yaml
+++ b/applications/project-grafana-logging/9.3.1/defaults/cm.yaml
@@ -68,13 +68,11 @@ data:
         servicemonitor.kommander.mesosphere.io/path: "dkp__logging__grafana__metrics"
 
     resources:
-      # keep request = limit to keep this container in guaranteed class
       limits:
-        cpu: 300m
-        memory: 200Mi
+        memory: 512Mi
       requests:
         cpu: 200m
-        memory: 200Mi
+        memory: 256Mi
 
     readinessProbe:
       httpGet:


### PR DESCRIPTION
**What problem does this PR solve?**:
Grafana ran into OOMKilled couple time with the default memory setting, turns out grafana minimum requirement is 512M memory and 1 cpu core.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-109257

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
