### PR TITLE
fix(git-operator): Override image  using kustomization overlay

### DIFF
--- a/hack/list-images.sh
+++ b/hack/list-images.sh
@@ -190,7 +190,7 @@ done
                                   (select(.containers != null) | .containers[].image), (select(.initContainers != null) | .initContainers[].image)' \
   				./services/git-operator/*/git-operator-manifests/* \
   # we patch the cronjob image in this kustomization
-  gojq --yaml-input --raw-output 'select(.kind | test("^(?:Kustomization)$")) | .images | map("\(.name):\(.newTag)") | .[]' \
+  gojq --yaml-input --raw-output 'select(.kind | test("^(?:Kustomization)$")) | .images | map("\(.newName):\(.newTag)") | .[]' \
           ./services/git-operator/*/kustomization.yaml
 } >>"${IMAGES_FILE}"
 

--- a/services/git-operator/0.1.4/kustomization.yaml
+++ b/services/git-operator/0.1.4/kustomization.yaml
@@ -26,5 +26,6 @@ patches:
     kind: Certificate
     name: git-operator-git-webserver
 images:
-  - name: bitnamilegacy/kubectl
+  - name: bitnami/kubectl
+    newName: bitnamilegacy/kubectl
     newTag: 1.32.3


### PR DESCRIPTION
**What problem does this PR solve?**:
Can update existing kustomization overlay to specify `newName` which will replace `bitnami` images with `bitnamilegacy`

```
kustomize build services/git-operator/0.1.4 | grep -C1 bitnami
                  fieldPath: metadata.namespace
            image: bitnamilegacy/kubectl:1.32.3
            name: admin-credentials-rotate
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
