### PR TITLE
Fetch and apply OCI manifests

### DIFF
--- a/hack/release/README.md
+++ b/hack/release/README.md
@@ -17,3 +17,20 @@ go run github.com/mesosphere/kommander-applications/hack/release@<git ref> pre-r
 
 This command will result in:
  * The chart version being updated in the Kommander `HelmRelease` files in the local copy of the repo
+
+## Apply manifests from a Helm OCI artifact
+
+The CLI can fetch a Helm chart stored as an OCI artifact using ORAS (or fall back to Crane), render it to raw manifests with Helm, and apply them to the current Kubernetes context using server-side apply.
+
+Example using the Flux chart published at `ghcr.io/fluxcd-community/charts/flux2`:
+
+```bash
+go run ./hack/release apply-oci \
+  --ref ghcr.io/fluxcd-community/charts/flux2:latest \
+  --namespace kommander-flux
+```
+
+Requirements:
+- oras in PATH (preferred). If missing, the CLI will attempt to use crane.
+- helm in PATH to render templates.
+- A valid kubeconfig/current context for applying manifests.

--- a/hack/release/cmd/applyoci/applyoci.go
+++ b/hack/release/cmd/applyoci/applyoci.go
@@ -1,0 +1,311 @@
+package applyoci
+
+import (
+    "bytes"
+    "context"
+    "errors"
+    "fmt"
+    "io"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
+    "time"
+
+    "github.com/spf13/cobra"
+
+    appsv1 "k8s.io/api/apps/v1"
+    corev1 "k8s.io/api/core/v1"
+    networkingv1 "k8s.io/api/networking/v1"
+    rbacv1 "k8s.io/api/rbac/v1"
+    apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+    apiruntime "k8s.io/apimachinery/pkg/runtime"
+    "k8s.io/cli-runtime/pkg/genericclioptions"
+
+    "github.com/fluxcd/cli-utils/pkg/kstatus/polling"
+    helmv2b2 "github.com/fluxcd/helm-controller/api/v2beta2"
+    kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+    runclient "github.com/fluxcd/pkg/runtime/client"
+    "github.com/fluxcd/pkg/ssa"
+    "github.com/fluxcd/pkg/ssa/normalize"
+    ssautils "github.com/fluxcd/pkg/ssa/utils"
+    sourcev1 "github.com/fluxcd/source-controller/api/v1"
+    sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
+
+    "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var Cmd *cobra.Command //nolint:gochecknoglobals // Cobra commands are global.
+
+const (
+    refFlagName       = "ref"
+    namespaceFlagName = "namespace"
+    timeoutFlagName   = "timeout"
+)
+
+func init() { //nolint:gochecknoinits // Initializing cobra application.
+    Cmd = &cobra.Command{
+        Use:   "apply-oci",
+        Short: "Pull a Helm OCI artifact and apply its rendered manifests",
+        Args:  cobra.MaximumNArgs(0),
+        RunE:  run,
+    }
+
+    Cmd.Flags().String(refFlagName, "ghcr.io/fluxcd-community/charts/flux2:latest", "OCI reference to pull (e.g., ghcr.io/org/charts/name:tag)")
+    Cmd.Flags().String(namespaceFlagName, "kommander-flux", "Namespace to render/apply into")
+    Cmd.Flags().Duration(timeoutFlagName, 5*time.Minute, "Timeout for waiting on applied resources")
+}
+
+func run(cmd *cobra.Command, _ []string) error {
+    ctx := cmd.Context()
+    ociRef := Cmd.Flag(refFlagName).Value.String()
+    renderNS := Cmd.Flag(namespaceFlagName).Value.String()
+    waitTimeout, err := time.ParseDuration(Cmd.Flag(timeoutFlagName).Value.String())
+    if err != nil {
+        return err
+    }
+
+    tmpDir, err := os.MkdirTemp("", "kommander-oci-*")
+    if err != nil {
+        return err
+    }
+    defer os.RemoveAll(tmpDir)
+
+    // Pull chart using ORAS (preferred). Fallback to crane if available.
+    if err := orasPull(ctx, ociRef, tmpDir); err != nil {
+        // Best-effort fallback to crane
+        if craneErr := craneExport(ctx, ociRef, tmpDir); craneErr != nil {
+            return fmt.Errorf("failed to pull OCI artifact with oras (%v) and crane (%v)", err, craneErr)
+        }
+    }
+
+    chartTGZ, err := findChartArchive(tmpDir)
+    if err != nil {
+        return err
+    }
+
+    extractedDir := filepath.Join(tmpDir, "extracted")
+    if err := os.MkdirAll(extractedDir, 0o755); err != nil {
+        return err
+    }
+
+    if err := untar(chartTGZ, extractedDir); err != nil {
+        return err
+    }
+
+    chartDir, err := firstSubdir(extractedDir)
+    if err != nil {
+        return err
+    }
+
+    renderedPath := filepath.Join(tmpDir, "manifests.yaml")
+    if err := helmTemplate(ctx, chartDir, renderNS, renderedPath); err != nil {
+        return err
+    }
+
+    // Apply rendered manifests via SSA with a split between CRDs/Namespaces and the rest.
+    kubeFlags := genericclioptions.NewConfigFlags(true)
+    clientOpts := &runclient.Options{}
+    if err := applyWithSSA(ctx, kubeFlags, clientOpts, renderedPath, waitTimeout); err != nil {
+        return err
+    }
+
+    _, _ = fmt.Fprintln(cmd.OutOrStdout(), "Applied manifests from OCI artifact:", ociRef)
+    return nil
+}
+
+func orasPull(ctx context.Context, ref, outDir string) error {
+    if _, err := exec.LookPath("oras"); err != nil {
+        return err
+    }
+    // oras pull supports oci:// prefix
+    args := []string{"pull", "--output", outDir, fmt.Sprintf("oci://%s", strings.TrimPrefix(ref, "oci://"))}
+    c := exec.CommandContext(ctx, "oras", args...) //nolint:gosec // controlled args
+    c.Stdout = io.Discard
+    c.Stderr = io.Discard
+    return c.Run()
+}
+
+func craneExport(ctx context.Context, ref, outDir string) error {
+    if _, err := exec.LookPath("crane"); err != nil {
+        return err
+    }
+    // Export all layers as a tar stream, then extract
+    tarPath := filepath.Join(outDir, "artifact.tar")
+    f, err := os.Create(tarPath)
+    if err != nil {
+        return err
+    }
+    _ = f.Close()
+
+    c := exec.CommandContext(ctx, "bash", "-c", fmt.Sprintf("crane export %s - > %s", shellEscape(ref), shellEscape(tarPath))) //nolint:gosec // shell used for pipe
+    c.Stdout = io.Discard
+    c.Stderr = io.Discard
+    if err := c.Run(); err != nil {
+        return err
+    }
+    return untar(tarPath, outDir)
+}
+
+func shellEscape(s string) string {
+    return strings.ReplaceAll(s, "'", "'\\''")
+}
+
+func findChartArchive(dir string) (string, error) {
+    // Common ORAS layout for Helm chart artifacts: file named "chart" or a single *.tgz
+    // Prefer file named chart
+    chartPath := filepath.Join(dir, "chart")
+    if st, err := os.Stat(chartPath); err == nil && !st.IsDir() {
+        // Rename to .tgz to make extraction simpler
+        dest := chartPath + ".tgz"
+        if err := os.Rename(chartPath, dest); err != nil {
+            return "", err
+        }
+        return dest, nil
+    }
+
+    matches, err := filepath.Glob(filepath.Join(dir, "*.tgz"))
+    if err != nil {
+        return "", err
+    }
+    if len(matches) == 0 {
+        return "", errors.New("no Helm chart archive found in pulled artifact")
+    }
+    return matches[0], nil
+}
+
+func untar(archivePath, destDir string) error {
+    if _, err := exec.LookPath("tar"); err != nil {
+        return err
+    }
+    c := exec.Command("tar", "-xzf", archivePath, "-C", destDir) //nolint:gosec // expected args
+    c.Stdout = io.Discard
+    c.Stderr = io.Discard
+    return c.Run()
+}
+
+func firstSubdir(dir string) (string, error) {
+    entries, err := os.ReadDir(dir)
+    if err != nil {
+        return "", err
+    }
+    for _, e := range entries {
+        if e.IsDir() {
+            return filepath.Join(dir, e.Name()), nil
+        }
+    }
+    return "", fmt.Errorf("no directory found in %s", dir)
+}
+
+func helmTemplate(ctx context.Context, chartDir, namespace, outPath string) error {
+    if _, err := exec.LookPath("helm"); err != nil {
+        return err
+    }
+    // helm template <release> <chartDir> --namespace <ns>
+    args := []string{"template", filepath.Base(chartDir), chartDir, "--namespace", namespace}
+    c := exec.CommandContext(ctx, "helm", args...) //nolint:gosec // controlled args
+    var stdout bytes.Buffer
+    c.Stdout = &stdout
+    c.Stderr = io.Discard
+    if err := c.Run(); err != nil {
+        return err
+    }
+    return os.WriteFile(outPath, stdout.Bytes(), 0o644)
+}
+
+func applyWithSSA(ctx context.Context, rcg genericclioptions.RESTClientGetter, opts *runclient.Options, manifestPath string, wait time.Duration) error {
+    file, err := os.Open(manifestPath)
+    if err != nil {
+        return err
+    }
+    defer file.Close()
+
+    objs, err := ssautils.ReadObjects(file)
+    if err != nil {
+        return err
+    }
+    if len(objs) == 0 {
+        return fmt.Errorf("no Kubernetes objects found in: %s", manifestPath)
+    }
+    if err := normalize.UnstructuredList(objs); err != nil {
+        return err
+    }
+
+    var stageOne []*unstructured.Unstructured
+    var stageTwo []*unstructured.Unstructured
+    for _, u := range objs {
+        if ssautils.IsClusterDefinition(u) {
+            stageOne = append(stageOne, u)
+        } else {
+            stageTwo = append(stageTwo, u)
+        }
+    }
+
+    if len(stageOne) > 0 {
+        if _, err := applySet(ctx, rcg, opts, stageOne); err != nil {
+            return err
+        }
+        if err := waitForSet(rcg, opts, stageOne, wait); err != nil {
+            return err
+        }
+    }
+
+    if len(stageTwo) > 0 {
+        if _, err := applySet(ctx, rcg, opts, stageTwo); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+
+func newManager(rcg genericclioptions.RESTClientGetter, opts *runclient.Options) (*ssa.ResourceManager, error) {
+    cfg, err := rcg.ToRESTConfig()
+    if err != nil {
+        return nil, fmt.Errorf("kubernetes configuration load failed: %w", err)
+    }
+    cfg.QPS = opts.QPS
+    cfg.Burst = opts.Burst
+
+    restMapper, err := rcg.ToRESTMapper()
+    if err != nil {
+        return nil, err
+    }
+    kubeClient, err := client.New(cfg, client.Options{Mapper: restMapper, Scheme: newScheme()})
+    if err != nil {
+        return nil, err
+    }
+    kubePoller := polling.NewStatusPoller(kubeClient, restMapper, polling.Options{})
+    return ssa.NewResourceManager(kubeClient, kubePoller, ssa.Owner{Field: "flux", Group: "fluxcd.io"}), nil
+}
+
+func applySet(ctx context.Context, rcg genericclioptions.RESTClientGetter, opts *runclient.Options, objects []*unstructured.Unstructured) (*ssa.ChangeSet, error) {
+    man, err := newManager(rcg, opts)
+    if err != nil {
+        return nil, err
+    }
+    return man.ApplyAll(ctx, objects, ssa.DefaultApplyOptions())
+}
+
+func waitForSet(rcg genericclioptions.RESTClientGetter, opts *runclient.Options, objects []*unstructured.Unstructured, timeout time.Duration) error {
+    man, err := newManager(rcg, opts)
+    if err != nil {
+        return err
+    }
+    return man.WaitForSet(ssautils.ObjectsToObjMetadataSet(objects), ssa.WaitOptions{Interval: 2 * time.Second, Timeout: timeout})
+}
+
+func newScheme() *apiruntime.Scheme {
+    scheme := apiruntime.NewScheme()
+    _ = apiextensionsv1.AddToScheme(scheme)
+    _ = corev1.AddToScheme(scheme)
+    _ = rbacv1.AddToScheme(scheme)
+    _ = appsv1.AddToScheme(scheme)
+    _ = networkingv1.AddToScheme(scheme)
+    _ = sourcev1b2.AddToScheme(scheme)
+    _ = sourcev1.AddToScheme(scheme)
+    _ = kustomizev1.AddToScheme(scheme)
+    _ = helmv2b2.AddToScheme(scheme)
+    return scheme
+}
+

--- a/hack/release/cmd/root.go
+++ b/hack/release/cmd/root.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mesosphere/kommander-applications/hack/release/cmd/postrelease"
 	"github.com/mesosphere/kommander-applications/hack/release/cmd/prerelease"
+    "github.com/mesosphere/kommander-applications/hack/release/cmd/applyoci"
 )
 
 var rootCmd *cobra.Command //nolint:gochecknoglobals // Cobra commands are global.
@@ -16,6 +17,7 @@ func init() { //nolint:gochecknoinits // Initializing cobra application.
 	rootCmd = &cobra.Command{}
 	rootCmd.AddCommand(prerelease.Cmd)
 	rootCmd.AddCommand(postrelease.Cmd)
+    rootCmd.AddCommand(applyoci.Cmd)
 }
 
 func Execute(ctx context.Context) {


### PR DESCRIPTION
**What problem does this PR solve?**:
This PR enables the Kommander CLI to reliably fetch Kubernetes manifests from Helm OCI artifacts using ORAS or Crane, render them, and apply them to a Kubernetes cluster. This provides a direct and automated way to deploy applications from OCI-packaged charts.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
This PR introduces a new CLI command: `hack/release apply-oci`.
It performs the following steps:
1.  Pulls the specified Helm OCI artifact using `oras` (preferred) or `crane` (fallback).
2.  Extracts the Helm chart from the pulled artifact.
3.  Renders the Helm chart into raw Kubernetes manifests using `helm template`.
4.  Applies the rendered manifests to the current Kubernetes context using server-side apply (SSA).
    *   It prioritizes applying Cluster-scoped resources (CRDs, Namespaces) first and waits for their reconciliation before applying other resources.

**Requirements**:
*   `oras` (or `crane`) must be available in the system's PATH.
*   `helm` must be available in the system's PATH.
*   A valid `kubeconfig` must be configured for cluster access.

**Example usage**:
```bash
go run ./hack/release apply-oci \
  --ref ghcr.io/fluxcd-community/charts/flux2:latest \
  --namespace kommander-flux
```

**Does this PR introduce a user-facing change?**:
```release-note
CLI: Added `apply-oci` command to pull Helm OCI artifacts, render, and apply manifests to a Kubernetes cluster.
```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [x] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [x] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).

---
<a href="https://cursor.com/background-agent?bcId=bc-c3aacab4-dfb9-4599-9634-c9cc0733973c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c3aacab4-dfb9-4599-9634-c9cc0733973c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

