### PR TITLE
fix: Replace bitnami with bitnamilegacy (2.12) (#3941)

### DIFF
--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -25,8 +25,8 @@ additional_crds:
   - https://raw.githubusercontent.com/istio/istio/1.9.1/manifests/charts/base/crds/crd-all.gen.yaml
   # TODO: verify this is not masking real problem in https://d2iq.atlassian.net/browse/D2IQ-99126
   - https://raw.githubusercontent.com/kubernetes-retired/kubefed/master/charts/kubefed/crds/crds.yaml
-  - https://raw.githubusercontent.com/cert-manager/cert-manager/master/deploy/crds/crd-certificates.yaml
-  - https://raw.githubusercontent.com/cert-manager/cert-manager/master/deploy/crds/crd-issuers.yaml
+  - https://raw.githubusercontent.com/cert-manager/cert-manager/refs/heads/master/deploy/crds/cert-manager.io_certificates.yaml
+  - https://raw.githubusercontent.com/cert-manager/cert-manager/refs/heads/master/deploy/crds/cert-manager.io_issuers.yaml
   - https://raw.githubusercontent.com/rook/rook/master/deploy/olm/assemble/objectbucket.io_objectbucketclaims.yaml
 
 # set values for substitution variables (e.g. ${releaseNamespace}) in the resources

--- a/apptests/appscenarios/contants.go
+++ b/apptests/appscenarios/contants.go
@@ -20,6 +20,6 @@ const (
 	dkpCriticalPriority           = "dkp-critical-priority"
 
 	// Velero constants
-	kubetoolsImageRepository = "bitnami/kubectl"
+	kubetoolsImageRepository = "bitnamilegacy/kubectl"
 	kubetoolsImageTag        = "1.29.6"
 )

--- a/apptests/testdata/rook-ceph/manifests/persistent-volume-creator.yaml
+++ b/apptests/testdata/rook-ceph/manifests/persistent-volume-creator.yaml
@@ -53,7 +53,7 @@ spec:
           # If we use an image that is also used in k-apps then our tooling might exclude this image from tar by assuming
           # its one of the default images of kind-airgapped tooling (like calico etc.,).
           # TODO: we can make this better
-          image: bitnami/kubectl:1.28.5
+          image: bitnamilegacy/kubectl:1.28.5
           command:
             - /bin/bash
             - -c

--- a/common/build/list-images-values.yaml
+++ b/common/build/list-images-values.yaml
@@ -1,3 +1,3 @@
 secretName: unused
 commonName: unused
-kubectlImage: bitnami/kubectl:1.29.6
+kubectlImage: bitnamilegacy/kubectl:1.29.6

--- a/devbox.lock
+++ b/devbox.lock
@@ -274,6 +274,10 @@
         }
       }
     },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2025-08-21T00:30:53Z",
+      "resolved": "github:NixOS/nixpkgs/596312aae91421d6923f18cecce934a7d3bfd6b8?lastModified=1755736253&narHash=sha256-jlIQRypNhB1PcB1BE%2BexpE4xZeJxzoAGr1iUbHQta8s%3D"
+    },
     "gitlint@latest": {
       "last_modified": "2024-06-12T20:55:33Z",
       "resolved": "github:NixOS/nixpkgs/a9858885e197f984d92d7fe64e9fff6b2e488d40#gitlint",

--- a/hack/list-images.sh
+++ b/hack/list-images.sh
@@ -128,13 +128,21 @@ done
 
 # These services use raw manifests rather than Helm charts so list the images directly from the manifests.
 # If more raw manifest services are added, then they should be added to the list of paths below.
-gojq --yaml-input --raw-output 'select(.kind | test("^(?:Deployment|Job|CronJob|StatefulSet|DaemonSet)$")) |
-                                .spec.template.spec |
-                                (select(.containers != null) | .containers[].image), (select(.initContainers != null) | .initContainers[].image)' \
-				./services/git-operator/*/git-operator-manifests/* \
-                                ./services/kommander-flux/*/templates/* \
-                                ./services/kube-prometheus-stack/*/etcd-metrics-proxy/* \
-                                >>"${IMAGES_FILE}"
+{
+  gojq --yaml-input --raw-output 'select(.kind | test("^(?:Deployment|Job|CronJob|StatefulSet|DaemonSet)$")) |
+                                  (.spec.template.spec // .spec.jobTemplate.spec.template.spec) |
+                                  (select(.containers != null) | .containers[].image), (select(.initContainers != null) | .initContainers[].image)' \
+                                  ./services/kommander-flux/*/templates/* \
+                                  ./services/kube-prometheus-stack/*/etcd-metrics-proxy/* \
+  # process git operator separately
+  gojq --yaml-input --raw-output 'select(.kind | test("^(?:Deployment|Job|StatefulSet|DaemonSet)$")) |
+                                  .spec.template.spec |
+                                  (select(.containers != null) | .containers[].image), (select(.initContainers != null) | .initContainers[].image)' \
+          ./services/git-operator/*/git-operator-manifests/* \
+  # we patch the cronjob image in this kustomization
+  gojq --yaml-input --raw-output 'select(.kind | test("^(?:Kustomization)$")) | .images | map("\(.newName):\(.newTag)") | .[]' \
+          ./services/git-operator/*/kustomization.yaml
+} >>"${IMAGES_FILE}"
 
 # Ensure that all images are fully qualified to ensure uniqueness of images in the image bundle.
 sed --expression='s|^docker.io/||' \

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -14,7 +14,7 @@ resources:
       - url: https://github.com/aquasecurity/kube-bench
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: docker.io/bitnami/thanos:0.35.1-debian-12-r1
+  - container_image: docker.io/bitnamilegacy/thanos:0.35.1-debian-12-r1
     sources:
       - license_path: LICENSE
         ref: v${image_tag%-debian-12-r1}
@@ -575,7 +575,7 @@ resources:
       - url: https://github.com/NVIDIA/cuda-samples
         ref: v12.5
         license_path: LICENSE
-  - container_image: docker.io/bitnami/kubectl:1.29.6
+  - container_image: docker.io/bitnamilegacy/kubectl:1.29.6
     sources:
       - url: https://github.com/kubernetes/kubectl
         ref: v0${image_tag#1}
@@ -583,7 +583,7 @@ resources:
   - container_image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
     sources:
       - url: https://github.com/kubernetes/ingress-nginx
-        ref:  controller-v1.5.2
+        ref: controller-v1.5.1
         license_path: LICENSE
         directory: /images/kube-webhook-certgen/rootfs
   - container_image: ghcr.io/mesosphere/dkp-container-images/docker.io/bitnami/postgres-exporter:0.12.0-debian-11-r77-d2iq.0
@@ -596,7 +596,7 @@ resources:
       - url: https://github.com/nginx/nginx
         ref: release-${image_tag%-alpine}
         license_path: docs/text/LICENSE
-  - container_image: bitnami/external-dns:0.14.2-debian-12-r7
+  - container_image: bitnamilegacy/external-dns:0.14.2-debian-12-r7
     sources:
       - url: https://github.com/kubernetes-sigs/external-dns
         ref: v${image_tag%-debian-12-r7}
@@ -626,7 +626,7 @@ resources:
       - url: https://github.com/kubernetes/kubernetes
         ref: master
         license_path: LICENSE
-  - container_image: docker.io/bitnami/postgresql:15.8.0-debian-12-r14
+  - container_image: docker.io/bitnamilegacy/postgresql:15.8.0-debian-12-r14
     sources:
       - url: https://github.com/postgres/postgres
         ref: REL_15_8

--- a/services/ai-navigator-app/0.2.8/defaults/cm.yaml
+++ b/services/ai-navigator-app/0.2.8/defaults/cm.yaml
@@ -37,6 +37,8 @@ data:
           scriptsConfigMap: ai-navigator-cluster-info-api-postgresql-initdb
       readReplicas:
         priorityClassName: dkp-high-priority
+      image:
+        repository: bitnamilegacy/postgresql
 
     # Default values for cluster-info-api
     replicaCount: 1
@@ -92,4 +94,4 @@ data:
     tolerations: []
 
     affinity: {}
-    kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}
+    kubectlImage: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.29.6}

--- a/services/centralized-kubecost/0.37.5/defaults/cm.yaml
+++ b/services/centralized-kubecost/0.37.5/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
     ---
     hooks:
       clusterID:
-        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+        kubectlImage: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.29.6}"
         priorityClassName: dkp-high-priority
 
     cost-analyzer:

--- a/services/centralized-kubecost/0.37.5/post-install-jobs/post-install-jobs.yaml
+++ b/services/centralized-kubecost/0.37.5/post-install-jobs/post-install-jobs.yaml
@@ -42,7 +42,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+          image: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.29.6}"
           command:
             - sh
             - -c

--- a/services/centralized-kubecost/0.37.5/release/release.yaml
+++ b/services/centralized-kubecost/0.37.5/release/release.yaml
@@ -73,7 +73,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+          image: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.29.6}"
           command:
             - sh
             - "-c"

--- a/services/dex/2.13.15/defaults/cm.yaml
+++ b/services/dex/2.13.15/defaults/cm.yaml
@@ -7,7 +7,7 @@ data:
   values.yaml: |-
     ---
     priorityClassName: "dkp-critical-priority"
-    kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+    kubectlImage: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.29.6}"
     image: mesosphere/dex
     imageTag: v2.41.1-d2iq.1
     resources:

--- a/services/external-dns/7.5.6/defaults/cm.yaml
+++ b/services/external-dns/7.5.6/defaults/cm.yaml
@@ -7,6 +7,7 @@ data:
   values.yaml: |-
     priorityClassName: dkp-high-priority
     image:
+      repository: bitnamilegacy/external-dns
       tag: 0.14.2-debian-12-r7
     service:
       labels:

--- a/services/git-operator/0.1.4/kustomization.yaml
+++ b/services/git-operator/0.1.4/kustomization.yaml
@@ -25,3 +25,7 @@ patches:
   target:
     kind: Certificate
     name: git-operator-git-webserver
+images:
+  - name: bitnami/kubectl
+    newName: bitnamilegacy/kubectl
+    newTag: 1.29.6

--- a/services/grafana-loki/0.79.4/grafana-loki-pre-install-jobs/pre-install.yaml
+++ b/services/grafana-loki/0.79.4/grafana-loki-pre-install-jobs/pre-install.yaml
@@ -46,7 +46,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: pre-install
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+          image: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.29.6}"
           command:
             - sh
             - -c

--- a/services/istio/1.22.3/defaults/cm.yaml
+++ b/services/istio/1.22.3/defaults/cm.yaml
@@ -29,7 +29,7 @@ data:
         labels:
           prometheus.kommander.d2iq.io/select: "true"
     global:
-      image: ${kubetoolsImageRepository:=bitnami/kubectl}
+      image: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}
       tag: ${kubetoolsImageTag:=1.29.6}
       priorityClassName: "dkp-critical-priority"
     operator:

--- a/services/knative/1.10.5/defaults/cm.yaml
+++ b/services/knative/1.10.5/defaults/cm.yaml
@@ -7,7 +7,7 @@ data:
   values.yaml: |
     global:
       priorityClassName: "dkp-high-priority"
-      image: ${kubetoolsImageRepository:=bitnami/kubectl}
+      image: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}
       tag: ${kubetoolsImageTag:=1.29.6}
     eventing:
       enabled: false

--- a/services/kommander/0.12.2/dynamic-helmreleases/cluster-observer/list-images-values.yaml
+++ b/services/kommander/0.12.2/dynamic-helmreleases/cluster-observer/list-images-values.yaml
@@ -1,2 +1,2 @@
 hooks:
-  kubectlImage: "bitnami/kubectl:1.29.6"
+  kubectlImage: "bitnamilegacy/kubectl:1.29.6"

--- a/services/kube-prometheus-stack/60.4.1/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/60.4.1/defaults/cm.yaml
@@ -22,7 +22,7 @@ data:
     mesosphereResources:
       create: true
       hooks:
-        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+        kubectlImage: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.29.6}"
       rules:
         # addon alert rules are defaulted to false to prevent potential misfires if addons
         # are disabled.

--- a/services/kubecost/0.37.6/defaults/cm.yaml
+++ b/services/kubecost/0.37.6/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
     ---
     hooks:
       clusterID:
-        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+        kubectlImage: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.29.6}"
         priorityClassName: dkp-high-priority
 
     cost-analyzer:

--- a/services/kubefed/0.10.5/defaults/cm.yaml
+++ b/services/kubefed/0.10.5/defaults/cm.yaml
@@ -33,7 +33,7 @@ data:
         labels:
           servicemonitor.kommander.mesosphere.io/path: metrics
       postInstallJob:
-        repository: bitnami
+        repository: bitnamilegacy
         image: kubectl
         tag: 1.29.6
     webhook:

--- a/services/kubetunnel/0.0.36/defaults/cm.yaml
+++ b/services/kubetunnel/0.0.36/defaults/cm.yaml
@@ -16,7 +16,7 @@ data:
       selfSigned: true
     hooks:
       kubectlImage:
-        repository: "${kubetoolsImageRepository:=bitnami/kubectl}"
+        repository: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}"
         tag: "${kubetoolsImageTag:=1.29.6}"
     controller:
       manager:

--- a/services/nkp-insights-management/1.2.2/defaults/cm.yaml
+++ b/services/nkp-insights-management/1.2.2/defaults/cm.yaml
@@ -34,7 +34,7 @@ data:
     insightsCRIngress:
       globalRateLimitAverageQPS: 100
       globalRateLimitBurst: 100
-    kubectlImage: bitnami/kubectl:1.29.6
+    kubectlImage: bitnamilegacy/kubectl:1.29.6
     managementCM:
       backendTokenTTL: 1h
       insightsTTL: 72h

--- a/services/nkp-insights/1.2.2/defaults/cm.yaml
+++ b/services/nkp-insights/1.2.2/defaults/cm.yaml
@@ -429,7 +429,7 @@ data:
             cpu: 100m
             memory: 512Mi
       schedule: '@every 35m'
-    kubectlImage: bitnami/kubectl:1.29.6
+    kubectlImage: bitnamilegacy/kubectl:1.29.6
     nova:
       baseEvaluationTimeout: 1m
       enabled: true

--- a/services/project-grafana-loki/0.79.4/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.79.4/defaults/cm.yaml
@@ -27,7 +27,7 @@ data:
     ####################################################################
 
     # this is used in object-bucket-claims overrides
-    kubectlImage: bitnami/kubectl:1.29.6
+    kubectlImage: bitnamilegacy/kubectl:1.29.6
 
     loki:
       ingesterFullname: loki-ingester

--- a/services/rook-ceph-cluster/1.14.5/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.14.5/defaults/cm.yaml
@@ -244,7 +244,7 @@ data:
           memory: "100Mi"
 
     # this is used in object-bucket-claims overrides
-    kubectlImage: bitnami/kubectl:1.29.6
+    kubectlImage: bitnamilegacy/kubectl:1.29.6
 
     #################################################################
     ## BEGIN NKP specific config overrides                         ##

--- a/services/rook-ceph-cluster/1.14.5/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.14.5/pre-install/ceph-crd-check.yaml
@@ -47,7 +47,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: pre-install
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+          image: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.29.6}"
           command:
             - sh
             - -c
@@ -57,7 +57,7 @@ spec:
                 sleep 30
               done
         - name: pre-upgrade
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+          image: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.29.6}"
           command:
             - sh
             - -c

--- a/services/thanos/15.7.6/defaults/cm.yaml
+++ b/services/thanos/15.7.6/defaults/cm.yaml
@@ -6,6 +6,9 @@ metadata:
 data:
   values.yaml: |
     ---
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/thanos
     storegateway:
       enabled: false
     compactor:

--- a/services/thanos/15.7.6/jobs/jobs.yaml
+++ b/services/thanos/15.7.6/jobs/jobs.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+          image: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.29.6}"
           command:
             - sh
             - "-c"

--- a/services/traefik/27.0.2/defaults/cm.yaml
+++ b/services/traefik/27.0.2/defaults/cm.yaml
@@ -39,7 +39,7 @@ data:
         app: traefik
       initContainers:
       - name: initialize-middleware
-        image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.29.6}"
+        image: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.29.6}"
         command:
           - bash
         args:

--- a/services/velero/6.6.0/defaults/cm.yaml
+++ b/services/velero/6.6.0/defaults/cm.yaml
@@ -54,6 +54,7 @@ data:
             name: plugins
     kubectl:
       image:
+        repository: docker.io/bitnamilegacy/kubectl
         # If we don't override the version here, upstream chart will pull an image dynamically based on k8s cluster version.
         # which makes it harder to build airgapped tar bundles. So to make bundle collection predictable, we override the tag here.
         tag: "${kubetoolsImageTag:=1.29.6}"

--- a/services/velero/6.6.0/velero-pre-install.yaml
+++ b/services/velero/6.6.0/velero-pre-install.yaml
@@ -18,5 +18,5 @@ spec:
   postBuild:
     substitute:
       releaseNamespace: ${releaseNamespace}
-      kubetoolsImageRepository: ${kubetoolsImageRepository:=bitnami/kubectl}
+      kubetoolsImageRepository: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}
       kubetoolsImageTag: ${kubetoolsImageTag:=1.29.6}


### PR DESCRIPTION
* fix: Replace bitnami with bitnamilegacy

* fix: override ainav/external-dns images

* fix: override thanos image

* fix: override velero kubectl image

* fix: Update cert-manager crds url

* fix: Fix ingress-nginx release tag

* build: devbox diff

**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
