### PR TITLE
fix(grafana): Disable preinstalled plugins (#3874)

### DIFF
--- a/services/centralized-grafana/70.4.2/defaults/cm.yaml
+++ b/services/centralized-grafana/70.4.2/defaults/cm.yaml
@@ -74,7 +74,7 @@ data:
         users:
           auto_assign_org_role: Admin
         plugins:
-          allow_loading_unsigned_plugins: "grafana-piechart-panel"
+          preinstall_disabled: true
         dashboards:
           default_home_dashboard_path: "/tmp/dashboards/global-overview.json"
         analytics:

--- a/services/grafana-logging/8.11.0/defaults/cm.yaml
+++ b/services/grafana-logging/8.11.0/defaults/cm.yaml
@@ -54,7 +54,7 @@ data:
       users:
         auto_assign_org_role: Admin
       plugins:
-        allow_loading_unsigned_plugins: "grafana-piechart-panel"
+        preinstall_disabled: true
       analytics:
         reporting_enabled: false
         check_for_updates: false

--- a/services/kube-prometheus-stack/70.4.2/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/70.4.2/defaults/cm.yaml
@@ -389,7 +389,7 @@ data:
         users:
           auto_assign_org_role: Admin
         plugins:
-          allow_loading_unsigned_plugins: "grafana-piechart-panel"
+          preinstall_disabled: true
         dashboards:
           default_home_dashboard_path: "/tmp/dashboards/k8s-resources-cluster.json"
         analytics:

--- a/services/project-grafana-logging/8.11.0/defaults/cm.yaml
+++ b/services/project-grafana-logging/8.11.0/defaults/cm.yaml
@@ -55,7 +55,7 @@ data:
       users:
         auto_assign_org_role: Admin
       plugins:
-        allow_loading_unsigned_plugins: "grafana-piechart-panel"
+        preinstall_disabled: true
       analytics:
         reporting_enabled: false
         check_for_updates: false


### PR DESCRIPTION
fix(grafana): Disablle preinstalled plugins

**What problem does this PR solve?**:
backports https://github.com/mesosphere/kommander-applications/pull/3874

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-108951

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
