### PR TITLE
feat: Add version validation for KNative components in extract-images.py

### DIFF
--- a/hack/knative/README.md
+++ b/hack/knative/README.md
@@ -25,7 +25,7 @@ python3 hack/knative/extract-images.py --eventing-version <version> --serving-ve
 ### Options
 
 - `--eventing-version` (required): KNative eventing version (e.g., 1.18.1)
-- `--serving-version` (required): KNative serving version (e.g., 1.18.1)  
+- `--serving-version` (required): KNative serving version (e.g., 1.18.1)
 - `--k-apps-version` (optional): Output directory version (defaults to serving version)
 
 ### Version Management

--- a/hack/knative/extract-images.py
+++ b/hack/knative/extract-images.py
@@ -587,11 +587,11 @@ def update_cm_yaml(k_apps_version, serving_overrides, eventing_overrides):
 def validate_version_exists(component, version):
     """Check if a specific version exists for a component in the knative/operator repository."""
     api_url = f"https://api.github.com/repos/knative/operator/contents/cmd/operator/kodata/{component}/{version}"
-    
+
     content = run_curl(api_url)
     if not content:
         return False
-        
+
     try:
         response = json.loads(content)
         # If we get a "message" field with "Not Found", the version doesn't exist
@@ -605,11 +605,11 @@ def validate_version_exists(component, version):
 def get_available_versions(component):
     """Get list of available versions for a component."""
     api_url = f"https://api.github.com/repos/knative/operator/contents/cmd/operator/kodata/{component}"
-    
+
     content = run_curl(api_url)
     if not content:
         return []
-        
+
     try:
         folders = json.loads(content)
         versions = []
@@ -711,48 +711,48 @@ def main():
     print("Validating versions...")
     eventing_exists = validate_version_exists("knative-eventing", eventing_version)
     serving_exists = validate_version_exists("knative-serving", serving_version)
-    
+
     errors = []
     warnings = []
-    
+
     if not eventing_exists:
         available_eventing = get_available_versions("knative-eventing")
         latest_eventing = available_eventing[-1] if available_eventing else "unknown"
         errors.append(f"❌ KNative eventing version {eventing_version} does not exist!")
         errors.append(f"   Available eventing versions: {', '.join(available_eventing[-5:] if available_eventing else ['none'])}")
         errors.append(f"   Latest available: {latest_eventing}")
-        
+
     if not serving_exists:
         available_serving = get_available_versions("knative-serving")
         latest_serving = available_serving[-1] if available_serving else "unknown"
         errors.append(f"❌ KNative serving version {serving_version} does not exist!")
         errors.append(f"   Available serving versions: {', '.join(available_serving[-5:] if available_serving else ['none'])}")
         errors.append(f"   Latest available: {latest_serving}")
-    
+
     # Check for version mismatches (common issue)
     if eventing_exists and serving_exists:
         if eventing_version != serving_version:
             warnings.append(f"⚠️  Warning: Using different versions for eventing ({eventing_version}) and serving ({serving_version})")
             warnings.append(f"   This may cause compatibility issues.")
-    
+
     # Print errors and warnings
     if errors:
         print("\nVersion Validation Errors:")
         print("-" * 40)
         for error in errors:
             print(error)
-    
+
     if warnings:
         print("\nWarnings:")
         print("-" * 20)
         for warning in warnings:
             print(warning)
-    
+
     # Exit if critical errors found
     if errors:
         print(f"\n❌ Cannot proceed with invalid versions. Please fix the version parameters and try again.")
         return 1
-        
+
     if warnings:
         print(f"\n✅ Validation passed with warnings. Proceeding...\n")
     else:


### PR DESCRIPTION
**What problem does this PR solve?**:

- Implemented functions to validate the existence of specified eventing and serving versions in the knative/operator repository.
- Added error and warning messages for version mismatches and non-existent versions.
- Updated README.md to include version management instructions and examples for handling version validation.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

Related to: https://jira.nutanix.com/browse/NCN-109148


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
