### PR TITLE
ci(gha): Close/reopen PRs after license update

### DIFF
--- a/.github/workflows/validate-licenses.yaml
+++ b/.github/workflows/validate-licenses.yaml
@@ -74,9 +74,12 @@ jobs:
           if output=$(git status --porcelain) && [ ! -z "$output" ]; then
             git commit -S -v -m "build: Updated licenses.d2iq.yaml"
             git push --force-with-lease
+            gh pr close "$PR_URL"
+            gh pr reopen "$PR_URL"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
       - name: Run validation
         uses: docker://mesosphere/dkp-licenses-cli:licenses-v0.0.13
         with:


### PR DESCRIPTION
**What problem does this PR solve?**:
Short-term fix to manually close/reopen PRs after license update is pushed by GHA

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-108002

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

Temp commit to bump an image to trigger the licenses bump, workflow successfully closed/reopened PR after the commit:
<img width="870" height="230" alt="image" src="https://github.com/user-attachments/assets/0a4d0d90-86f3-413e-9800-1baabc2600e2" />
<img width="882" height="250" alt="image" src="https://github.com/user-attachments/assets/a659c0d8-41a6-4eca-97b5-7d9c8697587e" />


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
