### PR TITLE
fix(grafana): Avoid downloading plugin updates

### DIFF
--- a/applications/centralized-grafana/75.16.1/defaults/cm.yaml
+++ b/applications/centralized-grafana/75.16.1/defaults/cm.yaml
@@ -87,6 +87,7 @@ data:
         analytics:
           reporting_enabled: false
           check_for_updates: false
+          check_for_plugin_updates: false
 
       datasources:
         datasources.yaml:

--- a/applications/grafana-logging/9.3.1/defaults/cm.yaml
+++ b/applications/grafana-logging/9.3.1/defaults/cm.yaml
@@ -67,6 +67,7 @@ data:
       analytics:
         reporting_enabled: false
         check_for_updates: false
+        check_for_plugin_updates: false
 
     service:
       type: ClusterIP

--- a/applications/kube-prometheus-stack/75.16.1/defaults/cm.yaml
+++ b/applications/kube-prometheus-stack/75.16.1/defaults/cm.yaml
@@ -517,6 +517,7 @@ data:
         analytics:
           reporting_enabled: false
           check_for_updates: false
+          check_for_plugin_updates: false
 
       service:
         type: ClusterIP

--- a/applications/project-grafana-logging/9.3.1/defaults/cm.yaml
+++ b/applications/project-grafana-logging/9.3.1/defaults/cm.yaml
@@ -66,6 +66,7 @@ data:
       analytics:
         reporting_enabled: false
         check_for_updates: false
+        check_for_plugin_updates: false
 
     service:
       type: ClusterIP


### PR DESCRIPTION
**What problem does this PR solve?**:
Attempting to download plugin updates from the internet was causing errors in grafana pods on airgapped clusters.
```
logger=plugin.angulardetectorsprovider.dynamic t=2025-08-21T22:36:47.819844151Z level=error msg="Error while updating detectors" error="fetch: http do: Get \"https://grafana.com/api/plugins/angular_patterns\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-109351

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
