### PR TITLE
fix: re-revert git-operator manifests

### DIFF
--- a/services/git-operator/0.1.4/additional-images.txt
+++ b/services/git-operator/0.1.4/additional-images.txt
@@ -1,0 +1,1 @@
+docker.io/bitnamilegacy/kubectl:1.32.3

--- a/services/git-operator/0.1.4/additional-images.txt
+++ b/services/git-operator/0.1.4/additional-images.txt
@@ -1,1 +1,0 @@
-docker.io/bitnamilegacy/kubectl:1.32.3

--- a/services/git-operator/0.1.4/git-operator-manifests/all.yaml
+++ b/services/git-operator/0.1.4/git-operator-manifests/all.yaml
@@ -1140,7 +1140,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: bitnami/kubectl:1.32.3
+            image: bitnamilegacy/kubectl:1.32.3
             name: admin-credentials-rotate
           priorityClassName: system-cluster-critical
           restartPolicy: OnFailure


### PR DESCRIPTION
**What problem does this PR solve?**:
Git Operator Admin Creds Rotate Job uses the bitnami/kubectl image
It should use bitnamilegacy/kubectl 

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-109366

**Special notes for your reviewer**:
This change was failing some test earlier, is it safe to ignore this test? Can we just check to see if this can fix the issue without publishing a new git operator image altogether?

**Does this PR introduce a user-facing change?**:
N/A

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
