### PR TITLE
Review code modification

### DIFF
--- a/pr_4081.patch
+++ b/pr_4081.patch
@@ -1,0 +1,13330 @@
+From a65808f484e632c3f926c395d004fee170b7efde Mon Sep 17 00:00:00 2001
+From: Zihui Liu <zihui.liu@nutanix.com>
+Date: Wed, 1 Oct 2025 06:42:54 -0700
+Subject: [PATCH] feat: SPIKE Flux Customization
+
+---
+ ...alerts.notification.toolkit.fluxcd.io.yaml |  581 ---
+ ...tion_buckets.source.toolkit.fluxcd.io.yaml |  988 -----
+ ...repositories.source.toolkit.fluxcd.io.yaml | 1277 ------
+ ...n_helmcharts.source.toolkit.fluxcd.io.yaml |  980 -----
+ ...n_helmreleases.helm.toolkit.fluxcd.io.yaml | 3696 -----------------
+ ...repositories.source.toolkit.fluxcd.io.yaml |  848 ----
+ ...mizations.kustomize.toolkit.fluxcd.io.yaml | 1788 --------
+ ...repositories.source.toolkit.fluxcd.io.yaml |  825 ----
+ ...viders.notification.toolkit.fluxcd.io.yaml |  560 ---
+ ...eivers.notification.toolkit.fluxcd.io.yaml |  683 ---
+ .../apps_v1_deployment_helm-controller.yaml   |   94 -
+ ...ps_v1_deployment_kustomize-controller.yaml |   95 -
+ ...v1_deployment_notification-controller.yaml |   98 -
+ .../apps_v1_deployment_source-controller.yaml |  106 -
+ .../2.6.1/templates/kustomization.yaml        |   35 -
+ ....k8s.io_v1_networkpolicy_allow-egress.yaml |   19 -
+ ...8s.io_v1_networkpolicy_allow-scraping.yaml |   19 -
+ ...8s.io_v1_networkpolicy_allow-webhooks.yaml |   18 -
+ .../v1_service_notification-controller.yaml   |   20 -
+ .../v1_service_source-controller.yaml         |   20 -
+ .../v1_service_webhook-receiver.yaml          |   20 -
+ .../v1_serviceaccount_helm-controller.yaml    |   10 -
+ ...1_serviceaccount_kustomize-controller.yaml |   10 -
+ ...erviceaccount_notification-controller.yaml |   10 -
+ .../v1_serviceaccount_source-controller.yaml  |   10 -
+ .../kommander-flux/2.6.4/helmrelease/cm.yaml  |   15 +
+ .../2.6.4/helmrelease/helmrelease.yaml        |   62 +
+ .../2.6.4/helmrelease/kustomization.yaml      |    5 +
+ .../{2.6.1 => 2.6.4}/kustomization.yaml       |    1 +
+ .../{2.6.1 => 2.6.4}/metadata.yaml            |    0
+ .../mirror/flux-oci-mirror.yaml               |    0
+ .../mirror/kustomization.yaml                 |    0
+ .../mirror/network-policy.yaml                |    0
+ .../patch-proxy-env-vars.yaml                 |    0
+ .../patch-source-ctrl-network-policy.yaml     |    0
+ .../2.6.4/templates/kustomization.yaml        |   11 +
+ ....k8s.io_v1_networkpolicy_allow-source.yaml |    0
+ ...terrole_crd-controller-kommander-flux.yaml |    2 +-
+ ..._clusterrole_flux-edit-kommander-flux.yaml |    2 +-
+ ..._clusterrole_flux-view-kommander-flux.yaml |    2 +-
+ ...ing_cluster-reconciler-kommander-flux.yaml |    2 +-
+ ...binding_crd-controller-kommander-flux.yaml |    2 +-
+ .../v1_namespace_kommander-flux.yaml          |    2 +-
+ ...rcequota_critical-pods-kommander-flux.yaml |    2 +-
+ 44 files changed, 101 insertions(+), 12817 deletions(-)
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_alerts.notification.toolkit.fluxcd.io.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_buckets.source.toolkit.fluxcd.io.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_gitrepositories.source.toolkit.fluxcd.io.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_helmcharts.source.toolkit.fluxcd.io.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_helmreleases.helm.toolkit.fluxcd.io.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_helmrepositories.source.toolkit.fluxcd.io.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_kustomizations.kustomize.toolkit.fluxcd.io.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_ocirepositories.source.toolkit.fluxcd.io.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_providers.notification.toolkit.fluxcd.io.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_receivers.notification.toolkit.fluxcd.io.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/apps_v1_deployment_helm-controller.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/apps_v1_deployment_kustomize-controller.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/apps_v1_deployment_notification-controller.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/apps_v1_deployment_source-controller.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/kustomization.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/networking.k8s.io_v1_networkpolicy_allow-egress.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/networking.k8s.io_v1_networkpolicy_allow-scraping.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/networking.k8s.io_v1_networkpolicy_allow-webhooks.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/v1_service_notification-controller.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/v1_service_source-controller.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/v1_service_webhook-receiver.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/v1_serviceaccount_helm-controller.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/v1_serviceaccount_kustomize-controller.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/v1_serviceaccount_notification-controller.yaml
+ delete mode 100644 applications/kommander-flux/2.6.1/templates/v1_serviceaccount_source-controller.yaml
+ create mode 100644 applications/kommander-flux/2.6.4/helmrelease/cm.yaml
+ create mode 100644 applications/kommander-flux/2.6.4/helmrelease/helmrelease.yaml
+ create mode 100644 applications/kommander-flux/2.6.4/helmrelease/kustomization.yaml
+ rename applications/kommander-flux/{2.6.1 => 2.6.4}/kustomization.yaml (95%)
+ rename applications/kommander-flux/{2.6.1 => 2.6.4}/metadata.yaml (100%)
+ rename applications/kommander-flux/{2.6.1 => 2.6.4}/mirror/flux-oci-mirror.yaml (100%)
+ rename applications/kommander-flux/{2.6.1 => 2.6.4}/mirror/kustomization.yaml (100%)
+ rename applications/kommander-flux/{2.6.1 => 2.6.4}/mirror/network-policy.yaml (100%)
+ rename applications/kommander-flux/{2.6.1 => 2.6.4}/patch-proxy-env-vars.yaml (100%)
+ rename applications/kommander-flux/{2.6.1 => 2.6.4}/patch-source-ctrl-network-policy.yaml (100%)
+ create mode 100644 applications/kommander-flux/2.6.4/templates/kustomization.yaml
+ rename applications/kommander-flux/{2.6.1 => 2.6.4}/templates/networking.k8s.io_v1_networkpolicy_allow-source.yaml (100%)
+ rename applications/kommander-flux/{2.6.1 => 2.6.4}/templates/rbac.authorization.k8s.io_v1_clusterrole_crd-controller-kommander-flux.yaml (97%)
+ rename applications/kommander-flux/{2.6.1 => 2.6.4}/templates/rbac.authorization.k8s.io_v1_clusterrole_flux-edit-kommander-flux.yaml (93%)
+ rename applications/kommander-flux/{2.6.1 => 2.6.4}/templates/rbac.authorization.k8s.io_v1_clusterrole_flux-view-kommander-flux.yaml (93%)
+ rename applications/kommander-flux/{2.6.1 => 2.6.4}/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_cluster-reconciler-kommander-flux.yaml (92%)
+ rename applications/kommander-flux/{2.6.1 => 2.6.4}/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_crd-controller-kommander-flux.yaml (95%)
+ rename applications/kommander-flux/{2.6.1 => 2.6.4}/templates/v1_namespace_kommander-flux.yaml (89%)
+ rename applications/kommander-flux/{2.6.1 => 2.6.4}/templates/v1_resourcequota_critical-pods-kommander-flux.yaml (91%)
+
+diff --git a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_alerts.notification.toolkit.fluxcd.io.yaml b/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_alerts.notification.toolkit.fluxcd.io.yaml
+deleted file mode 100644
+index 147b95091e..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_alerts.notification.toolkit.fluxcd.io.yaml
++++ /dev/null
+@@ -1,581 +0,0 @@
+-apiVersion: apiextensions.k8s.io/v1
+-kind: CustomResourceDefinition
+-metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: v0.16.1
+-  labels:
+-    app.kubernetes.io/component: notification-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: alerts.notification.toolkit.fluxcd.io
+-spec:
+-  group: notification.toolkit.fluxcd.io
+-  names:
+-    kind: Alert
+-    listKind: AlertList
+-    plural: alerts
+-    singular: alert
+-  scope: Namespaced
+-  versions:
+-  - additionalPrinterColumns:
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    deprecated: true
+-    deprecationWarning: v1beta1 Alert is deprecated, upgrade to v1beta3
+-    name: v1beta1
+-    schema:
+-      openAPIV3Schema:
+-        description: Alert is the Schema for the alerts API
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: AlertSpec defines an alerting rule for events involving a
+-              list of objects
+-            properties:
+-              eventSeverity:
+-                default: info
+-                description: |-
+-                  Filter events based on severity, defaults to ('info').
+-                  If set to 'info' no events will be filtered.
+-                enum:
+-                - info
+-                - error
+-                type: string
+-              eventSources:
+-                description: Filter events based on the involved objects.
+-                items:
+-                  description: |-
+-                    CrossNamespaceObjectReference contains enough information to let you locate the
+-                    typed referenced object at cluster level
+-                  properties:
+-                    apiVersion:
+-                      description: API version of the referent
+-                      type: string
+-                    kind:
+-                      description: Kind of the referent
+-                      enum:
+-                      - Bucket
+-                      - GitRepository
+-                      - Kustomization
+-                      - HelmRelease
+-                      - HelmChart
+-                      - HelmRepository
+-                      - ImageRepository
+-                      - ImagePolicy
+-                      - ImageUpdateAutomation
+-                      - OCIRepository
+-                      type: string
+-                    matchLabels:
+-                      additionalProperties:
+-                        type: string
+-                      description: |-
+-                        MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+-                      type: object
+-                    name:
+-                      description: Name of the referent
+-                      maxLength: 53
+-                      minLength: 1
+-                      type: string
+-                    namespace:
+-                      description: Namespace of the referent
+-                      maxLength: 53
+-                      minLength: 1
+-                      type: string
+-                  required:
+-                  - kind
+-                  - name
+-                  type: object
+-                type: array
+-              exclusionList:
+-                description: A list of Golang regular expressions to be used for excluding
+-                  messages.
+-                items:
+-                  type: string
+-                type: array
+-              providerRef:
+-                description: Send events using this provider.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              summary:
+-                description: Short description of the impact and affected cluster.
+-                type: string
+-              suspend:
+-                description: |-
+-                  This flag tells the controller to suspend subsequent events dispatching.
+-                  Defaults to false.
+-                type: boolean
+-            required:
+-            - eventSources
+-            - providerRef
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: AlertStatus defines the observed state of Alert
+-            properties:
+-              conditions:
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation.
+-                format: int64
+-                type: integer
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    deprecated: true
+-    deprecationWarning: v1beta2 Alert is deprecated, upgrade to v1beta3
+-    name: v1beta2
+-    schema:
+-      openAPIV3Schema:
+-        description: Alert is the Schema for the alerts API
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: AlertSpec defines an alerting rule for events involving a
+-              list of objects.
+-            properties:
+-              eventMetadata:
+-                additionalProperties:
+-                  type: string
+-                description: |-
+-                  EventMetadata is an optional field for adding metadata to events dispatched by the
+-                  controller. This can be used for enhancing the context of the event. If a field
+-                  would override one already present on the original event as generated by the emitter,
+-                  then the override doesn't happen, i.e. the original value is preserved, and an info
+-                  log is printed.
+-                type: object
+-              eventSeverity:
+-                default: info
+-                description: |-
+-                  EventSeverity specifies how to filter events based on severity.
+-                  If set to 'info' no events will be filtered.
+-                enum:
+-                - info
+-                - error
+-                type: string
+-              eventSources:
+-                description: |-
+-                  EventSources specifies how to filter events based
+-                  on the involved object kind, name and namespace.
+-                items:
+-                  description: |-
+-                    CrossNamespaceObjectReference contains enough information to let you locate the
+-                    typed referenced object at cluster level
+-                  properties:
+-                    apiVersion:
+-                      description: API version of the referent
+-                      type: string
+-                    kind:
+-                      description: Kind of the referent
+-                      enum:
+-                      - Bucket
+-                      - GitRepository
+-                      - Kustomization
+-                      - HelmRelease
+-                      - HelmChart
+-                      - HelmRepository
+-                      - ImageRepository
+-                      - ImagePolicy
+-                      - ImageUpdateAutomation
+-                      - OCIRepository
+-                      type: string
+-                    matchLabels:
+-                      additionalProperties:
+-                        type: string
+-                      description: |-
+-                        MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+-                        MatchLabels requires the name to be set to `*`.
+-                      type: object
+-                    name:
+-                      description: |-
+-                        Name of the referent
+-                        If multiple resources are targeted `*` may be set.
+-                      maxLength: 253
+-                      minLength: 1
+-                      type: string
+-                    namespace:
+-                      description: Namespace of the referent
+-                      maxLength: 253
+-                      minLength: 1
+-                      type: string
+-                  required:
+-                  - kind
+-                  - name
+-                  type: object
+-                type: array
+-              exclusionList:
+-                description: |-
+-                  ExclusionList specifies a list of Golang regular expressions
+-                  to be used for excluding messages.
+-                items:
+-                  type: string
+-                type: array
+-              inclusionList:
+-                description: |-
+-                  InclusionList specifies a list of Golang regular expressions
+-                  to be used for including messages.
+-                items:
+-                  type: string
+-                type: array
+-              providerRef:
+-                description: ProviderRef specifies which Provider this Alert should
+-                  use.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              summary:
+-                description: Summary holds a short description of the impact and affected
+-                  cluster.
+-                maxLength: 255
+-                type: string
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend subsequent
+-                  events handling for this Alert.
+-                type: boolean
+-            required:
+-            - eventSources
+-            - providerRef
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: AlertStatus defines the observed state of the Alert.
+-            properties:
+-              conditions:
+-                description: Conditions holds the conditions for the Alert.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation.
+-                format: int64
+-                type: integer
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    name: v1beta3
+-    schema:
+-      openAPIV3Schema:
+-        description: Alert is the Schema for the alerts API
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: AlertSpec defines an alerting rule for events involving a
+-              list of objects.
+-            properties:
+-              eventMetadata:
+-                additionalProperties:
+-                  type: string
+-                description: |-
+-                  EventMetadata is an optional field for adding metadata to events dispatched by the
+-                  controller. This can be used for enhancing the context of the event. If a field
+-                  would override one already present on the original event as generated by the emitter,
+-                  then the override doesn't happen, i.e. the original value is preserved, and an info
+-                  log is printed.
+-                type: object
+-              eventSeverity:
+-                default: info
+-                description: |-
+-                  EventSeverity specifies how to filter events based on severity.
+-                  If set to 'info' no events will be filtered.
+-                enum:
+-                - info
+-                - error
+-                type: string
+-              eventSources:
+-                description: |-
+-                  EventSources specifies how to filter events based
+-                  on the involved object kind, name and namespace.
+-                items:
+-                  description: |-
+-                    CrossNamespaceObjectReference contains enough information to let you locate the
+-                    typed referenced object at cluster level
+-                  properties:
+-                    apiVersion:
+-                      description: API version of the referent
+-                      type: string
+-                    kind:
+-                      description: Kind of the referent
+-                      enum:
+-                      - Bucket
+-                      - GitRepository
+-                      - Kustomization
+-                      - HelmRelease
+-                      - HelmChart
+-                      - HelmRepository
+-                      - ImageRepository
+-                      - ImagePolicy
+-                      - ImageUpdateAutomation
+-                      - OCIRepository
+-                      type: string
+-                    matchLabels:
+-                      additionalProperties:
+-                        type: string
+-                      description: |-
+-                        MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+-                        MatchLabels requires the name to be set to `*`.
+-                      type: object
+-                    name:
+-                      description: |-
+-                        Name of the referent
+-                        If multiple resources are targeted `*` may be set.
+-                      maxLength: 253
+-                      minLength: 1
+-                      type: string
+-                    namespace:
+-                      description: Namespace of the referent
+-                      maxLength: 253
+-                      minLength: 1
+-                      type: string
+-                  required:
+-                  - kind
+-                  - name
+-                  type: object
+-                type: array
+-              exclusionList:
+-                description: |-
+-                  ExclusionList specifies a list of Golang regular expressions
+-                  to be used for excluding messages.
+-                items:
+-                  type: string
+-                type: array
+-              inclusionList:
+-                description: |-
+-                  InclusionList specifies a list of Golang regular expressions
+-                  to be used for including messages.
+-                items:
+-                  type: string
+-                type: array
+-              providerRef:
+-                description: ProviderRef specifies which Provider this Alert should
+-                  use.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              summary:
+-                description: |-
+-                  Summary holds a short description of the impact and affected cluster.
+-                  Deprecated: Use EventMetadata instead.
+-                maxLength: 255
+-                type: string
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend subsequent
+-                  events handling for this Alert.
+-                type: boolean
+-            required:
+-            - eventSources
+-            - providerRef
+-            type: object
+-        type: object
+-    served: true
+-    storage: true
+-    subresources: {}
+diff --git a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_buckets.source.toolkit.fluxcd.io.yaml b/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_buckets.source.toolkit.fluxcd.io.yaml
+deleted file mode 100644
+index 9364294225..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_buckets.source.toolkit.fluxcd.io.yaml
++++ /dev/null
+@@ -1,988 +0,0 @@
+-apiVersion: apiextensions.k8s.io/v1
+-kind: CustomResourceDefinition
+-metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: v0.16.1
+-  labels:
+-    app.kubernetes.io/component: source-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: buckets.source.toolkit.fluxcd.io
+-spec:
+-  group: source.toolkit.fluxcd.io
+-  names:
+-    kind: Bucket
+-    listKind: BucketList
+-    plural: buckets
+-    singular: bucket
+-  scope: Namespaced
+-  versions:
+-  - additionalPrinterColumns:
+-    - jsonPath: .spec.endpoint
+-      name: Endpoint
+-      type: string
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    name: v1
+-    schema:
+-      openAPIV3Schema:
+-        description: Bucket is the Schema for the buckets API.
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: |-
+-              BucketSpec specifies the required configuration to produce an Artifact for
+-              an object storage bucket.
+-            properties:
+-              bucketName:
+-                description: BucketName is the name of the object storage bucket.
+-                type: string
+-              certSecretRef:
+-                description: |-
+-                  CertSecretRef can be given the name of a Secret containing
+-                  either or both of
+-
+-                  - a PEM-encoded client certificate (`tls.crt`) and private
+-                  key (`tls.key`);
+-                  - a PEM-encoded CA certificate (`ca.crt`)
+-
+-                  and whichever are supplied, will be used for connecting to the
+-                  bucket. The client cert and key are useful if you are
+-                  authenticating with a certificate; the CA cert is useful if
+-                  you are using a self-signed server certificate. The Secret must
+-                  be of type `Opaque` or `kubernetes.io/tls`.
+-
+-                  This field is only supported for the `generic` provider.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              endpoint:
+-                description: Endpoint is the object storage address the BucketName
+-                  is located at.
+-                type: string
+-              ignore:
+-                description: |-
+-                  Ignore overrides the set of excluded patterns in the .sourceignore format
+-                  (which is the same as .gitignore). If not provided, a default will be used,
+-                  consult the documentation for your version to find out what those are.
+-                type: string
+-              insecure:
+-                description: Insecure allows connecting to a non-TLS HTTP Endpoint.
+-                type: boolean
+-              interval:
+-                description: |-
+-                  Interval at which the Bucket Endpoint is checked for updates.
+-                  This interval is approximate and may be subject to jitter to ensure
+-                  efficient use of resources.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              prefix:
+-                description: Prefix to use for server-side filtering of files in the
+-                  Bucket.
+-                type: string
+-              provider:
+-                default: generic
+-                description: |-
+-                  Provider of the object storage bucket.
+-                  Defaults to 'generic', which expects an S3 (API) compatible object
+-                  storage.
+-                enum:
+-                - generic
+-                - aws
+-                - gcp
+-                - azure
+-                type: string
+-              proxySecretRef:
+-                description: |-
+-                  ProxySecretRef specifies the Secret containing the proxy configuration
+-                  to use while communicating with the Bucket server.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              region:
+-                description: Region of the Endpoint where the BucketName is located
+-                  in.
+-                type: string
+-              secretRef:
+-                description: |-
+-                  SecretRef specifies the Secret containing authentication credentials
+-                  for the Bucket.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              sts:
+-                description: |-
+-                  STS specifies the required configuration to use a Security Token
+-                  Service for fetching temporary credentials to authenticate in a
+-                  Bucket provider.
+-
+-                  This field is only supported for the `aws` and `generic` providers.
+-                properties:
+-                  certSecretRef:
+-                    description: |-
+-                      CertSecretRef can be given the name of a Secret containing
+-                      either or both of
+-
+-                      - a PEM-encoded client certificate (`tls.crt`) and private
+-                      key (`tls.key`);
+-                      - a PEM-encoded CA certificate (`ca.crt`)
+-
+-                      and whichever are supplied, will be used for connecting to the
+-                      STS endpoint. The client cert and key are useful if you are
+-                      authenticating with a certificate; the CA cert is useful if
+-                      you are using a self-signed server certificate. The Secret must
+-                      be of type `Opaque` or `kubernetes.io/tls`.
+-
+-                      This field is only supported for the `ldap` provider.
+-                    properties:
+-                      name:
+-                        description: Name of the referent.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                  endpoint:
+-                    description: |-
+-                      Endpoint is the HTTP/S endpoint of the Security Token Service from
+-                      where temporary credentials will be fetched.
+-                    pattern: ^(http|https)://.*$
+-                    type: string
+-                  provider:
+-                    description: Provider of the Security Token Service.
+-                    enum:
+-                    - aws
+-                    - ldap
+-                    type: string
+-                  secretRef:
+-                    description: |-
+-                      SecretRef specifies the Secret containing authentication credentials
+-                      for the STS endpoint. This Secret must contain the fields `username`
+-                      and `password` and is supported only for the `ldap` provider.
+-                    properties:
+-                      name:
+-                        description: Name of the referent.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - endpoint
+-                - provider
+-                type: object
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend the reconciliation of this
+-                  Bucket.
+-                type: boolean
+-              timeout:
+-                default: 60s
+-                description: Timeout for fetch operations, defaults to 60s.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+-                type: string
+-            required:
+-            - bucketName
+-            - endpoint
+-            - interval
+-            type: object
+-            x-kubernetes-validations:
+-            - message: STS configuration is only supported for the 'aws' and 'generic'
+-                Bucket providers
+-              rule: self.provider == 'aws' || self.provider == 'generic' || !has(self.sts)
+-            - message: '''aws'' is the only supported STS provider for the ''aws''
+-                Bucket provider'
+-              rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider
+-                == 'aws'
+-            - message: '''ldap'' is the only supported STS provider for the ''generic''
+-                Bucket provider'
+-              rule: self.provider != 'generic' || !has(self.sts) || self.sts.provider
+-                == 'ldap'
+-            - message: spec.sts.secretRef is not required for the 'aws' STS provider
+-              rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.secretRef)'
+-            - message: spec.sts.certSecretRef is not required for the 'aws' STS provider
+-              rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.certSecretRef)'
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: BucketStatus records the observed state of a Bucket.
+-            properties:
+-              artifact:
+-                description: Artifact represents the last successful Bucket reconciliation.
+-                properties:
+-                  digest:
+-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+-                    type: string
+-                  lastUpdateTime:
+-                    description: |-
+-                      LastUpdateTime is the timestamp corresponding to the last update of the
+-                      Artifact.
+-                    format: date-time
+-                    type: string
+-                  metadata:
+-                    additionalProperties:
+-                      type: string
+-                    description: Metadata holds upstream information such as OCI annotations.
+-                    type: object
+-                  path:
+-                    description: |-
+-                      Path is the relative file path of the Artifact. It can be used to locate
+-                      the file in the root of the Artifact storage on the local file system of
+-                      the controller managing the Source.
+-                    type: string
+-                  revision:
+-                    description: |-
+-                      Revision is a human-readable identifier traceable in the origin source
+-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+-                    type: string
+-                  size:
+-                    description: Size is the number of bytes in the file.
+-                    format: int64
+-                    type: integer
+-                  url:
+-                    description: |-
+-                      URL is the HTTP address of the Artifact as exposed by the controller
+-                      managing the Source. It can be used to retrieve the Artifact for
+-                      consumption, e.g. by another controller applying the Artifact contents.
+-                    type: string
+-                required:
+-                - lastUpdateTime
+-                - path
+-                - revision
+-                - url
+-                type: object
+-              conditions:
+-                description: Conditions holds the conditions for the Bucket.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation of
+-                  the Bucket object.
+-                format: int64
+-                type: integer
+-              observedIgnore:
+-                description: |-
+-                  ObservedIgnore is the observed exclusion patterns used for constructing
+-                  the source artifact.
+-                type: string
+-              url:
+-                description: |-
+-                  URL is the dynamic fetch link for the latest Artifact.
+-                  It is provided on a "best effort" basis, and using the precise
+-                  BucketStatus.Artifact data is recommended.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: true
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .spec.endpoint
+-      name: Endpoint
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    deprecated: true
+-    deprecationWarning: v1beta1 Bucket is deprecated, upgrade to v1
+-    name: v1beta1
+-    schema:
+-      openAPIV3Schema:
+-        description: Bucket is the Schema for the buckets API
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: BucketSpec defines the desired state of an S3 compatible
+-              bucket
+-            properties:
+-              accessFrom:
+-                description: AccessFrom defines an Access Control List for allowing
+-                  cross-namespace references to this object.
+-                properties:
+-                  namespaceSelectors:
+-                    description: |-
+-                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+-                      Items in this list are evaluated using a logical OR operation.
+-                    items:
+-                      description: |-
+-                        NamespaceSelector selects the namespaces to which this ACL applies.
+-                        An empty map of MatchLabels matches all namespaces in a cluster.
+-                      properties:
+-                        matchLabels:
+-                          additionalProperties:
+-                            type: string
+-                          description: |-
+-                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+-                          type: object
+-                      type: object
+-                    type: array
+-                required:
+-                - namespaceSelectors
+-                type: object
+-              bucketName:
+-                description: The bucket name.
+-                type: string
+-              endpoint:
+-                description: The bucket endpoint address.
+-                type: string
+-              ignore:
+-                description: |-
+-                  Ignore overrides the set of excluded patterns in the .sourceignore format
+-                  (which is the same as .gitignore). If not provided, a default will be used,
+-                  consult the documentation for your version to find out what those are.
+-                type: string
+-              insecure:
+-                description: Insecure allows connecting to a non-TLS S3 HTTP endpoint.
+-                type: boolean
+-              interval:
+-                description: The interval at which to check for bucket updates.
+-                type: string
+-              provider:
+-                default: generic
+-                description: The S3 compatible storage provider name, default ('generic').
+-                enum:
+-                - generic
+-                - aws
+-                - gcp
+-                type: string
+-              region:
+-                description: The bucket region.
+-                type: string
+-              secretRef:
+-                description: |-
+-                  The name of the secret containing authentication credentials
+-                  for the Bucket.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              suspend:
+-                description: This flag tells the controller to suspend the reconciliation
+-                  of this source.
+-                type: boolean
+-              timeout:
+-                default: 60s
+-                description: The timeout for download operations, defaults to 60s.
+-                type: string
+-            required:
+-            - bucketName
+-            - endpoint
+-            - interval
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: BucketStatus defines the observed state of a bucket
+-            properties:
+-              artifact:
+-                description: Artifact represents the output of the last successful
+-                  Bucket sync.
+-                properties:
+-                  checksum:
+-                    description: Checksum is the SHA256 checksum of the artifact.
+-                    type: string
+-                  lastUpdateTime:
+-                    description: |-
+-                      LastUpdateTime is the timestamp corresponding to the last update of this
+-                      artifact.
+-                    format: date-time
+-                    type: string
+-                  path:
+-                    description: Path is the relative file path of this artifact.
+-                    type: string
+-                  revision:
+-                    description: |-
+-                      Revision is a human readable identifier traceable in the origin source
+-                      system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
+-                      chart version, etc.
+-                    type: string
+-                  url:
+-                    description: URL is the HTTP address of this artifact.
+-                    type: string
+-                required:
+-                - lastUpdateTime
+-                - path
+-                - url
+-                type: object
+-              conditions:
+-                description: Conditions holds the conditions for the Bucket.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation.
+-                format: int64
+-                type: integer
+-              url:
+-                description: URL is the download link for the artifact output of the
+-                  last Bucket sync.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .spec.endpoint
+-      name: Endpoint
+-      type: string
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    deprecated: true
+-    deprecationWarning: v1beta2 Bucket is deprecated, upgrade to v1
+-    name: v1beta2
+-    schema:
+-      openAPIV3Schema:
+-        description: Bucket is the Schema for the buckets API.
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: |-
+-              BucketSpec specifies the required configuration to produce an Artifact for
+-              an object storage bucket.
+-            properties:
+-              accessFrom:
+-                description: |-
+-                  AccessFrom specifies an Access Control List for allowing cross-namespace
+-                  references to this object.
+-                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+-                properties:
+-                  namespaceSelectors:
+-                    description: |-
+-                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+-                      Items in this list are evaluated using a logical OR operation.
+-                    items:
+-                      description: |-
+-                        NamespaceSelector selects the namespaces to which this ACL applies.
+-                        An empty map of MatchLabels matches all namespaces in a cluster.
+-                      properties:
+-                        matchLabels:
+-                          additionalProperties:
+-                            type: string
+-                          description: |-
+-                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+-                          type: object
+-                      type: object
+-                    type: array
+-                required:
+-                - namespaceSelectors
+-                type: object
+-              bucketName:
+-                description: BucketName is the name of the object storage bucket.
+-                type: string
+-              certSecretRef:
+-                description: |-
+-                  CertSecretRef can be given the name of a Secret containing
+-                  either or both of
+-
+-                  - a PEM-encoded client certificate (`tls.crt`) and private
+-                  key (`tls.key`);
+-                  - a PEM-encoded CA certificate (`ca.crt`)
+-
+-                  and whichever are supplied, will be used for connecting to the
+-                  bucket. The client cert and key are useful if you are
+-                  authenticating with a certificate; the CA cert is useful if
+-                  you are using a self-signed server certificate. The Secret must
+-                  be of type `Opaque` or `kubernetes.io/tls`.
+-
+-                  This field is only supported for the `generic` provider.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              endpoint:
+-                description: Endpoint is the object storage address the BucketName
+-                  is located at.
+-                type: string
+-              ignore:
+-                description: |-
+-                  Ignore overrides the set of excluded patterns in the .sourceignore format
+-                  (which is the same as .gitignore). If not provided, a default will be used,
+-                  consult the documentation for your version to find out what those are.
+-                type: string
+-              insecure:
+-                description: Insecure allows connecting to a non-TLS HTTP Endpoint.
+-                type: boolean
+-              interval:
+-                description: |-
+-                  Interval at which the Bucket Endpoint is checked for updates.
+-                  This interval is approximate and may be subject to jitter to ensure
+-                  efficient use of resources.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              prefix:
+-                description: Prefix to use for server-side filtering of files in the
+-                  Bucket.
+-                type: string
+-              provider:
+-                default: generic
+-                description: |-
+-                  Provider of the object storage bucket.
+-                  Defaults to 'generic', which expects an S3 (API) compatible object
+-                  storage.
+-                enum:
+-                - generic
+-                - aws
+-                - gcp
+-                - azure
+-                type: string
+-              proxySecretRef:
+-                description: |-
+-                  ProxySecretRef specifies the Secret containing the proxy configuration
+-                  to use while communicating with the Bucket server.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              region:
+-                description: Region of the Endpoint where the BucketName is located
+-                  in.
+-                type: string
+-              secretRef:
+-                description: |-
+-                  SecretRef specifies the Secret containing authentication credentials
+-                  for the Bucket.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              sts:
+-                description: |-
+-                  STS specifies the required configuration to use a Security Token
+-                  Service for fetching temporary credentials to authenticate in a
+-                  Bucket provider.
+-
+-                  This field is only supported for the `aws` and `generic` providers.
+-                properties:
+-                  certSecretRef:
+-                    description: |-
+-                      CertSecretRef can be given the name of a Secret containing
+-                      either or both of
+-
+-                      - a PEM-encoded client certificate (`tls.crt`) and private
+-                      key (`tls.key`);
+-                      - a PEM-encoded CA certificate (`ca.crt`)
+-
+-                      and whichever are supplied, will be used for connecting to the
+-                      STS endpoint. The client cert and key are useful if you are
+-                      authenticating with a certificate; the CA cert is useful if
+-                      you are using a self-signed server certificate. The Secret must
+-                      be of type `Opaque` or `kubernetes.io/tls`.
+-
+-                      This field is only supported for the `ldap` provider.
+-                    properties:
+-                      name:
+-                        description: Name of the referent.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                  endpoint:
+-                    description: |-
+-                      Endpoint is the HTTP/S endpoint of the Security Token Service from
+-                      where temporary credentials will be fetched.
+-                    pattern: ^(http|https)://.*$
+-                    type: string
+-                  provider:
+-                    description: Provider of the Security Token Service.
+-                    enum:
+-                    - aws
+-                    - ldap
+-                    type: string
+-                  secretRef:
+-                    description: |-
+-                      SecretRef specifies the Secret containing authentication credentials
+-                      for the STS endpoint. This Secret must contain the fields `username`
+-                      and `password` and is supported only for the `ldap` provider.
+-                    properties:
+-                      name:
+-                        description: Name of the referent.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - endpoint
+-                - provider
+-                type: object
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend the reconciliation of this
+-                  Bucket.
+-                type: boolean
+-              timeout:
+-                default: 60s
+-                description: Timeout for fetch operations, defaults to 60s.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+-                type: string
+-            required:
+-            - bucketName
+-            - endpoint
+-            - interval
+-            type: object
+-            x-kubernetes-validations:
+-            - message: STS configuration is only supported for the 'aws' and 'generic'
+-                Bucket providers
+-              rule: self.provider == 'aws' || self.provider == 'generic' || !has(self.sts)
+-            - message: '''aws'' is the only supported STS provider for the ''aws''
+-                Bucket provider'
+-              rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider
+-                == 'aws'
+-            - message: '''ldap'' is the only supported STS provider for the ''generic''
+-                Bucket provider'
+-              rule: self.provider != 'generic' || !has(self.sts) || self.sts.provider
+-                == 'ldap'
+-            - message: spec.sts.secretRef is not required for the 'aws' STS provider
+-              rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.secretRef)'
+-            - message: spec.sts.certSecretRef is not required for the 'aws' STS provider
+-              rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.certSecretRef)'
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: BucketStatus records the observed state of a Bucket.
+-            properties:
+-              artifact:
+-                description: Artifact represents the last successful Bucket reconciliation.
+-                properties:
+-                  digest:
+-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+-                    type: string
+-                  lastUpdateTime:
+-                    description: |-
+-                      LastUpdateTime is the timestamp corresponding to the last update of the
+-                      Artifact.
+-                    format: date-time
+-                    type: string
+-                  metadata:
+-                    additionalProperties:
+-                      type: string
+-                    description: Metadata holds upstream information such as OCI annotations.
+-                    type: object
+-                  path:
+-                    description: |-
+-                      Path is the relative file path of the Artifact. It can be used to locate
+-                      the file in the root of the Artifact storage on the local file system of
+-                      the controller managing the Source.
+-                    type: string
+-                  revision:
+-                    description: |-
+-                      Revision is a human-readable identifier traceable in the origin source
+-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+-                    type: string
+-                  size:
+-                    description: Size is the number of bytes in the file.
+-                    format: int64
+-                    type: integer
+-                  url:
+-                    description: |-
+-                      URL is the HTTP address of the Artifact as exposed by the controller
+-                      managing the Source. It can be used to retrieve the Artifact for
+-                      consumption, e.g. by another controller applying the Artifact contents.
+-                    type: string
+-                required:
+-                - lastUpdateTime
+-                - path
+-                - revision
+-                - url
+-                type: object
+-              conditions:
+-                description: Conditions holds the conditions for the Bucket.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation of
+-                  the Bucket object.
+-                format: int64
+-                type: integer
+-              observedIgnore:
+-                description: |-
+-                  ObservedIgnore is the observed exclusion patterns used for constructing
+-                  the source artifact.
+-                type: string
+-              url:
+-                description: |-
+-                  URL is the dynamic fetch link for the latest Artifact.
+-                  It is provided on a "best effort" basis, and using the precise
+-                  BucketStatus.Artifact data is recommended.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+diff --git a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_gitrepositories.source.toolkit.fluxcd.io.yaml b/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_gitrepositories.source.toolkit.fluxcd.io.yaml
+deleted file mode 100644
+index dbc811f3e3..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_gitrepositories.source.toolkit.fluxcd.io.yaml
++++ /dev/null
+@@ -1,1277 +0,0 @@
+-apiVersion: apiextensions.k8s.io/v1
+-kind: CustomResourceDefinition
+-metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: v0.16.1
+-  labels:
+-    app.kubernetes.io/component: source-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: gitrepositories.source.toolkit.fluxcd.io
+-spec:
+-  group: source.toolkit.fluxcd.io
+-  names:
+-    kind: GitRepository
+-    listKind: GitRepositoryList
+-    plural: gitrepositories
+-    shortNames:
+-    - gitrepo
+-    singular: gitrepository
+-  scope: Namespaced
+-  versions:
+-  - additionalPrinterColumns:
+-    - jsonPath: .spec.url
+-      name: URL
+-      type: string
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    name: v1
+-    schema:
+-      openAPIV3Schema:
+-        description: GitRepository is the Schema for the gitrepositories API.
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: |-
+-              GitRepositorySpec specifies the required configuration to produce an
+-              Artifact for a Git repository.
+-            properties:
+-              ignore:
+-                description: |-
+-                  Ignore overrides the set of excluded patterns in the .sourceignore format
+-                  (which is the same as .gitignore). If not provided, a default will be used,
+-                  consult the documentation for your version to find out what those are.
+-                type: string
+-              include:
+-                description: |-
+-                  Include specifies a list of GitRepository resources which Artifacts
+-                  should be included in the Artifact produced for this GitRepository.
+-                items:
+-                  description: |-
+-                    GitRepositoryInclude specifies a local reference to a GitRepository which
+-                    Artifact (sub-)contents must be included, and where they should be placed.
+-                  properties:
+-                    fromPath:
+-                      description: |-
+-                        FromPath specifies the path to copy contents from, defaults to the root
+-                        of the Artifact.
+-                      type: string
+-                    repository:
+-                      description: |-
+-                        GitRepositoryRef specifies the GitRepository which Artifact contents
+-                        must be included.
+-                      properties:
+-                        name:
+-                          description: Name of the referent.
+-                          type: string
+-                      required:
+-                      - name
+-                      type: object
+-                    toPath:
+-                      description: |-
+-                        ToPath specifies the path to copy contents to, defaults to the name of
+-                        the GitRepositoryRef.
+-                      type: string
+-                  required:
+-                  - repository
+-                  type: object
+-                type: array
+-              interval:
+-                description: |-
+-                  Interval at which the GitRepository URL is checked for updates.
+-                  This interval is approximate and may be subject to jitter to ensure
+-                  efficient use of resources.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              provider:
+-                description: |-
+-                  Provider used for authentication, can be 'azure', 'github', 'generic'.
+-                  When not specified, defaults to 'generic'.
+-                enum:
+-                - generic
+-                - azure
+-                - github
+-                type: string
+-              proxySecretRef:
+-                description: |-
+-                  ProxySecretRef specifies the Secret containing the proxy configuration
+-                  to use while communicating with the Git server.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              recurseSubmodules:
+-                description: |-
+-                  RecurseSubmodules enables the initialization of all submodules within
+-                  the GitRepository as cloned from the URL, using their default settings.
+-                type: boolean
+-              ref:
+-                description: |-
+-                  Reference specifies the Git reference to resolve and monitor for
+-                  changes, defaults to the 'master' branch.
+-                properties:
+-                  branch:
+-                    description: Branch to check out, defaults to 'master' if no other
+-                      field is defined.
+-                    type: string
+-                  commit:
+-                    description: |-
+-                      Commit SHA to check out, takes precedence over all reference fields.
+-
+-                      This can be combined with Branch to shallow clone the branch, in which
+-                      the commit is expected to exist.
+-                    type: string
+-                  name:
+-                    description: |-
+-                      Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
+-
+-                      It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+-                      Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
+-                    type: string
+-                  semver:
+-                    description: SemVer tag expression to check out, takes precedence
+-                      over Tag.
+-                    type: string
+-                  tag:
+-                    description: Tag to check out, takes precedence over Branch.
+-                    type: string
+-                type: object
+-              secretRef:
+-                description: |-
+-                  SecretRef specifies the Secret containing authentication credentials for
+-                  the GitRepository.
+-                  For HTTPS repositories the Secret must contain 'username' and 'password'
+-                  fields for basic auth or 'bearerToken' field for token auth.
+-                  For SSH repositories the Secret must contain 'identity'
+-                  and 'known_hosts' fields.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              sparseCheckout:
+-                description: |-
+-                  SparseCheckout specifies a list of directories to checkout when cloning
+-                  the repository. If specified, only these directories are included in the
+-                  Artifact produced for this GitRepository.
+-                items:
+-                  type: string
+-                type: array
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend the reconciliation of this
+-                  GitRepository.
+-                type: boolean
+-              timeout:
+-                default: 60s
+-                description: Timeout for Git operations like cloning, defaults to
+-                  60s.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+-                type: string
+-              url:
+-                description: URL specifies the Git repository URL, it can be an HTTP/S
+-                  or SSH address.
+-                pattern: ^(http|https|ssh)://.*$
+-                type: string
+-              verify:
+-                description: |-
+-                  Verification specifies the configuration to verify the Git commit
+-                  signature(s).
+-                properties:
+-                  mode:
+-                    default: HEAD
+-                    description: |-
+-                      Mode specifies which Git object(s) should be verified.
+-
+-                      The variants "head" and "HEAD" both imply the same thing, i.e. verify
+-                      the commit that the HEAD of the Git repository points to. The variant
+-                      "head" solely exists to ensure backwards compatibility.
+-                    enum:
+-                    - head
+-                    - HEAD
+-                    - Tag
+-                    - TagAndHEAD
+-                    type: string
+-                  secretRef:
+-                    description: |-
+-                      SecretRef specifies the Secret containing the public keys of trusted Git
+-                      authors.
+-                    properties:
+-                      name:
+-                        description: Name of the referent.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - secretRef
+-                type: object
+-            required:
+-            - interval
+-            - url
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: GitRepositoryStatus records the observed state of a Git repository.
+-            properties:
+-              artifact:
+-                description: Artifact represents the last successful GitRepository
+-                  reconciliation.
+-                properties:
+-                  digest:
+-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+-                    type: string
+-                  lastUpdateTime:
+-                    description: |-
+-                      LastUpdateTime is the timestamp corresponding to the last update of the
+-                      Artifact.
+-                    format: date-time
+-                    type: string
+-                  metadata:
+-                    additionalProperties:
+-                      type: string
+-                    description: Metadata holds upstream information such as OCI annotations.
+-                    type: object
+-                  path:
+-                    description: |-
+-                      Path is the relative file path of the Artifact. It can be used to locate
+-                      the file in the root of the Artifact storage on the local file system of
+-                      the controller managing the Source.
+-                    type: string
+-                  revision:
+-                    description: |-
+-                      Revision is a human-readable identifier traceable in the origin source
+-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+-                    type: string
+-                  size:
+-                    description: Size is the number of bytes in the file.
+-                    format: int64
+-                    type: integer
+-                  url:
+-                    description: |-
+-                      URL is the HTTP address of the Artifact as exposed by the controller
+-                      managing the Source. It can be used to retrieve the Artifact for
+-                      consumption, e.g. by another controller applying the Artifact contents.
+-                    type: string
+-                required:
+-                - lastUpdateTime
+-                - path
+-                - revision
+-                - url
+-                type: object
+-              conditions:
+-                description: Conditions holds the conditions for the GitRepository.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              includedArtifacts:
+-                description: |-
+-                  IncludedArtifacts contains a list of the last successfully included
+-                  Artifacts as instructed by GitRepositorySpec.Include.
+-                items:
+-                  description: Artifact represents the output of a Source reconciliation.
+-                  properties:
+-                    digest:
+-                      description: Digest is the digest of the file in the form of
+-                        '<algorithm>:<checksum>'.
+-                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+-                      type: string
+-                    lastUpdateTime:
+-                      description: |-
+-                        LastUpdateTime is the timestamp corresponding to the last update of the
+-                        Artifact.
+-                      format: date-time
+-                      type: string
+-                    metadata:
+-                      additionalProperties:
+-                        type: string
+-                      description: Metadata holds upstream information such as OCI
+-                        annotations.
+-                      type: object
+-                    path:
+-                      description: |-
+-                        Path is the relative file path of the Artifact. It can be used to locate
+-                        the file in the root of the Artifact storage on the local file system of
+-                        the controller managing the Source.
+-                      type: string
+-                    revision:
+-                      description: |-
+-                        Revision is a human-readable identifier traceable in the origin source
+-                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+-                      type: string
+-                    size:
+-                      description: Size is the number of bytes in the file.
+-                      format: int64
+-                      type: integer
+-                    url:
+-                      description: |-
+-                        URL is the HTTP address of the Artifact as exposed by the controller
+-                        managing the Source. It can be used to retrieve the Artifact for
+-                        consumption, e.g. by another controller applying the Artifact contents.
+-                      type: string
+-                  required:
+-                  - lastUpdateTime
+-                  - path
+-                  - revision
+-                  - url
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: |-
+-                  ObservedGeneration is the last observed generation of the GitRepository
+-                  object.
+-                format: int64
+-                type: integer
+-              observedIgnore:
+-                description: |-
+-                  ObservedIgnore is the observed exclusion patterns used for constructing
+-                  the source artifact.
+-                type: string
+-              observedInclude:
+-                description: |-
+-                  ObservedInclude is the observed list of GitRepository resources used to
+-                  produce the current Artifact.
+-                items:
+-                  description: |-
+-                    GitRepositoryInclude specifies a local reference to a GitRepository which
+-                    Artifact (sub-)contents must be included, and where they should be placed.
+-                  properties:
+-                    fromPath:
+-                      description: |-
+-                        FromPath specifies the path to copy contents from, defaults to the root
+-                        of the Artifact.
+-                      type: string
+-                    repository:
+-                      description: |-
+-                        GitRepositoryRef specifies the GitRepository which Artifact contents
+-                        must be included.
+-                      properties:
+-                        name:
+-                          description: Name of the referent.
+-                          type: string
+-                      required:
+-                      - name
+-                      type: object
+-                    toPath:
+-                      description: |-
+-                        ToPath specifies the path to copy contents to, defaults to the name of
+-                        the GitRepositoryRef.
+-                      type: string
+-                  required:
+-                  - repository
+-                  type: object
+-                type: array
+-              observedRecurseSubmodules:
+-                description: |-
+-                  ObservedRecurseSubmodules is the observed resource submodules
+-                  configuration used to produce the current Artifact.
+-                type: boolean
+-              observedSparseCheckout:
+-                description: |-
+-                  ObservedSparseCheckout is the observed list of directories used to
+-                  produce the current Artifact.
+-                items:
+-                  type: string
+-                type: array
+-              sourceVerificationMode:
+-                description: |-
+-                  SourceVerificationMode is the last used verification mode indicating
+-                  which Git object(s) have been verified.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: true
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .spec.url
+-      name: URL
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    deprecated: true
+-    deprecationWarning: v1beta1 GitRepository is deprecated, upgrade to v1
+-    name: v1beta1
+-    schema:
+-      openAPIV3Schema:
+-        description: GitRepository is the Schema for the gitrepositories API
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: GitRepositorySpec defines the desired state of a Git repository.
+-            properties:
+-              accessFrom:
+-                description: AccessFrom defines an Access Control List for allowing
+-                  cross-namespace references to this object.
+-                properties:
+-                  namespaceSelectors:
+-                    description: |-
+-                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+-                      Items in this list are evaluated using a logical OR operation.
+-                    items:
+-                      description: |-
+-                        NamespaceSelector selects the namespaces to which this ACL applies.
+-                        An empty map of MatchLabels matches all namespaces in a cluster.
+-                      properties:
+-                        matchLabels:
+-                          additionalProperties:
+-                            type: string
+-                          description: |-
+-                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+-                          type: object
+-                      type: object
+-                    type: array
+-                required:
+-                - namespaceSelectors
+-                type: object
+-              gitImplementation:
+-                default: go-git
+-                description: |-
+-                  Determines which git client library to use.
+-                  Defaults to go-git, valid values are ('go-git', 'libgit2').
+-                enum:
+-                - go-git
+-                - libgit2
+-                type: string
+-              ignore:
+-                description: |-
+-                  Ignore overrides the set of excluded patterns in the .sourceignore format
+-                  (which is the same as .gitignore). If not provided, a default will be used,
+-                  consult the documentation for your version to find out what those are.
+-                type: string
+-              include:
+-                description: Extra git repositories to map into the repository
+-                items:
+-                  description: GitRepositoryInclude defines a source with a from and
+-                    to path.
+-                  properties:
+-                    fromPath:
+-                      description: The path to copy contents from, defaults to the
+-                        root directory.
+-                      type: string
+-                    repository:
+-                      description: Reference to a GitRepository to include.
+-                      properties:
+-                        name:
+-                          description: Name of the referent.
+-                          type: string
+-                      required:
+-                      - name
+-                      type: object
+-                    toPath:
+-                      description: The path to copy contents to, defaults to the name
+-                        of the source ref.
+-                      type: string
+-                  required:
+-                  - repository
+-                  type: object
+-                type: array
+-              interval:
+-                description: The interval at which to check for repository updates.
+-                type: string
+-              recurseSubmodules:
+-                description: |-
+-                  When enabled, after the clone is created, initializes all submodules within,
+-                  using their default settings.
+-                  This option is available only when using the 'go-git' GitImplementation.
+-                type: boolean
+-              ref:
+-                description: |-
+-                  The Git reference to checkout and monitor for changes, defaults to
+-                  master branch.
+-                properties:
+-                  branch:
+-                    description: The Git branch to checkout, defaults to master.
+-                    type: string
+-                  commit:
+-                    description: The Git commit SHA to checkout, if specified Tag
+-                      filters will be ignored.
+-                    type: string
+-                  semver:
+-                    description: The Git tag semver expression, takes precedence over
+-                      Tag.
+-                    type: string
+-                  tag:
+-                    description: The Git tag to checkout, takes precedence over Branch.
+-                    type: string
+-                type: object
+-              secretRef:
+-                description: |-
+-                  The secret name containing the Git credentials.
+-                  For HTTPS repositories the secret must contain username and password
+-                  fields.
+-                  For SSH repositories the secret must contain identity and known_hosts
+-                  fields.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              suspend:
+-                description: This flag tells the controller to suspend the reconciliation
+-                  of this source.
+-                type: boolean
+-              timeout:
+-                default: 60s
+-                description: The timeout for remote Git operations like cloning, defaults
+-                  to 60s.
+-                type: string
+-              url:
+-                description: The repository URL, can be a HTTP/S or SSH address.
+-                pattern: ^(http|https|ssh)://.*$
+-                type: string
+-              verify:
+-                description: Verify OpenPGP signature for the Git commit HEAD points
+-                  to.
+-                properties:
+-                  mode:
+-                    description: Mode describes what git object should be verified,
+-                      currently ('head').
+-                    enum:
+-                    - head
+-                    type: string
+-                  secretRef:
+-                    description: The secret name containing the public keys of all
+-                      trusted Git authors.
+-                    properties:
+-                      name:
+-                        description: Name of the referent.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - mode
+-                type: object
+-            required:
+-            - interval
+-            - url
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: GitRepositoryStatus defines the observed state of a Git repository.
+-            properties:
+-              artifact:
+-                description: Artifact represents the output of the last successful
+-                  repository sync.
+-                properties:
+-                  checksum:
+-                    description: Checksum is the SHA256 checksum of the artifact.
+-                    type: string
+-                  lastUpdateTime:
+-                    description: |-
+-                      LastUpdateTime is the timestamp corresponding to the last update of this
+-                      artifact.
+-                    format: date-time
+-                    type: string
+-                  path:
+-                    description: Path is the relative file path of this artifact.
+-                    type: string
+-                  revision:
+-                    description: |-
+-                      Revision is a human readable identifier traceable in the origin source
+-                      system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
+-                      chart version, etc.
+-                    type: string
+-                  url:
+-                    description: URL is the HTTP address of this artifact.
+-                    type: string
+-                required:
+-                - lastUpdateTime
+-                - path
+-                - url
+-                type: object
+-              conditions:
+-                description: Conditions holds the conditions for the GitRepository.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              includedArtifacts:
+-                description: IncludedArtifacts represents the included artifacts from
+-                  the last successful repository sync.
+-                items:
+-                  description: Artifact represents the output of a source synchronisation.
+-                  properties:
+-                    checksum:
+-                      description: Checksum is the SHA256 checksum of the artifact.
+-                      type: string
+-                    lastUpdateTime:
+-                      description: |-
+-                        LastUpdateTime is the timestamp corresponding to the last update of this
+-                        artifact.
+-                      format: date-time
+-                      type: string
+-                    path:
+-                      description: Path is the relative file path of this artifact.
+-                      type: string
+-                    revision:
+-                      description: |-
+-                        Revision is a human readable identifier traceable in the origin source
+-                        system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
+-                        chart version, etc.
+-                      type: string
+-                    url:
+-                      description: URL is the HTTP address of this artifact.
+-                      type: string
+-                  required:
+-                  - lastUpdateTime
+-                  - path
+-                  - url
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation.
+-                format: int64
+-                type: integer
+-              url:
+-                description: |-
+-                  URL is the download link for the artifact output of the last repository
+-                  sync.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .spec.url
+-      name: URL
+-      type: string
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    deprecated: true
+-    deprecationWarning: v1beta2 GitRepository is deprecated, upgrade to v1
+-    name: v1beta2
+-    schema:
+-      openAPIV3Schema:
+-        description: GitRepository is the Schema for the gitrepositories API.
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: |-
+-              GitRepositorySpec specifies the required configuration to produce an
+-              Artifact for a Git repository.
+-            properties:
+-              accessFrom:
+-                description: |-
+-                  AccessFrom specifies an Access Control List for allowing cross-namespace
+-                  references to this object.
+-                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+-                properties:
+-                  namespaceSelectors:
+-                    description: |-
+-                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+-                      Items in this list are evaluated using a logical OR operation.
+-                    items:
+-                      description: |-
+-                        NamespaceSelector selects the namespaces to which this ACL applies.
+-                        An empty map of MatchLabels matches all namespaces in a cluster.
+-                      properties:
+-                        matchLabels:
+-                          additionalProperties:
+-                            type: string
+-                          description: |-
+-                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+-                          type: object
+-                      type: object
+-                    type: array
+-                required:
+-                - namespaceSelectors
+-                type: object
+-              gitImplementation:
+-                default: go-git
+-                description: |-
+-                  GitImplementation specifies which Git client library implementation to
+-                  use. Defaults to 'go-git', valid values are ('go-git', 'libgit2').
+-                  Deprecated: gitImplementation is deprecated now that 'go-git' is the
+-                  only supported implementation.
+-                enum:
+-                - go-git
+-                - libgit2
+-                type: string
+-              ignore:
+-                description: |-
+-                  Ignore overrides the set of excluded patterns in the .sourceignore format
+-                  (which is the same as .gitignore). If not provided, a default will be used,
+-                  consult the documentation for your version to find out what those are.
+-                type: string
+-              include:
+-                description: |-
+-                  Include specifies a list of GitRepository resources which Artifacts
+-                  should be included in the Artifact produced for this GitRepository.
+-                items:
+-                  description: |-
+-                    GitRepositoryInclude specifies a local reference to a GitRepository which
+-                    Artifact (sub-)contents must be included, and where they should be placed.
+-                  properties:
+-                    fromPath:
+-                      description: |-
+-                        FromPath specifies the path to copy contents from, defaults to the root
+-                        of the Artifact.
+-                      type: string
+-                    repository:
+-                      description: |-
+-                        GitRepositoryRef specifies the GitRepository which Artifact contents
+-                        must be included.
+-                      properties:
+-                        name:
+-                          description: Name of the referent.
+-                          type: string
+-                      required:
+-                      - name
+-                      type: object
+-                    toPath:
+-                      description: |-
+-                        ToPath specifies the path to copy contents to, defaults to the name of
+-                        the GitRepositoryRef.
+-                      type: string
+-                  required:
+-                  - repository
+-                  type: object
+-                type: array
+-              interval:
+-                description: Interval at which to check the GitRepository for updates.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              recurseSubmodules:
+-                description: |-
+-                  RecurseSubmodules enables the initialization of all submodules within
+-                  the GitRepository as cloned from the URL, using their default settings.
+-                type: boolean
+-              ref:
+-                description: |-
+-                  Reference specifies the Git reference to resolve and monitor for
+-                  changes, defaults to the 'master' branch.
+-                properties:
+-                  branch:
+-                    description: Branch to check out, defaults to 'master' if no other
+-                      field is defined.
+-                    type: string
+-                  commit:
+-                    description: |-
+-                      Commit SHA to check out, takes precedence over all reference fields.
+-
+-                      This can be combined with Branch to shallow clone the branch, in which
+-                      the commit is expected to exist.
+-                    type: string
+-                  name:
+-                    description: |-
+-                      Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
+-
+-                      It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+-                      Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
+-                    type: string
+-                  semver:
+-                    description: SemVer tag expression to check out, takes precedence
+-                      over Tag.
+-                    type: string
+-                  tag:
+-                    description: Tag to check out, takes precedence over Branch.
+-                    type: string
+-                type: object
+-              secretRef:
+-                description: |-
+-                  SecretRef specifies the Secret containing authentication credentials for
+-                  the GitRepository.
+-                  For HTTPS repositories the Secret must contain 'username' and 'password'
+-                  fields for basic auth or 'bearerToken' field for token auth.
+-                  For SSH repositories the Secret must contain 'identity'
+-                  and 'known_hosts' fields.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend the reconciliation of this
+-                  GitRepository.
+-                type: boolean
+-              timeout:
+-                default: 60s
+-                description: Timeout for Git operations like cloning, defaults to
+-                  60s.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+-                type: string
+-              url:
+-                description: URL specifies the Git repository URL, it can be an HTTP/S
+-                  or SSH address.
+-                pattern: ^(http|https|ssh)://.*$
+-                type: string
+-              verify:
+-                description: |-
+-                  Verification specifies the configuration to verify the Git commit
+-                  signature(s).
+-                properties:
+-                  mode:
+-                    description: Mode specifies what Git object should be verified,
+-                      currently ('head').
+-                    enum:
+-                    - head
+-                    type: string
+-                  secretRef:
+-                    description: |-
+-                      SecretRef specifies the Secret containing the public keys of trusted Git
+-                      authors.
+-                    properties:
+-                      name:
+-                        description: Name of the referent.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - mode
+-                - secretRef
+-                type: object
+-            required:
+-            - interval
+-            - url
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: GitRepositoryStatus records the observed state of a Git repository.
+-            properties:
+-              artifact:
+-                description: Artifact represents the last successful GitRepository
+-                  reconciliation.
+-                properties:
+-                  digest:
+-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+-                    type: string
+-                  lastUpdateTime:
+-                    description: |-
+-                      LastUpdateTime is the timestamp corresponding to the last update of the
+-                      Artifact.
+-                    format: date-time
+-                    type: string
+-                  metadata:
+-                    additionalProperties:
+-                      type: string
+-                    description: Metadata holds upstream information such as OCI annotations.
+-                    type: object
+-                  path:
+-                    description: |-
+-                      Path is the relative file path of the Artifact. It can be used to locate
+-                      the file in the root of the Artifact storage on the local file system of
+-                      the controller managing the Source.
+-                    type: string
+-                  revision:
+-                    description: |-
+-                      Revision is a human-readable identifier traceable in the origin source
+-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+-                    type: string
+-                  size:
+-                    description: Size is the number of bytes in the file.
+-                    format: int64
+-                    type: integer
+-                  url:
+-                    description: |-
+-                      URL is the HTTP address of the Artifact as exposed by the controller
+-                      managing the Source. It can be used to retrieve the Artifact for
+-                      consumption, e.g. by another controller applying the Artifact contents.
+-                    type: string
+-                required:
+-                - lastUpdateTime
+-                - path
+-                - revision
+-                - url
+-                type: object
+-              conditions:
+-                description: Conditions holds the conditions for the GitRepository.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              contentConfigChecksum:
+-                description: |-
+-                  ContentConfigChecksum is a checksum of all the configurations related to
+-                  the content of the source artifact:
+-                   - .spec.ignore
+-                   - .spec.recurseSubmodules
+-                   - .spec.included and the checksum of the included artifacts
+-                  observed in .status.observedGeneration version of the object. This can
+-                  be used to determine if the content of the included repository has
+-                  changed.
+-                  It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`.
+-
+-                  Deprecated: Replaced with explicit fields for observed artifact content
+-                  config in the status.
+-                type: string
+-              includedArtifacts:
+-                description: |-
+-                  IncludedArtifacts contains a list of the last successfully included
+-                  Artifacts as instructed by GitRepositorySpec.Include.
+-                items:
+-                  description: Artifact represents the output of a Source reconciliation.
+-                  properties:
+-                    digest:
+-                      description: Digest is the digest of the file in the form of
+-                        '<algorithm>:<checksum>'.
+-                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+-                      type: string
+-                    lastUpdateTime:
+-                      description: |-
+-                        LastUpdateTime is the timestamp corresponding to the last update of the
+-                        Artifact.
+-                      format: date-time
+-                      type: string
+-                    metadata:
+-                      additionalProperties:
+-                        type: string
+-                      description: Metadata holds upstream information such as OCI
+-                        annotations.
+-                      type: object
+-                    path:
+-                      description: |-
+-                        Path is the relative file path of the Artifact. It can be used to locate
+-                        the file in the root of the Artifact storage on the local file system of
+-                        the controller managing the Source.
+-                      type: string
+-                    revision:
+-                      description: |-
+-                        Revision is a human-readable identifier traceable in the origin source
+-                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+-                      type: string
+-                    size:
+-                      description: Size is the number of bytes in the file.
+-                      format: int64
+-                      type: integer
+-                    url:
+-                      description: |-
+-                        URL is the HTTP address of the Artifact as exposed by the controller
+-                        managing the Source. It can be used to retrieve the Artifact for
+-                        consumption, e.g. by another controller applying the Artifact contents.
+-                      type: string
+-                  required:
+-                  - lastUpdateTime
+-                  - path
+-                  - revision
+-                  - url
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: |-
+-                  ObservedGeneration is the last observed generation of the GitRepository
+-                  object.
+-                format: int64
+-                type: integer
+-              observedIgnore:
+-                description: |-
+-                  ObservedIgnore is the observed exclusion patterns used for constructing
+-                  the source artifact.
+-                type: string
+-              observedInclude:
+-                description: |-
+-                  ObservedInclude is the observed list of GitRepository resources used to
+-                  to produce the current Artifact.
+-                items:
+-                  description: |-
+-                    GitRepositoryInclude specifies a local reference to a GitRepository which
+-                    Artifact (sub-)contents must be included, and where they should be placed.
+-                  properties:
+-                    fromPath:
+-                      description: |-
+-                        FromPath specifies the path to copy contents from, defaults to the root
+-                        of the Artifact.
+-                      type: string
+-                    repository:
+-                      description: |-
+-                        GitRepositoryRef specifies the GitRepository which Artifact contents
+-                        must be included.
+-                      properties:
+-                        name:
+-                          description: Name of the referent.
+-                          type: string
+-                      required:
+-                      - name
+-                      type: object
+-                    toPath:
+-                      description: |-
+-                        ToPath specifies the path to copy contents to, defaults to the name of
+-                        the GitRepositoryRef.
+-                      type: string
+-                  required:
+-                  - repository
+-                  type: object
+-                type: array
+-              observedRecurseSubmodules:
+-                description: |-
+-                  ObservedRecurseSubmodules is the observed resource submodules
+-                  configuration used to produce the current Artifact.
+-                type: boolean
+-              url:
+-                description: |-
+-                  URL is the dynamic fetch link for the latest Artifact.
+-                  It is provided on a "best effort" basis, and using the precise
+-                  GitRepositoryStatus.Artifact data is recommended.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+diff --git a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_helmcharts.source.toolkit.fluxcd.io.yaml b/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_helmcharts.source.toolkit.fluxcd.io.yaml
+deleted file mode 100644
+index 145d6aab65..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_helmcharts.source.toolkit.fluxcd.io.yaml
++++ /dev/null
+@@ -1,980 +0,0 @@
+-apiVersion: apiextensions.k8s.io/v1
+-kind: CustomResourceDefinition
+-metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: v0.16.1
+-  labels:
+-    app.kubernetes.io/component: source-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: helmcharts.source.toolkit.fluxcd.io
+-spec:
+-  group: source.toolkit.fluxcd.io
+-  names:
+-    kind: HelmChart
+-    listKind: HelmChartList
+-    plural: helmcharts
+-    shortNames:
+-    - hc
+-    singular: helmchart
+-  scope: Namespaced
+-  versions:
+-  - additionalPrinterColumns:
+-    - jsonPath: .spec.chart
+-      name: Chart
+-      type: string
+-    - jsonPath: .spec.version
+-      name: Version
+-      type: string
+-    - jsonPath: .spec.sourceRef.kind
+-      name: Source Kind
+-      type: string
+-    - jsonPath: .spec.sourceRef.name
+-      name: Source Name
+-      type: string
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    name: v1
+-    schema:
+-      openAPIV3Schema:
+-        description: HelmChart is the Schema for the helmcharts API.
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: HelmChartSpec specifies the desired state of a Helm chart.
+-            properties:
+-              chart:
+-                description: |-
+-                  Chart is the name or path the Helm chart is available at in the
+-                  SourceRef.
+-                type: string
+-              ignoreMissingValuesFiles:
+-                description: |-
+-                  IgnoreMissingValuesFiles controls whether to silently ignore missing values
+-                  files rather than failing.
+-                type: boolean
+-              interval:
+-                description: |-
+-                  Interval at which the HelmChart SourceRef is checked for updates.
+-                  This interval is approximate and may be subject to jitter to ensure
+-                  efficient use of resources.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              reconcileStrategy:
+-                default: ChartVersion
+-                description: |-
+-                  ReconcileStrategy determines what enables the creation of a new artifact.
+-                  Valid values are ('ChartVersion', 'Revision').
+-                  See the documentation of the values for an explanation on their behavior.
+-                  Defaults to ChartVersion when omitted.
+-                enum:
+-                - ChartVersion
+-                - Revision
+-                type: string
+-              sourceRef:
+-                description: SourceRef is the reference to the Source the chart is
+-                  available at.
+-                properties:
+-                  apiVersion:
+-                    description: APIVersion of the referent.
+-                    type: string
+-                  kind:
+-                    description: |-
+-                      Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
+-                      'Bucket').
+-                    enum:
+-                    - HelmRepository
+-                    - GitRepository
+-                    - Bucket
+-                    type: string
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - kind
+-                - name
+-                type: object
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend the reconciliation of this
+-                  source.
+-                type: boolean
+-              valuesFiles:
+-                description: |-
+-                  ValuesFiles is an alternative list of values files to use as the chart
+-                  values (values.yaml is not included by default), expected to be a
+-                  relative path in the SourceRef.
+-                  Values files are merged in the order of this list with the last file
+-                  overriding the first. Ignored when omitted.
+-                items:
+-                  type: string
+-                type: array
+-              verify:
+-                description: |-
+-                  Verify contains the secret name containing the trusted public keys
+-                  used to verify the signature and specifies which provider to use to check
+-                  whether OCI image is authentic.
+-                  This field is only supported when using HelmRepository source with spec.type 'oci'.
+-                  Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
+-                properties:
+-                  matchOIDCIdentity:
+-                    description: |-
+-                      MatchOIDCIdentity specifies the identity matching criteria to use
+-                      while verifying an OCI artifact which was signed using Cosign keyless
+-                      signing. The artifact's identity is deemed to be verified if any of the
+-                      specified matchers match against the identity.
+-                    items:
+-                      description: |-
+-                        OIDCIdentityMatch specifies options for verifying the certificate identity,
+-                        i.e. the issuer and the subject of the certificate.
+-                      properties:
+-                        issuer:
+-                          description: |-
+-                            Issuer specifies the regex pattern to match against to verify
+-                            the OIDC issuer in the Fulcio certificate. The pattern must be a
+-                            valid Go regular expression.
+-                          type: string
+-                        subject:
+-                          description: |-
+-                            Subject specifies the regex pattern to match against to verify
+-                            the identity subject in the Fulcio certificate. The pattern must
+-                            be a valid Go regular expression.
+-                          type: string
+-                      required:
+-                      - issuer
+-                      - subject
+-                      type: object
+-                    type: array
+-                  provider:
+-                    default: cosign
+-                    description: Provider specifies the technology used to sign the
+-                      OCI Artifact.
+-                    enum:
+-                    - cosign
+-                    - notation
+-                    type: string
+-                  secretRef:
+-                    description: |-
+-                      SecretRef specifies the Kubernetes Secret containing the
+-                      trusted public keys.
+-                    properties:
+-                      name:
+-                        description: Name of the referent.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - provider
+-                type: object
+-              version:
+-                default: '*'
+-                description: |-
+-                  Version is the chart version semver expression, ignored for charts from
+-                  GitRepository and Bucket sources. Defaults to latest when omitted.
+-                type: string
+-            required:
+-            - chart
+-            - interval
+-            - sourceRef
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: HelmChartStatus records the observed state of the HelmChart.
+-            properties:
+-              artifact:
+-                description: Artifact represents the output of the last successful
+-                  reconciliation.
+-                properties:
+-                  digest:
+-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+-                    type: string
+-                  lastUpdateTime:
+-                    description: |-
+-                      LastUpdateTime is the timestamp corresponding to the last update of the
+-                      Artifact.
+-                    format: date-time
+-                    type: string
+-                  metadata:
+-                    additionalProperties:
+-                      type: string
+-                    description: Metadata holds upstream information such as OCI annotations.
+-                    type: object
+-                  path:
+-                    description: |-
+-                      Path is the relative file path of the Artifact. It can be used to locate
+-                      the file in the root of the Artifact storage on the local file system of
+-                      the controller managing the Source.
+-                    type: string
+-                  revision:
+-                    description: |-
+-                      Revision is a human-readable identifier traceable in the origin source
+-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+-                    type: string
+-                  size:
+-                    description: Size is the number of bytes in the file.
+-                    format: int64
+-                    type: integer
+-                  url:
+-                    description: |-
+-                      URL is the HTTP address of the Artifact as exposed by the controller
+-                      managing the Source. It can be used to retrieve the Artifact for
+-                      consumption, e.g. by another controller applying the Artifact contents.
+-                    type: string
+-                required:
+-                - lastUpdateTime
+-                - path
+-                - revision
+-                - url
+-                type: object
+-              conditions:
+-                description: Conditions holds the conditions for the HelmChart.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedChartName:
+-                description: |-
+-                  ObservedChartName is the last observed chart name as specified by the
+-                  resolved chart reference.
+-                type: string
+-              observedGeneration:
+-                description: |-
+-                  ObservedGeneration is the last observed generation of the HelmChart
+-                  object.
+-                format: int64
+-                type: integer
+-              observedSourceArtifactRevision:
+-                description: |-
+-                  ObservedSourceArtifactRevision is the last observed Artifact.Revision
+-                  of the HelmChartSpec.SourceRef.
+-                type: string
+-              observedValuesFiles:
+-                description: |-
+-                  ObservedValuesFiles are the observed value files of the last successful
+-                  reconciliation.
+-                  It matches the chart in the last successfully reconciled artifact.
+-                items:
+-                  type: string
+-                type: array
+-              url:
+-                description: |-
+-                  URL is the dynamic fetch link for the latest Artifact.
+-                  It is provided on a "best effort" basis, and using the precise
+-                  BucketStatus.Artifact data is recommended.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: true
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .spec.chart
+-      name: Chart
+-      type: string
+-    - jsonPath: .spec.version
+-      name: Version
+-      type: string
+-    - jsonPath: .spec.sourceRef.kind
+-      name: Source Kind
+-      type: string
+-    - jsonPath: .spec.sourceRef.name
+-      name: Source Name
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    deprecated: true
+-    deprecationWarning: v1beta1 HelmChart is deprecated, upgrade to v1
+-    name: v1beta1
+-    schema:
+-      openAPIV3Schema:
+-        description: HelmChart is the Schema for the helmcharts API
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: HelmChartSpec defines the desired state of a Helm chart.
+-            properties:
+-              accessFrom:
+-                description: AccessFrom defines an Access Control List for allowing
+-                  cross-namespace references to this object.
+-                properties:
+-                  namespaceSelectors:
+-                    description: |-
+-                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+-                      Items in this list are evaluated using a logical OR operation.
+-                    items:
+-                      description: |-
+-                        NamespaceSelector selects the namespaces to which this ACL applies.
+-                        An empty map of MatchLabels matches all namespaces in a cluster.
+-                      properties:
+-                        matchLabels:
+-                          additionalProperties:
+-                            type: string
+-                          description: |-
+-                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+-                          type: object
+-                      type: object
+-                    type: array
+-                required:
+-                - namespaceSelectors
+-                type: object
+-              chart:
+-                description: The name or path the Helm chart is available at in the
+-                  SourceRef.
+-                type: string
+-              interval:
+-                description: The interval at which to check the Source for updates.
+-                type: string
+-              reconcileStrategy:
+-                default: ChartVersion
+-                description: |-
+-                  Determines what enables the creation of a new artifact. Valid values are
+-                  ('ChartVersion', 'Revision').
+-                  See the documentation of the values for an explanation on their behavior.
+-                  Defaults to ChartVersion when omitted.
+-                enum:
+-                - ChartVersion
+-                - Revision
+-                type: string
+-              sourceRef:
+-                description: The reference to the Source the chart is available at.
+-                properties:
+-                  apiVersion:
+-                    description: APIVersion of the referent.
+-                    type: string
+-                  kind:
+-                    description: |-
+-                      Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
+-                      'Bucket').
+-                    enum:
+-                    - HelmRepository
+-                    - GitRepository
+-                    - Bucket
+-                    type: string
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - kind
+-                - name
+-                type: object
+-              suspend:
+-                description: This flag tells the controller to suspend the reconciliation
+-                  of this source.
+-                type: boolean
+-              valuesFile:
+-                description: |-
+-                  Alternative values file to use as the default chart values, expected to
+-                  be a relative path in the SourceRef. Deprecated in favor of ValuesFiles,
+-                  for backwards compatibility the file defined here is merged before the
+-                  ValuesFiles items. Ignored when omitted.
+-                type: string
+-              valuesFiles:
+-                description: |-
+-                  Alternative list of values files to use as the chart values (values.yaml
+-                  is not included by default), expected to be a relative path in the SourceRef.
+-                  Values files are merged in the order of this list with the last file overriding
+-                  the first. Ignored when omitted.
+-                items:
+-                  type: string
+-                type: array
+-              version:
+-                default: '*'
+-                description: |-
+-                  The chart version semver expression, ignored for charts from GitRepository
+-                  and Bucket sources. Defaults to latest when omitted.
+-                type: string
+-            required:
+-            - chart
+-            - interval
+-            - sourceRef
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: HelmChartStatus defines the observed state of the HelmChart.
+-            properties:
+-              artifact:
+-                description: Artifact represents the output of the last successful
+-                  chart sync.
+-                properties:
+-                  checksum:
+-                    description: Checksum is the SHA256 checksum of the artifact.
+-                    type: string
+-                  lastUpdateTime:
+-                    description: |-
+-                      LastUpdateTime is the timestamp corresponding to the last update of this
+-                      artifact.
+-                    format: date-time
+-                    type: string
+-                  path:
+-                    description: Path is the relative file path of this artifact.
+-                    type: string
+-                  revision:
+-                    description: |-
+-                      Revision is a human readable identifier traceable in the origin source
+-                      system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
+-                      chart version, etc.
+-                    type: string
+-                  url:
+-                    description: URL is the HTTP address of this artifact.
+-                    type: string
+-                required:
+-                - lastUpdateTime
+-                - path
+-                - url
+-                type: object
+-              conditions:
+-                description: Conditions holds the conditions for the HelmChart.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation.
+-                format: int64
+-                type: integer
+-              url:
+-                description: URL is the download link for the last chart pulled.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .spec.chart
+-      name: Chart
+-      type: string
+-    - jsonPath: .spec.version
+-      name: Version
+-      type: string
+-    - jsonPath: .spec.sourceRef.kind
+-      name: Source Kind
+-      type: string
+-    - jsonPath: .spec.sourceRef.name
+-      name: Source Name
+-      type: string
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    deprecated: true
+-    deprecationWarning: v1beta2 HelmChart is deprecated, upgrade to v1
+-    name: v1beta2
+-    schema:
+-      openAPIV3Schema:
+-        description: HelmChart is the Schema for the helmcharts API.
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: HelmChartSpec specifies the desired state of a Helm chart.
+-            properties:
+-              accessFrom:
+-                description: |-
+-                  AccessFrom specifies an Access Control List for allowing cross-namespace
+-                  references to this object.
+-                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+-                properties:
+-                  namespaceSelectors:
+-                    description: |-
+-                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+-                      Items in this list are evaluated using a logical OR operation.
+-                    items:
+-                      description: |-
+-                        NamespaceSelector selects the namespaces to which this ACL applies.
+-                        An empty map of MatchLabels matches all namespaces in a cluster.
+-                      properties:
+-                        matchLabels:
+-                          additionalProperties:
+-                            type: string
+-                          description: |-
+-                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+-                          type: object
+-                      type: object
+-                    type: array
+-                required:
+-                - namespaceSelectors
+-                type: object
+-              chart:
+-                description: |-
+-                  Chart is the name or path the Helm chart is available at in the
+-                  SourceRef.
+-                type: string
+-              ignoreMissingValuesFiles:
+-                description: |-
+-                  IgnoreMissingValuesFiles controls whether to silently ignore missing values
+-                  files rather than failing.
+-                type: boolean
+-              interval:
+-                description: |-
+-                  Interval at which the HelmChart SourceRef is checked for updates.
+-                  This interval is approximate and may be subject to jitter to ensure
+-                  efficient use of resources.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              reconcileStrategy:
+-                default: ChartVersion
+-                description: |-
+-                  ReconcileStrategy determines what enables the creation of a new artifact.
+-                  Valid values are ('ChartVersion', 'Revision').
+-                  See the documentation of the values for an explanation on their behavior.
+-                  Defaults to ChartVersion when omitted.
+-                enum:
+-                - ChartVersion
+-                - Revision
+-                type: string
+-              sourceRef:
+-                description: SourceRef is the reference to the Source the chart is
+-                  available at.
+-                properties:
+-                  apiVersion:
+-                    description: APIVersion of the referent.
+-                    type: string
+-                  kind:
+-                    description: |-
+-                      Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
+-                      'Bucket').
+-                    enum:
+-                    - HelmRepository
+-                    - GitRepository
+-                    - Bucket
+-                    type: string
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - kind
+-                - name
+-                type: object
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend the reconciliation of this
+-                  source.
+-                type: boolean
+-              valuesFile:
+-                description: |-
+-                  ValuesFile is an alternative values file to use as the default chart
+-                  values, expected to be a relative path in the SourceRef. Deprecated in
+-                  favor of ValuesFiles, for backwards compatibility the file specified here
+-                  is merged before the ValuesFiles items. Ignored when omitted.
+-                type: string
+-              valuesFiles:
+-                description: |-
+-                  ValuesFiles is an alternative list of values files to use as the chart
+-                  values (values.yaml is not included by default), expected to be a
+-                  relative path in the SourceRef.
+-                  Values files are merged in the order of this list with the last file
+-                  overriding the first. Ignored when omitted.
+-                items:
+-                  type: string
+-                type: array
+-              verify:
+-                description: |-
+-                  Verify contains the secret name containing the trusted public keys
+-                  used to verify the signature and specifies which provider to use to check
+-                  whether OCI image is authentic.
+-                  This field is only supported when using HelmRepository source with spec.type 'oci'.
+-                  Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
+-                properties:
+-                  matchOIDCIdentity:
+-                    description: |-
+-                      MatchOIDCIdentity specifies the identity matching criteria to use
+-                      while verifying an OCI artifact which was signed using Cosign keyless
+-                      signing. The artifact's identity is deemed to be verified if any of the
+-                      specified matchers match against the identity.
+-                    items:
+-                      description: |-
+-                        OIDCIdentityMatch specifies options for verifying the certificate identity,
+-                        i.e. the issuer and the subject of the certificate.
+-                      properties:
+-                        issuer:
+-                          description: |-
+-                            Issuer specifies the regex pattern to match against to verify
+-                            the OIDC issuer in the Fulcio certificate. The pattern must be a
+-                            valid Go regular expression.
+-                          type: string
+-                        subject:
+-                          description: |-
+-                            Subject specifies the regex pattern to match against to verify
+-                            the identity subject in the Fulcio certificate. The pattern must
+-                            be a valid Go regular expression.
+-                          type: string
+-                      required:
+-                      - issuer
+-                      - subject
+-                      type: object
+-                    type: array
+-                  provider:
+-                    default: cosign
+-                    description: Provider specifies the technology used to sign the
+-                      OCI Artifact.
+-                    enum:
+-                    - cosign
+-                    - notation
+-                    type: string
+-                  secretRef:
+-                    description: |-
+-                      SecretRef specifies the Kubernetes Secret containing the
+-                      trusted public keys.
+-                    properties:
+-                      name:
+-                        description: Name of the referent.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - provider
+-                type: object
+-              version:
+-                default: '*'
+-                description: |-
+-                  Version is the chart version semver expression, ignored for charts from
+-                  GitRepository and Bucket sources. Defaults to latest when omitted.
+-                type: string
+-            required:
+-            - chart
+-            - interval
+-            - sourceRef
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: HelmChartStatus records the observed state of the HelmChart.
+-            properties:
+-              artifact:
+-                description: Artifact represents the output of the last successful
+-                  reconciliation.
+-                properties:
+-                  digest:
+-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+-                    type: string
+-                  lastUpdateTime:
+-                    description: |-
+-                      LastUpdateTime is the timestamp corresponding to the last update of the
+-                      Artifact.
+-                    format: date-time
+-                    type: string
+-                  metadata:
+-                    additionalProperties:
+-                      type: string
+-                    description: Metadata holds upstream information such as OCI annotations.
+-                    type: object
+-                  path:
+-                    description: |-
+-                      Path is the relative file path of the Artifact. It can be used to locate
+-                      the file in the root of the Artifact storage on the local file system of
+-                      the controller managing the Source.
+-                    type: string
+-                  revision:
+-                    description: |-
+-                      Revision is a human-readable identifier traceable in the origin source
+-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+-                    type: string
+-                  size:
+-                    description: Size is the number of bytes in the file.
+-                    format: int64
+-                    type: integer
+-                  url:
+-                    description: |-
+-                      URL is the HTTP address of the Artifact as exposed by the controller
+-                      managing the Source. It can be used to retrieve the Artifact for
+-                      consumption, e.g. by another controller applying the Artifact contents.
+-                    type: string
+-                required:
+-                - lastUpdateTime
+-                - path
+-                - revision
+-                - url
+-                type: object
+-              conditions:
+-                description: Conditions holds the conditions for the HelmChart.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedChartName:
+-                description: |-
+-                  ObservedChartName is the last observed chart name as specified by the
+-                  resolved chart reference.
+-                type: string
+-              observedGeneration:
+-                description: |-
+-                  ObservedGeneration is the last observed generation of the HelmChart
+-                  object.
+-                format: int64
+-                type: integer
+-              observedSourceArtifactRevision:
+-                description: |-
+-                  ObservedSourceArtifactRevision is the last observed Artifact.Revision
+-                  of the HelmChartSpec.SourceRef.
+-                type: string
+-              observedValuesFiles:
+-                description: |-
+-                  ObservedValuesFiles are the observed value files of the last successful
+-                  reconciliation.
+-                  It matches the chart in the last successfully reconciled artifact.
+-                items:
+-                  type: string
+-                type: array
+-              url:
+-                description: |-
+-                  URL is the dynamic fetch link for the latest Artifact.
+-                  It is provided on a "best effort" basis, and using the precise
+-                  BucketStatus.Artifact data is recommended.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+diff --git a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_helmreleases.helm.toolkit.fluxcd.io.yaml b/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_helmreleases.helm.toolkit.fluxcd.io.yaml
+deleted file mode 100644
+index 11ef0f1438..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_helmreleases.helm.toolkit.fluxcd.io.yaml
++++ /dev/null
+@@ -1,3696 +0,0 @@
+-apiVersion: apiextensions.k8s.io/v1
+-kind: CustomResourceDefinition
+-metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: v0.16.1
+-  labels:
+-    app.kubernetes.io/component: helm-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: helmreleases.helm.toolkit.fluxcd.io
+-spec:
+-  group: helm.toolkit.fluxcd.io
+-  names:
+-    kind: HelmRelease
+-    listKind: HelmReleaseList
+-    plural: helmreleases
+-    shortNames:
+-    - hr
+-    singular: helmrelease
+-  scope: Namespaced
+-  versions:
+-  - additionalPrinterColumns:
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    name: v2
+-    schema:
+-      openAPIV3Schema:
+-        description: HelmRelease is the Schema for the helmreleases API
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: HelmReleaseSpec defines the desired state of a Helm release.
+-            properties:
+-              chart:
+-                description: |-
+-                  Chart defines the template of the v1.HelmChart that should be created
+-                  for this HelmRelease.
+-                properties:
+-                  metadata:
+-                    description: ObjectMeta holds the template for metadata like labels
+-                      and annotations.
+-                    properties:
+-                      annotations:
+-                        additionalProperties:
+-                          type: string
+-                        description: |-
+-                          Annotations is an unstructured key value map stored with a resource that may be
+-                          set by external tools to store and retrieve arbitrary metadata. They are not
+-                          queryable and should be preserved when modifying objects.
+-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+-                        type: object
+-                      labels:
+-                        additionalProperties:
+-                          type: string
+-                        description: |-
+-                          Map of string keys and values that can be used to organize and categorize
+-                          (scope and select) objects.
+-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+-                        type: object
+-                    type: object
+-                  spec:
+-                    description: Spec holds the template for the v1.HelmChartSpec
+-                      for this HelmRelease.
+-                    properties:
+-                      chart:
+-                        description: The name or path the Helm chart is available
+-                          at in the SourceRef.
+-                        maxLength: 2048
+-                        minLength: 1
+-                        type: string
+-                      ignoreMissingValuesFiles:
+-                        description: IgnoreMissingValuesFiles controls whether to
+-                          silently ignore missing values files rather than failing.
+-                        type: boolean
+-                      interval:
+-                        description: |-
+-                          Interval at which to check the v1.Source for updates. Defaults to
+-                          'HelmReleaseSpec.Interval'.
+-                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                        type: string
+-                      reconcileStrategy:
+-                        default: ChartVersion
+-                        description: |-
+-                          Determines what enables the creation of a new artifact. Valid values are
+-                          ('ChartVersion', 'Revision').
+-                          See the documentation of the values for an explanation on their behavior.
+-                          Defaults to ChartVersion when omitted.
+-                        enum:
+-                        - ChartVersion
+-                        - Revision
+-                        type: string
+-                      sourceRef:
+-                        description: The name and namespace of the v1.Source the chart
+-                          is available at.
+-                        properties:
+-                          apiVersion:
+-                            description: APIVersion of the referent.
+-                            type: string
+-                          kind:
+-                            description: Kind of the referent.
+-                            enum:
+-                            - HelmRepository
+-                            - GitRepository
+-                            - Bucket
+-                            type: string
+-                          name:
+-                            description: Name of the referent.
+-                            maxLength: 253
+-                            minLength: 1
+-                            type: string
+-                          namespace:
+-                            description: Namespace of the referent.
+-                            maxLength: 63
+-                            minLength: 1
+-                            type: string
+-                        required:
+-                        - kind
+-                        - name
+-                        type: object
+-                      valuesFiles:
+-                        description: |-
+-                          Alternative list of values files to use as the chart values (values.yaml
+-                          is not included by default), expected to be a relative path in the SourceRef.
+-                          Values files are merged in the order of this list with the last file overriding
+-                          the first. Ignored when omitted.
+-                        items:
+-                          type: string
+-                        type: array
+-                      verify:
+-                        description: |-
+-                          Verify contains the secret name containing the trusted public keys
+-                          used to verify the signature and specifies which provider to use to check
+-                          whether OCI image is authentic.
+-                          This field is only supported for OCI sources.
+-                          Chart dependencies, which are not bundled in the umbrella chart artifact,
+-                          are not verified.
+-                        properties:
+-                          provider:
+-                            default: cosign
+-                            description: Provider specifies the technology used to
+-                              sign the OCI Helm chart.
+-                            enum:
+-                            - cosign
+-                            - notation
+-                            type: string
+-                          secretRef:
+-                            description: |-
+-                              SecretRef specifies the Kubernetes Secret containing the
+-                              trusted public keys.
+-                            properties:
+-                              name:
+-                                description: Name of the referent.
+-                                type: string
+-                            required:
+-                            - name
+-                            type: object
+-                        required:
+-                        - provider
+-                        type: object
+-                      version:
+-                        default: '*'
+-                        description: |-
+-                          Version semver expression, ignored for charts from v1.GitRepository and
+-                          v1beta2.Bucket sources. Defaults to latest when omitted.
+-                        type: string
+-                    required:
+-                    - chart
+-                    - sourceRef
+-                    type: object
+-                required:
+-                - spec
+-                type: object
+-              chartRef:
+-                description: |-
+-                  ChartRef holds a reference to a source controller resource containing the
+-                  Helm chart artifact.
+-                properties:
+-                  apiVersion:
+-                    description: APIVersion of the referent.
+-                    type: string
+-                  kind:
+-                    description: Kind of the referent.
+-                    enum:
+-                    - OCIRepository
+-                    - HelmChart
+-                    type: string
+-                  name:
+-                    description: Name of the referent.
+-                    maxLength: 253
+-                    minLength: 1
+-                    type: string
+-                  namespace:
+-                    description: |-
+-                      Namespace of the referent, defaults to the namespace of the Kubernetes
+-                      resource object that contains the reference.
+-                    maxLength: 63
+-                    minLength: 1
+-                    type: string
+-                required:
+-                - kind
+-                - name
+-                type: object
+-              dependsOn:
+-                description: |-
+-                  DependsOn may contain a meta.NamespacedObjectReference slice with
+-                  references to HelmRelease resources that must be ready before this HelmRelease
+-                  can be reconciled.
+-                items:
+-                  description: |-
+-                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+-                    namespace.
+-                  properties:
+-                    name:
+-                      description: Name of the referent.
+-                      type: string
+-                    namespace:
+-                      description: Namespace of the referent, when not specified it
+-                        acts as LocalObjectReference.
+-                      type: string
+-                  required:
+-                  - name
+-                  type: object
+-                type: array
+-              driftDetection:
+-                description: |-
+-                  DriftDetection holds the configuration for detecting and handling
+-                  differences between the manifest in the Helm storage and the resources
+-                  currently existing in the cluster.
+-                properties:
+-                  ignore:
+-                    description: |-
+-                      Ignore contains a list of rules for specifying which changes to ignore
+-                      during diffing.
+-                    items:
+-                      description: |-
+-                        IgnoreRule defines a rule to selectively disregard specific changes during
+-                        the drift detection process.
+-                      properties:
+-                        paths:
+-                          description: |-
+-                            Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from
+-                            consideration in a Kubernetes object.
+-                          items:
+-                            type: string
+-                          type: array
+-                        target:
+-                          description: |-
+-                            Target is a selector for specifying Kubernetes objects to which this
+-                            rule applies.
+-                            If Target is not set, the Paths will be ignored for all Kubernetes
+-                            objects within the manifest of the Helm release.
+-                          properties:
+-                            annotationSelector:
+-                              description: |-
+-                                AnnotationSelector is a string that follows the label selection expression
+-                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                It matches with the resource annotations.
+-                              type: string
+-                            group:
+-                              description: |-
+-                                Group is the API group to select resources from.
+-                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                              type: string
+-                            kind:
+-                              description: |-
+-                                Kind of the API Group to select resources from.
+-                                Together with Group and Version it is capable of unambiguously
+-                                identifying and/or selecting resources.
+-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                              type: string
+-                            labelSelector:
+-                              description: |-
+-                                LabelSelector is a string that follows the label selection expression
+-                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                It matches with the resource labels.
+-                              type: string
+-                            name:
+-                              description: Name to match resources with.
+-                              type: string
+-                            namespace:
+-                              description: Namespace to select resources from.
+-                              type: string
+-                            version:
+-                              description: |-
+-                                Version of the API Group to select resources from.
+-                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                              type: string
+-                          type: object
+-                      required:
+-                      - paths
+-                      type: object
+-                    type: array
+-                  mode:
+-                    description: |-
+-                      Mode defines how differences should be handled between the Helm manifest
+-                      and the manifest currently applied to the cluster.
+-                      If not explicitly set, it defaults to DiffModeDisabled.
+-                    enum:
+-                    - enabled
+-                    - warn
+-                    - disabled
+-                    type: string
+-                type: object
+-              install:
+-                description: Install holds the configuration for Helm install actions
+-                  for this HelmRelease.
+-                properties:
+-                  crds:
+-                    description: |-
+-                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+-                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+-                      `Create` or `CreateReplace`. Default is `Create` and if omitted
+-                      CRDs are installed but not updated.
+-
+-                      Skip: do neither install nor replace (update) any CRDs.
+-
+-                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+-
+-                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+-                      but not deleted.
+-
+-                      By default, CRDs are applied (installed) during Helm install action.
+-                      With this option users can opt in to CRD replace existing CRDs on Helm
+-                      install actions, which is not (yet) natively supported by Helm.
+-                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+-                    enum:
+-                    - Skip
+-                    - Create
+-                    - CreateReplace
+-                    type: string
+-                  createNamespace:
+-                    description: |-
+-                      CreateNamespace tells the Helm install action to create the
+-                      HelmReleaseSpec.TargetNamespace if it does not exist yet.
+-                      On uninstall, the namespace will not be garbage collected.
+-                    type: boolean
+-                  disableHooks:
+-                    description: DisableHooks prevents hooks from running during the
+-                      Helm install action.
+-                    type: boolean
+-                  disableOpenAPIValidation:
+-                    description: |-
+-                      DisableOpenAPIValidation prevents the Helm install action from validating
+-                      rendered templates against the Kubernetes OpenAPI Schema.
+-                    type: boolean
+-                  disableSchemaValidation:
+-                    description: |-
+-                      DisableSchemaValidation prevents the Helm install action from validating
+-                      the values against the JSON Schema.
+-                    type: boolean
+-                  disableTakeOwnership:
+-                    description: |-
+-                      DisableTakeOwnership disables taking ownership of existing resources
+-                      during the Helm install action. Defaults to false.
+-                    type: boolean
+-                  disableWait:
+-                    description: |-
+-                      DisableWait disables the waiting for resources to be ready after a Helm
+-                      install has been performed.
+-                    type: boolean
+-                  disableWaitForJobs:
+-                    description: |-
+-                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+-                      install has been performed.
+-                    type: boolean
+-                  remediation:
+-                    description: |-
+-                      Remediation holds the remediation configuration for when the Helm install
+-                      action for the HelmRelease fails. The default is to not perform any action.
+-                    properties:
+-                      ignoreTestFailures:
+-                        description: |-
+-                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+-                          tests are run after an install action but fail. Defaults to
+-                          'Test.IgnoreFailures'.
+-                        type: boolean
+-                      remediateLastFailure:
+-                        description: |-
+-                          RemediateLastFailure tells the controller to remediate the last failure, when
+-                          no retries remain. Defaults to 'false'.
+-                        type: boolean
+-                      retries:
+-                        description: |-
+-                          Retries is the number of retries that should be attempted on failures before
+-                          bailing. Remediation, using an uninstall, is performed between each attempt.
+-                          Defaults to '0', a negative integer equals to unlimited retries.
+-                        type: integer
+-                    type: object
+-                  replace:
+-                    description: |-
+-                      Replace tells the Helm install action to re-use the 'ReleaseName', but only
+-                      if that name is a deleted release which remains in the history.
+-                    type: boolean
+-                  skipCRDs:
+-                    description: |-
+-                      SkipCRDs tells the Helm install action to not install any CRDs. By default,
+-                      CRDs are installed if not already present.
+-
+-                      Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
+-                    type: boolean
+-                  timeout:
+-                    description: |-
+-                      Timeout is the time to wait for any individual Kubernetes operation (like
+-                      Jobs for hooks) during the performance of a Helm install action. Defaults to
+-                      'HelmReleaseSpec.Timeout'.
+-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                    type: string
+-                type: object
+-              interval:
+-                description: Interval at which to reconcile the Helm release.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              kubeConfig:
+-                description: |-
+-                  KubeConfig for reconciling the HelmRelease on a remote cluster.
+-                  When used in combination with HelmReleaseSpec.ServiceAccountName,
+-                  forces the controller to act on behalf of that Service Account at the
+-                  target cluster.
+-                  If the --default-service-account flag is set, its value will be used as
+-                  a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+-                  is empty.
+-                properties:
+-                  secretRef:
+-                    description: |-
+-                      SecretRef holds the name of a secret that contains a key with
+-                      the kubeconfig file as the value. If no key is set, the key will default
+-                      to 'value'.
+-                      It is recommended that the kubeconfig is self-contained, and the secret
+-                      is regularly updated if credentials such as a cloud-access-token expire.
+-                      Cloud specific `cmd-path` auth helpers will not function without adding
+-                      binaries and credentials to the Pod that is responsible for reconciling
+-                      Kubernetes resources.
+-                    properties:
+-                      key:
+-                        description: Key in the Secret, when not specified an implementation-specific
+-                          default key is used.
+-                        type: string
+-                      name:
+-                        description: Name of the Secret.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - secretRef
+-                type: object
+-              maxHistory:
+-                description: |-
+-                  MaxHistory is the number of revisions saved by Helm for this HelmRelease.
+-                  Use '0' for an unlimited number of revisions; defaults to '5'.
+-                type: integer
+-              persistentClient:
+-                description: |-
+-                  PersistentClient tells the controller to use a persistent Kubernetes
+-                  client for this release. When enabled, the client will be reused for the
+-                  duration of the reconciliation, instead of being created and destroyed
+-                  for each (step of a) Helm action.
+-
+-                  This can improve performance, but may cause issues with some Helm charts
+-                  that for example do create Custom Resource Definitions during installation
+-                  outside Helm's CRD lifecycle hooks, which are then not observed to be
+-                  available by e.g. post-install hooks.
+-
+-                  If not set, it defaults to true.
+-                type: boolean
+-              postRenderers:
+-                description: |-
+-                  PostRenderers holds an array of Helm PostRenderers, which will be applied in order
+-                  of their definition.
+-                items:
+-                  description: PostRenderer contains a Helm PostRenderer specification.
+-                  properties:
+-                    kustomize:
+-                      description: Kustomization to apply as PostRenderer.
+-                      properties:
+-                        images:
+-                          description: |-
+-                            Images is a list of (image name, new name, new tag or digest)
+-                            for changing image names, tags or digests. This can also be achieved with a
+-                            patch, but this operator is simpler to specify.
+-                          items:
+-                            description: Image contains an image name, a new name,
+-                              a new tag or digest, which will replace the original
+-                              name and tag.
+-                            properties:
+-                              digest:
+-                                description: |-
+-                                  Digest is the value used to replace the original image tag.
+-                                  If digest is present NewTag value is ignored.
+-                                type: string
+-                              name:
+-                                description: Name is a tag-less image name.
+-                                type: string
+-                              newName:
+-                                description: NewName is the value used to replace
+-                                  the original name.
+-                                type: string
+-                              newTag:
+-                                description: NewTag is the value used to replace the
+-                                  original tag.
+-                                type: string
+-                            required:
+-                            - name
+-                            type: object
+-                          type: array
+-                        patches:
+-                          description: |-
+-                            Strategic merge and JSON patches, defined as inline YAML objects,
+-                            capable of targeting objects based on kind, label and annotation selectors.
+-                          items:
+-                            description: |-
+-                              Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+-                              be applied to.
+-                            properties:
+-                              patch:
+-                                description: |-
+-                                  Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+-                                  an array of operation objects.
+-                                type: string
+-                              target:
+-                                description: Target points to the resources that the
+-                                  patch document should be applied to.
+-                                properties:
+-                                  annotationSelector:
+-                                    description: |-
+-                                      AnnotationSelector is a string that follows the label selection expression
+-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                      It matches with the resource annotations.
+-                                    type: string
+-                                  group:
+-                                    description: |-
+-                                      Group is the API group to select resources from.
+-                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                                    type: string
+-                                  kind:
+-                                    description: |-
+-                                      Kind of the API Group to select resources from.
+-                                      Together with Group and Version it is capable of unambiguously
+-                                      identifying and/or selecting resources.
+-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                                    type: string
+-                                  labelSelector:
+-                                    description: |-
+-                                      LabelSelector is a string that follows the label selection expression
+-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                      It matches with the resource labels.
+-                                    type: string
+-                                  name:
+-                                    description: Name to match resources with.
+-                                    type: string
+-                                  namespace:
+-                                    description: Namespace to select resources from.
+-                                    type: string
+-                                  version:
+-                                    description: |-
+-                                      Version of the API Group to select resources from.
+-                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                                    type: string
+-                                type: object
+-                            required:
+-                            - patch
+-                            type: object
+-                          type: array
+-                      type: object
+-                  type: object
+-                type: array
+-              releaseName:
+-                description: |-
+-                  ReleaseName used for the Helm release. Defaults to a composition of
+-                  '[TargetNamespace-]Name'.
+-                maxLength: 53
+-                minLength: 1
+-                type: string
+-              rollback:
+-                description: Rollback holds the configuration for Helm rollback actions
+-                  for this HelmRelease.
+-                properties:
+-                  cleanupOnFail:
+-                    description: |-
+-                      CleanupOnFail allows deletion of new resources created during the Helm
+-                      rollback action when it fails.
+-                    type: boolean
+-                  disableHooks:
+-                    description: DisableHooks prevents hooks from running during the
+-                      Helm rollback action.
+-                    type: boolean
+-                  disableWait:
+-                    description: |-
+-                      DisableWait disables the waiting for resources to be ready after a Helm
+-                      rollback has been performed.
+-                    type: boolean
+-                  disableWaitForJobs:
+-                    description: |-
+-                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+-                      rollback has been performed.
+-                    type: boolean
+-                  force:
+-                    description: Force forces resource updates through a replacement
+-                      strategy.
+-                    type: boolean
+-                  recreate:
+-                    description: Recreate performs pod restarts for the resource if
+-                      applicable.
+-                    type: boolean
+-                  timeout:
+-                    description: |-
+-                      Timeout is the time to wait for any individual Kubernetes operation (like
+-                      Jobs for hooks) during the performance of a Helm rollback action. Defaults to
+-                      'HelmReleaseSpec.Timeout'.
+-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                    type: string
+-                type: object
+-              serviceAccountName:
+-                description: |-
+-                  The name of the Kubernetes service account to impersonate
+-                  when reconciling this HelmRelease.
+-                maxLength: 253
+-                minLength: 1
+-                type: string
+-              storageNamespace:
+-                description: |-
+-                  StorageNamespace used for the Helm storage.
+-                  Defaults to the namespace of the HelmRelease.
+-                maxLength: 63
+-                minLength: 1
+-                type: string
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend reconciliation for this HelmRelease,
+-                  it does not apply to already started reconciliations. Defaults to false.
+-                type: boolean
+-              targetNamespace:
+-                description: |-
+-                  TargetNamespace to target when performing operations for the HelmRelease.
+-                  Defaults to the namespace of the HelmRelease.
+-                maxLength: 63
+-                minLength: 1
+-                type: string
+-              test:
+-                description: Test holds the configuration for Helm test actions for
+-                  this HelmRelease.
+-                properties:
+-                  enable:
+-                    description: |-
+-                      Enable enables Helm test actions for this HelmRelease after an Helm install
+-                      or upgrade action has been performed.
+-                    type: boolean
+-                  filters:
+-                    description: Filters is a list of tests to run or exclude from
+-                      running.
+-                    items:
+-                      description: Filter holds the configuration for individual Helm
+-                        test filters.
+-                      properties:
+-                        exclude:
+-                          description: Exclude specifies whether the named test should
+-                            be excluded.
+-                          type: boolean
+-                        name:
+-                          description: Name is the name of the test.
+-                          maxLength: 253
+-                          minLength: 1
+-                          type: string
+-                      required:
+-                      - name
+-                      type: object
+-                    type: array
+-                  ignoreFailures:
+-                    description: |-
+-                      IgnoreFailures tells the controller to skip remediation when the Helm tests
+-                      are run but fail. Can be overwritten for tests run after install or upgrade
+-                      actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
+-                    type: boolean
+-                  timeout:
+-                    description: |-
+-                      Timeout is the time to wait for any individual Kubernetes operation during
+-                      the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
+-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                    type: string
+-                type: object
+-              timeout:
+-                description: |-
+-                  Timeout is the time to wait for any individual Kubernetes operation (like Jobs
+-                  for hooks) during the performance of a Helm action. Defaults to '5m0s'.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              uninstall:
+-                description: Uninstall holds the configuration for Helm uninstall
+-                  actions for this HelmRelease.
+-                properties:
+-                  deletionPropagation:
+-                    default: background
+-                    description: |-
+-                      DeletionPropagation specifies the deletion propagation policy when
+-                      a Helm uninstall is performed.
+-                    enum:
+-                    - background
+-                    - foreground
+-                    - orphan
+-                    type: string
+-                  disableHooks:
+-                    description: DisableHooks prevents hooks from running during the
+-                      Helm rollback action.
+-                    type: boolean
+-                  disableWait:
+-                    description: |-
+-                      DisableWait disables waiting for all the resources to be deleted after
+-                      a Helm uninstall is performed.
+-                    type: boolean
+-                  keepHistory:
+-                    description: |-
+-                      KeepHistory tells Helm to remove all associated resources and mark the
+-                      release as deleted, but retain the release history.
+-                    type: boolean
+-                  timeout:
+-                    description: |-
+-                      Timeout is the time to wait for any individual Kubernetes operation (like
+-                      Jobs for hooks) during the performance of a Helm uninstall action. Defaults
+-                      to 'HelmReleaseSpec.Timeout'.
+-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                    type: string
+-                type: object
+-              upgrade:
+-                description: Upgrade holds the configuration for Helm upgrade actions
+-                  for this HelmRelease.
+-                properties:
+-                  cleanupOnFail:
+-                    description: |-
+-                      CleanupOnFail allows deletion of new resources created during the Helm
+-                      upgrade action when it fails.
+-                    type: boolean
+-                  crds:
+-                    description: |-
+-                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+-                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+-                      `Create` or `CreateReplace`. Default is `Skip` and if omitted
+-                      CRDs are neither installed nor upgraded.
+-
+-                      Skip: do neither install nor replace (update) any CRDs.
+-
+-                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+-
+-                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+-                      but not deleted.
+-
+-                      By default, CRDs are not applied during Helm upgrade action. With this
+-                      option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
+-                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+-                    enum:
+-                    - Skip
+-                    - Create
+-                    - CreateReplace
+-                    type: string
+-                  disableHooks:
+-                    description: DisableHooks prevents hooks from running during the
+-                      Helm upgrade action.
+-                    type: boolean
+-                  disableOpenAPIValidation:
+-                    description: |-
+-                      DisableOpenAPIValidation prevents the Helm upgrade action from validating
+-                      rendered templates against the Kubernetes OpenAPI Schema.
+-                    type: boolean
+-                  disableSchemaValidation:
+-                    description: |-
+-                      DisableSchemaValidation prevents the Helm upgrade action from validating
+-                      the values against the JSON Schema.
+-                    type: boolean
+-                  disableTakeOwnership:
+-                    description: |-
+-                      DisableTakeOwnership disables taking ownership of existing resources
+-                      during the Helm upgrade action. Defaults to false.
+-                    type: boolean
+-                  disableWait:
+-                    description: |-
+-                      DisableWait disables the waiting for resources to be ready after a Helm
+-                      upgrade has been performed.
+-                    type: boolean
+-                  disableWaitForJobs:
+-                    description: |-
+-                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+-                      upgrade has been performed.
+-                    type: boolean
+-                  force:
+-                    description: Force forces resource updates through a replacement
+-                      strategy.
+-                    type: boolean
+-                  preserveValues:
+-                    description: |-
+-                      PreserveValues will make Helm reuse the last release's values and merge in
+-                      overrides from 'Values'. Setting this flag makes the HelmRelease
+-                      non-declarative.
+-                    type: boolean
+-                  remediation:
+-                    description: |-
+-                      Remediation holds the remediation configuration for when the Helm upgrade
+-                      action for the HelmRelease fails. The default is to not perform any action.
+-                    properties:
+-                      ignoreTestFailures:
+-                        description: |-
+-                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+-                          tests are run after an upgrade action but fail.
+-                          Defaults to 'Test.IgnoreFailures'.
+-                        type: boolean
+-                      remediateLastFailure:
+-                        description: |-
+-                          RemediateLastFailure tells the controller to remediate the last failure, when
+-                          no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
+-                        type: boolean
+-                      retries:
+-                        description: |-
+-                          Retries is the number of retries that should be attempted on failures before
+-                          bailing. Remediation, using 'Strategy', is performed between each attempt.
+-                          Defaults to '0', a negative integer equals to unlimited retries.
+-                        type: integer
+-                      strategy:
+-                        description: Strategy to use for failure remediation. Defaults
+-                          to 'rollback'.
+-                        enum:
+-                        - rollback
+-                        - uninstall
+-                        type: string
+-                    type: object
+-                  timeout:
+-                    description: |-
+-                      Timeout is the time to wait for any individual Kubernetes operation (like
+-                      Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
+-                      'HelmReleaseSpec.Timeout'.
+-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                    type: string
+-                type: object
+-              values:
+-                description: Values holds the values for this Helm release.
+-                x-kubernetes-preserve-unknown-fields: true
+-              valuesFrom:
+-                description: |-
+-                  ValuesFrom holds references to resources containing Helm values for this HelmRelease,
+-                  and information about how they should be merged.
+-                items:
+-                  description: |-
+-                    ValuesReference contains a reference to a resource containing Helm values,
+-                    and optionally the key they can be found at.
+-                  properties:
+-                    kind:
+-                      description: Kind of the values referent, valid values are ('Secret',
+-                        'ConfigMap').
+-                      enum:
+-                      - Secret
+-                      - ConfigMap
+-                      type: string
+-                    name:
+-                      description: |-
+-                        Name of the values referent. Should reside in the same namespace as the
+-                        referring resource.
+-                      maxLength: 253
+-                      minLength: 1
+-                      type: string
+-                    optional:
+-                      description: |-
+-                        Optional marks this ValuesReference as optional. When set, a not found error
+-                        for the values reference is ignored, but any ValuesKey, TargetPath or
+-                        transient error will still result in a reconciliation failure.
+-                      type: boolean
+-                    targetPath:
+-                      description: |-
+-                        TargetPath is the YAML dot notation path the value should be merged at. When
+-                        set, the ValuesKey is expected to be a single flat value. Defaults to 'None',
+-                        which results in the values getting merged at the root.
+-                      maxLength: 250
+-                      pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
+-                      type: string
+-                    valuesKey:
+-                      description: |-
+-                        ValuesKey is the data key where the values.yaml or a specific value can be
+-                        found at. Defaults to 'values.yaml'.
+-                      maxLength: 253
+-                      pattern: ^[\-._a-zA-Z0-9]+$
+-                      type: string
+-                  required:
+-                  - kind
+-                  - name
+-                  type: object
+-                type: array
+-            required:
+-            - interval
+-            type: object
+-            x-kubernetes-validations:
+-            - message: either chart or chartRef must be set
+-              rule: (has(self.chart) && !has(self.chartRef)) || (!has(self.chart)
+-                && has(self.chartRef))
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: HelmReleaseStatus defines the observed state of a HelmRelease.
+-            properties:
+-              conditions:
+-                description: Conditions holds the conditions for the HelmRelease.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              failures:
+-                description: |-
+-                  Failures is the reconciliation failure count against the latest desired
+-                  state. It is reset after a successful reconciliation.
+-                format: int64
+-                type: integer
+-              helmChart:
+-                description: |-
+-                  HelmChart is the namespaced name of the HelmChart resource created by
+-                  the controller for the HelmRelease.
+-                type: string
+-              history:
+-                description: |-
+-                  History holds the history of Helm releases performed for this HelmRelease
+-                  up to the last successfully completed release.
+-                items:
+-                  description: |-
+-                    Snapshot captures a point-in-time copy of the status information for a Helm release,
+-                    as managed by the controller.
+-                  properties:
+-                    apiVersion:
+-                      description: |-
+-                        APIVersion is the API version of the Snapshot.
+-                        Provisional: when the calculation method of the Digest field is changed,
+-                        this field will be used to distinguish between the old and new methods.
+-                      type: string
+-                    appVersion:
+-                      description: AppVersion is the chart app version of the release
+-                        object in storage.
+-                      type: string
+-                    chartName:
+-                      description: ChartName is the chart name of the release object
+-                        in storage.
+-                      type: string
+-                    chartVersion:
+-                      description: |-
+-                        ChartVersion is the chart version of the release object in
+-                        storage.
+-                      type: string
+-                    configDigest:
+-                      description: |-
+-                        ConfigDigest is the checksum of the config (better known as
+-                        "values") of the release object in storage.
+-                        It has the format of `<algo>:<checksum>`.
+-                      type: string
+-                    deleted:
+-                      description: Deleted is when the release was deleted.
+-                      format: date-time
+-                      type: string
+-                    digest:
+-                      description: |-
+-                        Digest is the checksum of the release object in storage.
+-                        It has the format of `<algo>:<checksum>`.
+-                      type: string
+-                    firstDeployed:
+-                      description: FirstDeployed is when the release was first deployed.
+-                      format: date-time
+-                      type: string
+-                    lastDeployed:
+-                      description: LastDeployed is when the release was last deployed.
+-                      format: date-time
+-                      type: string
+-                    name:
+-                      description: Name is the name of the release.
+-                      type: string
+-                    namespace:
+-                      description: Namespace is the namespace the release is deployed
+-                        to.
+-                      type: string
+-                    ociDigest:
+-                      description: OCIDigest is the digest of the OCI artifact associated
+-                        with the release.
+-                      type: string
+-                    status:
+-                      description: Status is the current state of the release.
+-                      type: string
+-                    testHooks:
+-                      additionalProperties:
+-                        description: |-
+-                          TestHookStatus holds the status information for a test hook as observed
+-                          to be run by the controller.
+-                        properties:
+-                          lastCompleted:
+-                            description: LastCompleted is the time the test hook last
+-                              completed.
+-                            format: date-time
+-                            type: string
+-                          lastStarted:
+-                            description: LastStarted is the time the test hook was
+-                              last started.
+-                            format: date-time
+-                            type: string
+-                          phase:
+-                            description: Phase the test hook was observed to be in.
+-                            type: string
+-                        type: object
+-                      description: |-
+-                        TestHooks is the list of test hooks for the release as observed to be
+-                        run by the controller.
+-                      type: object
+-                    version:
+-                      description: Version is the version of the release object in
+-                        storage.
+-                      type: integer
+-                  required:
+-                  - chartName
+-                  - chartVersion
+-                  - configDigest
+-                  - digest
+-                  - firstDeployed
+-                  - lastDeployed
+-                  - name
+-                  - namespace
+-                  - status
+-                  - version
+-                  type: object
+-                type: array
+-              installFailures:
+-                description: |-
+-                  InstallFailures is the install failure count against the latest desired
+-                  state. It is reset after a successful reconciliation.
+-                format: int64
+-                type: integer
+-              lastAttemptedConfigDigest:
+-                description: |-
+-                  LastAttemptedConfigDigest is the digest for the config (better known as
+-                  "values") of the last reconciliation attempt.
+-                type: string
+-              lastAttemptedGeneration:
+-                description: |-
+-                  LastAttemptedGeneration is the last generation the controller attempted
+-                  to reconcile.
+-                format: int64
+-                type: integer
+-              lastAttemptedReleaseAction:
+-                description: |-
+-                  LastAttemptedReleaseAction is the last release action performed for this
+-                  HelmRelease. It is used to determine the active remediation strategy.
+-                enum:
+-                - install
+-                - upgrade
+-                type: string
+-              lastAttemptedRevision:
+-                description: |-
+-                  LastAttemptedRevision is the Source revision of the last reconciliation
+-                  attempt. For OCIRepository  sources, the 12 first characters of the digest are
+-                  appended to the chart version e.g. "1.2.3+1234567890ab".
+-                type: string
+-              lastAttemptedRevisionDigest:
+-                description: |-
+-                  LastAttemptedRevisionDigest is the digest of the last reconciliation attempt.
+-                  This is only set for OCIRepository sources.
+-                type: string
+-              lastAttemptedValuesChecksum:
+-                description: |-
+-                  LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
+-                  reconciliation attempt.
+-                  Deprecated: Use LastAttemptedConfigDigest instead.
+-                type: string
+-              lastHandledForceAt:
+-                description: |-
+-                  LastHandledForceAt holds the value of the most recent force request
+-                  value, so a change of the annotation value can be detected.
+-                type: string
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              lastHandledResetAt:
+-                description: |-
+-                  LastHandledResetAt holds the value of the most recent reset request
+-                  value, so a change of the annotation value can be detected.
+-                type: string
+-              lastReleaseRevision:
+-                description: |-
+-                  LastReleaseRevision is the revision of the last successful Helm release.
+-                  Deprecated: Use History instead.
+-                type: integer
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation.
+-                format: int64
+-                type: integer
+-              observedPostRenderersDigest:
+-                description: |-
+-                  ObservedPostRenderersDigest is the digest for the post-renderers of
+-                  the last successful reconciliation attempt.
+-                type: string
+-              storageNamespace:
+-                description: |-
+-                  StorageNamespace is the namespace of the Helm release storage for the
+-                  current release.
+-                maxLength: 63
+-                minLength: 1
+-                type: string
+-              upgradeFailures:
+-                description: |-
+-                  UpgradeFailures is the upgrade failure count against the latest desired
+-                  state. It is reset after a successful reconciliation.
+-                format: int64
+-                type: integer
+-            type: object
+-        type: object
+-    served: true
+-    storage: true
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    deprecated: true
+-    deprecationWarning: v2beta1 HelmRelease is deprecated, upgrade to v2
+-    name: v2beta1
+-    schema:
+-      openAPIV3Schema:
+-        description: HelmRelease is the Schema for the helmreleases API
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: HelmReleaseSpec defines the desired state of a Helm release.
+-            properties:
+-              chart:
+-                description: |-
+-                  Chart defines the template of the v1beta2.HelmChart that should be created
+-                  for this HelmRelease.
+-                properties:
+-                  metadata:
+-                    description: ObjectMeta holds the template for metadata like labels
+-                      and annotations.
+-                    properties:
+-                      annotations:
+-                        additionalProperties:
+-                          type: string
+-                        description: |-
+-                          Annotations is an unstructured key value map stored with a resource that may be
+-                          set by external tools to store and retrieve arbitrary metadata. They are not
+-                          queryable and should be preserved when modifying objects.
+-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+-                        type: object
+-                      labels:
+-                        additionalProperties:
+-                          type: string
+-                        description: |-
+-                          Map of string keys and values that can be used to organize and categorize
+-                          (scope and select) objects.
+-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+-                        type: object
+-                    type: object
+-                  spec:
+-                    description: Spec holds the template for the v1beta2.HelmChartSpec
+-                      for this HelmRelease.
+-                    properties:
+-                      chart:
+-                        description: The name or path the Helm chart is available
+-                          at in the SourceRef.
+-                        type: string
+-                      interval:
+-                        description: |-
+-                          Interval at which to check the v1beta2.Source for updates. Defaults to
+-                          'HelmReleaseSpec.Interval'.
+-                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                        type: string
+-                      reconcileStrategy:
+-                        default: ChartVersion
+-                        description: |-
+-                          Determines what enables the creation of a new artifact. Valid values are
+-                          ('ChartVersion', 'Revision').
+-                          See the documentation of the values for an explanation on their behavior.
+-                          Defaults to ChartVersion when omitted.
+-                        enum:
+-                        - ChartVersion
+-                        - Revision
+-                        type: string
+-                      sourceRef:
+-                        description: The name and namespace of the v1beta2.Source
+-                          the chart is available at.
+-                        properties:
+-                          apiVersion:
+-                            description: APIVersion of the referent.
+-                            type: string
+-                          kind:
+-                            description: Kind of the referent.
+-                            enum:
+-                            - HelmRepository
+-                            - GitRepository
+-                            - Bucket
+-                            type: string
+-                          name:
+-                            description: Name of the referent.
+-                            maxLength: 253
+-                            minLength: 1
+-                            type: string
+-                          namespace:
+-                            description: Namespace of the referent.
+-                            maxLength: 63
+-                            minLength: 1
+-                            type: string
+-                        required:
+-                        - kind
+-                        - name
+-                        type: object
+-                      valuesFile:
+-                        description: |-
+-                          Alternative values file to use as the default chart values, expected to
+-                          be a relative path in the SourceRef. Deprecated in favor of ValuesFiles,
+-                          for backwards compatibility the file defined here is merged before the
+-                          ValuesFiles items. Ignored when omitted.
+-                        type: string
+-                      valuesFiles:
+-                        description: |-
+-                          Alternative list of values files to use as the chart values (values.yaml
+-                          is not included by default), expected to be a relative path in the SourceRef.
+-                          Values files are merged in the order of this list with the last file overriding
+-                          the first. Ignored when omitted.
+-                        items:
+-                          type: string
+-                        type: array
+-                      verify:
+-                        description: |-
+-                          Verify contains the secret name containing the trusted public keys
+-                          used to verify the signature and specifies which provider to use to check
+-                          whether OCI image is authentic.
+-                          This field is only supported for OCI sources.
+-                          Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
+-                        properties:
+-                          provider:
+-                            default: cosign
+-                            description: Provider specifies the technology used to
+-                              sign the OCI Helm chart.
+-                            enum:
+-                            - cosign
+-                            type: string
+-                          secretRef:
+-                            description: |-
+-                              SecretRef specifies the Kubernetes Secret containing the
+-                              trusted public keys.
+-                            properties:
+-                              name:
+-                                description: Name of the referent.
+-                                type: string
+-                            required:
+-                            - name
+-                            type: object
+-                        required:
+-                        - provider
+-                        type: object
+-                      version:
+-                        default: '*'
+-                        description: |-
+-                          Version semver expression, ignored for charts from v1beta2.GitRepository and
+-                          v1beta2.Bucket sources. Defaults to latest when omitted.
+-                        type: string
+-                    required:
+-                    - chart
+-                    - sourceRef
+-                    type: object
+-                required:
+-                - spec
+-                type: object
+-              chartRef:
+-                description: |-
+-                  ChartRef holds a reference to a source controller resource containing the
+-                  Helm chart artifact.
+-
+-                  Note: this field is provisional to the v2 API, and not actively used
+-                  by v2beta1 HelmReleases.
+-                properties:
+-                  apiVersion:
+-                    description: APIVersion of the referent.
+-                    type: string
+-                  kind:
+-                    description: Kind of the referent.
+-                    enum:
+-                    - OCIRepository
+-                    - HelmChart
+-                    type: string
+-                  name:
+-                    description: Name of the referent.
+-                    maxLength: 253
+-                    minLength: 1
+-                    type: string
+-                  namespace:
+-                    description: |-
+-                      Namespace of the referent, defaults to the namespace of the Kubernetes
+-                      resource object that contains the reference.
+-                    maxLength: 63
+-                    minLength: 1
+-                    type: string
+-                required:
+-                - kind
+-                - name
+-                type: object
+-              dependsOn:
+-                description: |-
+-                  DependsOn may contain a meta.NamespacedObjectReference slice with
+-                  references to HelmRelease resources that must be ready before this HelmRelease
+-                  can be reconciled.
+-                items:
+-                  description: |-
+-                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+-                    namespace.
+-                  properties:
+-                    name:
+-                      description: Name of the referent.
+-                      type: string
+-                    namespace:
+-                      description: Namespace of the referent, when not specified it
+-                        acts as LocalObjectReference.
+-                      type: string
+-                  required:
+-                  - name
+-                  type: object
+-                type: array
+-              driftDetection:
+-                description: |-
+-                  DriftDetection holds the configuration for detecting and handling
+-                  differences between the manifest in the Helm storage and the resources
+-                  currently existing in the cluster.
+-
+-                  Note: this field is provisional to the v2beta2 API, and not actively used
+-                  by v2beta1 HelmReleases.
+-                properties:
+-                  ignore:
+-                    description: |-
+-                      Ignore contains a list of rules for specifying which changes to ignore
+-                      during diffing.
+-                    items:
+-                      description: |-
+-                        IgnoreRule defines a rule to selectively disregard specific changes during
+-                        the drift detection process.
+-                      properties:
+-                        paths:
+-                          description: |-
+-                            Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from
+-                            consideration in a Kubernetes object.
+-                          items:
+-                            type: string
+-                          type: array
+-                        target:
+-                          description: |-
+-                            Target is a selector for specifying Kubernetes objects to which this
+-                            rule applies.
+-                            If Target is not set, the Paths will be ignored for all Kubernetes
+-                            objects within the manifest of the Helm release.
+-                          properties:
+-                            annotationSelector:
+-                              description: |-
+-                                AnnotationSelector is a string that follows the label selection expression
+-                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                It matches with the resource annotations.
+-                              type: string
+-                            group:
+-                              description: |-
+-                                Group is the API group to select resources from.
+-                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                              type: string
+-                            kind:
+-                              description: |-
+-                                Kind of the API Group to select resources from.
+-                                Together with Group and Version it is capable of unambiguously
+-                                identifying and/or selecting resources.
+-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                              type: string
+-                            labelSelector:
+-                              description: |-
+-                                LabelSelector is a string that follows the label selection expression
+-                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                It matches with the resource labels.
+-                              type: string
+-                            name:
+-                              description: Name to match resources with.
+-                              type: string
+-                            namespace:
+-                              description: Namespace to select resources from.
+-                              type: string
+-                            version:
+-                              description: |-
+-                                Version of the API Group to select resources from.
+-                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                              type: string
+-                          type: object
+-                      required:
+-                      - paths
+-                      type: object
+-                    type: array
+-                  mode:
+-                    description: |-
+-                      Mode defines how differences should be handled between the Helm manifest
+-                      and the manifest currently applied to the cluster.
+-                      If not explicitly set, it defaults to DiffModeDisabled.
+-                    enum:
+-                    - enabled
+-                    - warn
+-                    - disabled
+-                    type: string
+-                type: object
+-              install:
+-                description: Install holds the configuration for Helm install actions
+-                  for this HelmRelease.
+-                properties:
+-                  crds:
+-                    description: |-
+-                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+-                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+-                      `Create` or `CreateReplace`. Default is `Create` and if omitted
+-                      CRDs are installed but not updated.
+-
+-                      Skip: do neither install nor replace (update) any CRDs.
+-
+-                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+-
+-                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+-                      but not deleted.
+-
+-                      By default, CRDs are applied (installed) during Helm install action.
+-                      With this option users can opt-in to CRD replace existing CRDs on Helm
+-                      install actions, which is not (yet) natively supported by Helm.
+-                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+-                    enum:
+-                    - Skip
+-                    - Create
+-                    - CreateReplace
+-                    type: string
+-                  createNamespace:
+-                    description: |-
+-                      CreateNamespace tells the Helm install action to create the
+-                      HelmReleaseSpec.TargetNamespace if it does not exist yet.
+-                      On uninstall, the namespace will not be garbage collected.
+-                    type: boolean
+-                  disableHooks:
+-                    description: DisableHooks prevents hooks from running during the
+-                      Helm install action.
+-                    type: boolean
+-                  disableOpenAPIValidation:
+-                    description: |-
+-                      DisableOpenAPIValidation prevents the Helm install action from validating
+-                      rendered templates against the Kubernetes OpenAPI Schema.
+-                    type: boolean
+-                  disableWait:
+-                    description: |-
+-                      DisableWait disables the waiting for resources to be ready after a Helm
+-                      install has been performed.
+-                    type: boolean
+-                  disableWaitForJobs:
+-                    description: |-
+-                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+-                      install has been performed.
+-                    type: boolean
+-                  remediation:
+-                    description: |-
+-                      Remediation holds the remediation configuration for when the Helm install
+-                      action for the HelmRelease fails. The default is to not perform any action.
+-                    properties:
+-                      ignoreTestFailures:
+-                        description: |-
+-                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+-                          tests are run after an install action but fail. Defaults to
+-                          'Test.IgnoreFailures'.
+-                        type: boolean
+-                      remediateLastFailure:
+-                        description: |-
+-                          RemediateLastFailure tells the controller to remediate the last failure, when
+-                          no retries remain. Defaults to 'false'.
+-                        type: boolean
+-                      retries:
+-                        description: |-
+-                          Retries is the number of retries that should be attempted on failures before
+-                          bailing. Remediation, using an uninstall, is performed between each attempt.
+-                          Defaults to '0', a negative integer equals to unlimited retries.
+-                        type: integer
+-                    type: object
+-                  replace:
+-                    description: |-
+-                      Replace tells the Helm install action to re-use the 'ReleaseName', but only
+-                      if that name is a deleted release which remains in the history.
+-                    type: boolean
+-                  skipCRDs:
+-                    description: |-
+-                      SkipCRDs tells the Helm install action to not install any CRDs. By default,
+-                      CRDs are installed if not already present.
+-
+-                      Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
+-                    type: boolean
+-                  timeout:
+-                    description: |-
+-                      Timeout is the time to wait for any individual Kubernetes operation (like
+-                      Jobs for hooks) during the performance of a Helm install action. Defaults to
+-                      'HelmReleaseSpec.Timeout'.
+-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                    type: string
+-                type: object
+-              interval:
+-                description: |-
+-                  Interval at which to reconcile the Helm release.
+-                  This interval is approximate and may be subject to jitter to ensure
+-                  efficient use of resources.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              kubeConfig:
+-                description: |-
+-                  KubeConfig for reconciling the HelmRelease on a remote cluster.
+-                  When used in combination with HelmReleaseSpec.ServiceAccountName,
+-                  forces the controller to act on behalf of that Service Account at the
+-                  target cluster.
+-                  If the --default-service-account flag is set, its value will be used as
+-                  a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+-                  is empty.
+-                properties:
+-                  secretRef:
+-                    description: |-
+-                      SecretRef holds the name of a secret that contains a key with
+-                      the kubeconfig file as the value. If no key is set, the key will default
+-                      to 'value'.
+-                      It is recommended that the kubeconfig is self-contained, and the secret
+-                      is regularly updated if credentials such as a cloud-access-token expire.
+-                      Cloud specific `cmd-path` auth helpers will not function without adding
+-                      binaries and credentials to the Pod that is responsible for reconciling
+-                      Kubernetes resources.
+-                    properties:
+-                      key:
+-                        description: Key in the Secret, when not specified an implementation-specific
+-                          default key is used.
+-                        type: string
+-                      name:
+-                        description: Name of the Secret.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - secretRef
+-                type: object
+-              maxHistory:
+-                description: |-
+-                  MaxHistory is the number of revisions saved by Helm for this HelmRelease.
+-                  Use '0' for an unlimited number of revisions; defaults to '10'.
+-                type: integer
+-              persistentClient:
+-                description: |-
+-                  PersistentClient tells the controller to use a persistent Kubernetes
+-                  client for this release. When enabled, the client will be reused for the
+-                  duration of the reconciliation, instead of being created and destroyed
+-                  for each (step of a) Helm action.
+-
+-                  This can improve performance, but may cause issues with some Helm charts
+-                  that for example do create Custom Resource Definitions during installation
+-                  outside Helm's CRD lifecycle hooks, which are then not observed to be
+-                  available by e.g. post-install hooks.
+-
+-                  If not set, it defaults to true.
+-                type: boolean
+-              postRenderers:
+-                description: |-
+-                  PostRenderers holds an array of Helm PostRenderers, which will be applied in order
+-                  of their definition.
+-                items:
+-                  description: PostRenderer contains a Helm PostRenderer specification.
+-                  properties:
+-                    kustomize:
+-                      description: Kustomization to apply as PostRenderer.
+-                      properties:
+-                        images:
+-                          description: |-
+-                            Images is a list of (image name, new name, new tag or digest)
+-                            for changing image names, tags or digests. This can also be achieved with a
+-                            patch, but this operator is simpler to specify.
+-                          items:
+-                            description: Image contains an image name, a new name,
+-                              a new tag or digest, which will replace the original
+-                              name and tag.
+-                            properties:
+-                              digest:
+-                                description: |-
+-                                  Digest is the value used to replace the original image tag.
+-                                  If digest is present NewTag value is ignored.
+-                                type: string
+-                              name:
+-                                description: Name is a tag-less image name.
+-                                type: string
+-                              newName:
+-                                description: NewName is the value used to replace
+-                                  the original name.
+-                                type: string
+-                              newTag:
+-                                description: NewTag is the value used to replace the
+-                                  original tag.
+-                                type: string
+-                            required:
+-                            - name
+-                            type: object
+-                          type: array
+-                        patches:
+-                          description: |-
+-                            Strategic merge and JSON patches, defined as inline YAML objects,
+-                            capable of targeting objects based on kind, label and annotation selectors.
+-                          items:
+-                            description: |-
+-                              Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+-                              be applied to.
+-                            properties:
+-                              patch:
+-                                description: |-
+-                                  Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+-                                  an array of operation objects.
+-                                type: string
+-                              target:
+-                                description: Target points to the resources that the
+-                                  patch document should be applied to.
+-                                properties:
+-                                  annotationSelector:
+-                                    description: |-
+-                                      AnnotationSelector is a string that follows the label selection expression
+-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                      It matches with the resource annotations.
+-                                    type: string
+-                                  group:
+-                                    description: |-
+-                                      Group is the API group to select resources from.
+-                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                                    type: string
+-                                  kind:
+-                                    description: |-
+-                                      Kind of the API Group to select resources from.
+-                                      Together with Group and Version it is capable of unambiguously
+-                                      identifying and/or selecting resources.
+-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                                    type: string
+-                                  labelSelector:
+-                                    description: |-
+-                                      LabelSelector is a string that follows the label selection expression
+-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                      It matches with the resource labels.
+-                                    type: string
+-                                  name:
+-                                    description: Name to match resources with.
+-                                    type: string
+-                                  namespace:
+-                                    description: Namespace to select resources from.
+-                                    type: string
+-                                  version:
+-                                    description: |-
+-                                      Version of the API Group to select resources from.
+-                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                                    type: string
+-                                type: object
+-                            required:
+-                            - patch
+-                            type: object
+-                          type: array
+-                        patchesJson6902:
+-                          description: JSON 6902 patches, defined as inline YAML objects.
+-                          items:
+-                            description: JSON6902Patch contains a JSON6902 patch and
+-                              the target the patch should be applied to.
+-                            properties:
+-                              patch:
+-                                description: Patch contains the JSON6902 patch document
+-                                  with an array of operation objects.
+-                                items:
+-                                  description: |-
+-                                    JSON6902 is a JSON6902 operation object.
+-                                    https://datatracker.ietf.org/doc/html/rfc6902#section-4
+-                                  properties:
+-                                    from:
+-                                      description: |-
+-                                        From contains a JSON-pointer value that references a location within the target document where the operation is
+-                                        performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
+-                                      type: string
+-                                    op:
+-                                      description: |-
+-                                        Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
+-                                        "test".
+-                                        https://datatracker.ietf.org/doc/html/rfc6902#section-4
+-                                      enum:
+-                                      - test
+-                                      - remove
+-                                      - add
+-                                      - replace
+-                                      - move
+-                                      - copy
+-                                      type: string
+-                                    path:
+-                                      description: |-
+-                                        Path contains the JSON-pointer value that references a location within the target document where the operation
+-                                        is performed. The meaning of the value depends on the value of Op.
+-                                      type: string
+-                                    value:
+-                                      description: |-
+-                                        Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
+-                                        account by all operations.
+-                                      x-kubernetes-preserve-unknown-fields: true
+-                                  required:
+-                                  - op
+-                                  - path
+-                                  type: object
+-                                type: array
+-                              target:
+-                                description: Target points to the resources that the
+-                                  patch document should be applied to.
+-                                properties:
+-                                  annotationSelector:
+-                                    description: |-
+-                                      AnnotationSelector is a string that follows the label selection expression
+-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                      It matches with the resource annotations.
+-                                    type: string
+-                                  group:
+-                                    description: |-
+-                                      Group is the API group to select resources from.
+-                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                                    type: string
+-                                  kind:
+-                                    description: |-
+-                                      Kind of the API Group to select resources from.
+-                                      Together with Group and Version it is capable of unambiguously
+-                                      identifying and/or selecting resources.
+-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                                    type: string
+-                                  labelSelector:
+-                                    description: |-
+-                                      LabelSelector is a string that follows the label selection expression
+-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                      It matches with the resource labels.
+-                                    type: string
+-                                  name:
+-                                    description: Name to match resources with.
+-                                    type: string
+-                                  namespace:
+-                                    description: Namespace to select resources from.
+-                                    type: string
+-                                  version:
+-                                    description: |-
+-                                      Version of the API Group to select resources from.
+-                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                                    type: string
+-                                type: object
+-                            required:
+-                            - patch
+-                            - target
+-                            type: object
+-                          type: array
+-                        patchesStrategicMerge:
+-                          description: Strategic merge patches, defined as inline
+-                            YAML objects.
+-                          items:
+-                            x-kubernetes-preserve-unknown-fields: true
+-                          type: array
+-                      type: object
+-                  type: object
+-                type: array
+-              releaseName:
+-                description: |-
+-                  ReleaseName used for the Helm release. Defaults to a composition of
+-                  '[TargetNamespace-]Name'.
+-                maxLength: 53
+-                minLength: 1
+-                type: string
+-              rollback:
+-                description: Rollback holds the configuration for Helm rollback actions
+-                  for this HelmRelease.
+-                properties:
+-                  cleanupOnFail:
+-                    description: |-
+-                      CleanupOnFail allows deletion of new resources created during the Helm
+-                      rollback action when it fails.
+-                    type: boolean
+-                  disableHooks:
+-                    description: DisableHooks prevents hooks from running during the
+-                      Helm rollback action.
+-                    type: boolean
+-                  disableWait:
+-                    description: |-
+-                      DisableWait disables the waiting for resources to be ready after a Helm
+-                      rollback has been performed.
+-                    type: boolean
+-                  disableWaitForJobs:
+-                    description: |-
+-                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+-                      rollback has been performed.
+-                    type: boolean
+-                  force:
+-                    description: Force forces resource updates through a replacement
+-                      strategy.
+-                    type: boolean
+-                  recreate:
+-                    description: Recreate performs pod restarts for the resource if
+-                      applicable.
+-                    type: boolean
+-                  timeout:
+-                    description: |-
+-                      Timeout is the time to wait for any individual Kubernetes operation (like
+-                      Jobs for hooks) during the performance of a Helm rollback action. Defaults to
+-                      'HelmReleaseSpec.Timeout'.
+-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                    type: string
+-                type: object
+-              serviceAccountName:
+-                description: |-
+-                  The name of the Kubernetes service account to impersonate
+-                  when reconciling this HelmRelease.
+-                type: string
+-              storageNamespace:
+-                description: |-
+-                  StorageNamespace used for the Helm storage.
+-                  Defaults to the namespace of the HelmRelease.
+-                maxLength: 63
+-                minLength: 1
+-                type: string
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend reconciliation for this HelmRelease,
+-                  it does not apply to already started reconciliations. Defaults to false.
+-                type: boolean
+-              targetNamespace:
+-                description: |-
+-                  TargetNamespace to target when performing operations for the HelmRelease.
+-                  Defaults to the namespace of the HelmRelease.
+-                maxLength: 63
+-                minLength: 1
+-                type: string
+-              test:
+-                description: Test holds the configuration for Helm test actions for
+-                  this HelmRelease.
+-                properties:
+-                  enable:
+-                    description: |-
+-                      Enable enables Helm test actions for this HelmRelease after an Helm install
+-                      or upgrade action has been performed.
+-                    type: boolean
+-                  ignoreFailures:
+-                    description: |-
+-                      IgnoreFailures tells the controller to skip remediation when the Helm tests
+-                      are run but fail. Can be overwritten for tests run after install or upgrade
+-                      actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
+-                    type: boolean
+-                  timeout:
+-                    description: |-
+-                      Timeout is the time to wait for any individual Kubernetes operation during
+-                      the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
+-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                    type: string
+-                type: object
+-              timeout:
+-                description: |-
+-                  Timeout is the time to wait for any individual Kubernetes operation (like Jobs
+-                  for hooks) during the performance of a Helm action. Defaults to '5m0s'.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              uninstall:
+-                description: Uninstall holds the configuration for Helm uninstall
+-                  actions for this HelmRelease.
+-                properties:
+-                  deletionPropagation:
+-                    default: background
+-                    description: |-
+-                      DeletionPropagation specifies the deletion propagation policy when
+-                      a Helm uninstall is performed.
+-                    enum:
+-                    - background
+-                    - foreground
+-                    - orphan
+-                    type: string
+-                  disableHooks:
+-                    description: DisableHooks prevents hooks from running during the
+-                      Helm rollback action.
+-                    type: boolean
+-                  disableWait:
+-                    description: |-
+-                      DisableWait disables waiting for all the resources to be deleted after
+-                      a Helm uninstall is performed.
+-                    type: boolean
+-                  keepHistory:
+-                    description: |-
+-                      KeepHistory tells Helm to remove all associated resources and mark the
+-                      release as deleted, but retain the release history.
+-                    type: boolean
+-                  timeout:
+-                    description: |-
+-                      Timeout is the time to wait for any individual Kubernetes operation (like
+-                      Jobs for hooks) during the performance of a Helm uninstall action. Defaults
+-                      to 'HelmReleaseSpec.Timeout'.
+-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                    type: string
+-                type: object
+-              upgrade:
+-                description: Upgrade holds the configuration for Helm upgrade actions
+-                  for this HelmRelease.
+-                properties:
+-                  cleanupOnFail:
+-                    description: |-
+-                      CleanupOnFail allows deletion of new resources created during the Helm
+-                      upgrade action when it fails.
+-                    type: boolean
+-                  crds:
+-                    description: |-
+-                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+-                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+-                      `Create` or `CreateReplace`. Default is `Skip` and if omitted
+-                      CRDs are neither installed nor upgraded.
+-
+-                      Skip: do neither install nor replace (update) any CRDs.
+-
+-                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+-
+-                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+-                      but not deleted.
+-
+-                      By default, CRDs are not applied during Helm upgrade action. With this
+-                      option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
+-                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+-                    enum:
+-                    - Skip
+-                    - Create
+-                    - CreateReplace
+-                    type: string
+-                  disableHooks:
+-                    description: DisableHooks prevents hooks from running during the
+-                      Helm upgrade action.
+-                    type: boolean
+-                  disableOpenAPIValidation:
+-                    description: |-
+-                      DisableOpenAPIValidation prevents the Helm upgrade action from validating
+-                      rendered templates against the Kubernetes OpenAPI Schema.
+-                    type: boolean
+-                  disableWait:
+-                    description: |-
+-                      DisableWait disables the waiting for resources to be ready after a Helm
+-                      upgrade has been performed.
+-                    type: boolean
+-                  disableWaitForJobs:
+-                    description: |-
+-                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+-                      upgrade has been performed.
+-                    type: boolean
+-                  force:
+-                    description: Force forces resource updates through a replacement
+-                      strategy.
+-                    type: boolean
+-                  preserveValues:
+-                    description: |-
+-                      PreserveValues will make Helm reuse the last release's values and merge in
+-                      overrides from 'Values'. Setting this flag makes the HelmRelease
+-                      non-declarative.
+-                    type: boolean
+-                  remediation:
+-                    description: |-
+-                      Remediation holds the remediation configuration for when the Helm upgrade
+-                      action for the HelmRelease fails. The default is to not perform any action.
+-                    properties:
+-                      ignoreTestFailures:
+-                        description: |-
+-                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+-                          tests are run after an upgrade action but fail.
+-                          Defaults to 'Test.IgnoreFailures'.
+-                        type: boolean
+-                      remediateLastFailure:
+-                        description: |-
+-                          RemediateLastFailure tells the controller to remediate the last failure, when
+-                          no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
+-                        type: boolean
+-                      retries:
+-                        description: |-
+-                          Retries is the number of retries that should be attempted on failures before
+-                          bailing. Remediation, using 'Strategy', is performed between each attempt.
+-                          Defaults to '0', a negative integer equals to unlimited retries.
+-                        type: integer
+-                      strategy:
+-                        description: Strategy to use for failure remediation. Defaults
+-                          to 'rollback'.
+-                        enum:
+-                        - rollback
+-                        - uninstall
+-                        type: string
+-                    type: object
+-                  timeout:
+-                    description: |-
+-                      Timeout is the time to wait for any individual Kubernetes operation (like
+-                      Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
+-                      'HelmReleaseSpec.Timeout'.
+-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                    type: string
+-                type: object
+-              values:
+-                description: Values holds the values for this Helm release.
+-                x-kubernetes-preserve-unknown-fields: true
+-              valuesFrom:
+-                description: |-
+-                  ValuesFrom holds references to resources containing Helm values for this HelmRelease,
+-                  and information about how they should be merged.
+-                items:
+-                  description: |-
+-                    ValuesReference contains a reference to a resource containing Helm values,
+-                    and optionally the key they can be found at.
+-                  properties:
+-                    kind:
+-                      description: Kind of the values referent, valid values are ('Secret',
+-                        'ConfigMap').
+-                      enum:
+-                      - Secret
+-                      - ConfigMap
+-                      type: string
+-                    name:
+-                      description: |-
+-                        Name of the values referent. Should reside in the same namespace as the
+-                        referring resource.
+-                      maxLength: 253
+-                      minLength: 1
+-                      type: string
+-                    optional:
+-                      description: |-
+-                        Optional marks this ValuesReference as optional. When set, a not found error
+-                        for the values reference is ignored, but any ValuesKey, TargetPath or
+-                        transient error will still result in a reconciliation failure.
+-                      type: boolean
+-                    targetPath:
+-                      description: |-
+-                        TargetPath is the YAML dot notation path the value should be merged at. When
+-                        set, the ValuesKey is expected to be a single flat value. Defaults to 'None',
+-                        which results in the values getting merged at the root.
+-                      maxLength: 250
+-                      pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
+-                      type: string
+-                    valuesKey:
+-                      description: |-
+-                        ValuesKey is the data key where the values.yaml or a specific value can be
+-                        found at. Defaults to 'values.yaml'.
+-                        When set, must be a valid Data Key, consisting of alphanumeric characters,
+-                        '-', '_' or '.'.
+-                      maxLength: 253
+-                      pattern: ^[\-._a-zA-Z0-9]+$
+-                      type: string
+-                  required:
+-                  - kind
+-                  - name
+-                  type: object
+-                type: array
+-            required:
+-            - chart
+-            - interval
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: HelmReleaseStatus defines the observed state of a HelmRelease.
+-            properties:
+-              conditions:
+-                description: Conditions holds the conditions for the HelmRelease.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              failures:
+-                description: |-
+-                  Failures is the reconciliation failure count against the latest desired
+-                  state. It is reset after a successful reconciliation.
+-                format: int64
+-                type: integer
+-              helmChart:
+-                description: |-
+-                  HelmChart is the namespaced name of the HelmChart resource created by
+-                  the controller for the HelmRelease.
+-                type: string
+-              history:
+-                description: |-
+-                  History holds the history of Helm releases performed for this HelmRelease
+-                  up to the last successfully completed release.
+-
+-                  Note: this field is provisional to the v2beta2 API, and not actively used
+-                  by v2beta1 HelmReleases.
+-                items:
+-                  description: |-
+-                    Snapshot captures a point-in-time copy of the status information for a Helm release,
+-                    as managed by the controller.
+-                  properties:
+-                    apiVersion:
+-                      description: |-
+-                        APIVersion is the API version of the Snapshot.
+-                        Provisional: when the calculation method of the Digest field is changed,
+-                        this field will be used to distinguish between the old and new methods.
+-                      type: string
+-                    appVersion:
+-                      description: AppVersion is the chart app version of the release
+-                        object in storage.
+-                      type: string
+-                    chartName:
+-                      description: ChartName is the chart name of the release object
+-                        in storage.
+-                      type: string
+-                    chartVersion:
+-                      description: |-
+-                        ChartVersion is the chart version of the release object in
+-                        storage.
+-                      type: string
+-                    configDigest:
+-                      description: |-
+-                        ConfigDigest is the checksum of the config (better known as
+-                        "values") of the release object in storage.
+-                        It has the format of `<algo>:<checksum>`.
+-                      type: string
+-                    deleted:
+-                      description: Deleted is when the release was deleted.
+-                      format: date-time
+-                      type: string
+-                    digest:
+-                      description: |-
+-                        Digest is the checksum of the release object in storage.
+-                        It has the format of `<algo>:<checksum>`.
+-                      type: string
+-                    firstDeployed:
+-                      description: FirstDeployed is when the release was first deployed.
+-                      format: date-time
+-                      type: string
+-                    lastDeployed:
+-                      description: LastDeployed is when the release was last deployed.
+-                      format: date-time
+-                      type: string
+-                    name:
+-                      description: Name is the name of the release.
+-                      type: string
+-                    namespace:
+-                      description: Namespace is the namespace the release is deployed
+-                        to.
+-                      type: string
+-                    ociDigest:
+-                      description: OCIDigest is the digest of the OCI artifact associated
+-                        with the release.
+-                      type: string
+-                    status:
+-                      description: Status is the current state of the release.
+-                      type: string
+-                    testHooks:
+-                      additionalProperties:
+-                        description: |-
+-                          TestHookStatus holds the status information for a test hook as observed
+-                          to be run by the controller.
+-                        properties:
+-                          lastCompleted:
+-                            description: LastCompleted is the time the test hook last
+-                              completed.
+-                            format: date-time
+-                            type: string
+-                          lastStarted:
+-                            description: LastStarted is the time the test hook was
+-                              last started.
+-                            format: date-time
+-                            type: string
+-                          phase:
+-                            description: Phase the test hook was observed to be in.
+-                            type: string
+-                        type: object
+-                      description: |-
+-                        TestHooks is the list of test hooks for the release as observed to be
+-                        run by the controller.
+-                      type: object
+-                    version:
+-                      description: Version is the version of the release object in
+-                        storage.
+-                      type: integer
+-                  required:
+-                  - chartName
+-                  - chartVersion
+-                  - configDigest
+-                  - digest
+-                  - firstDeployed
+-                  - lastDeployed
+-                  - name
+-                  - namespace
+-                  - status
+-                  - version
+-                  type: object
+-                type: array
+-              installFailures:
+-                description: |-
+-                  InstallFailures is the install failure count against the latest desired
+-                  state. It is reset after a successful reconciliation.
+-                format: int64
+-                type: integer
+-              lastAppliedRevision:
+-                description: LastAppliedRevision is the revision of the last successfully
+-                  applied source.
+-                type: string
+-              lastAttemptedConfigDigest:
+-                description: |-
+-                  LastAttemptedConfigDigest is the digest for the config (better known as
+-                  "values") of the last reconciliation attempt.
+-
+-                  Note: this field is provisional to the v2beta2 API, and not actively used
+-                  by v2beta1 HelmReleases.
+-                type: string
+-              lastAttemptedGeneration:
+-                description: |-
+-                  LastAttemptedGeneration is the last generation the controller attempted
+-                  to reconcile.
+-
+-                  Note: this field is provisional to the v2beta2 API, and not actively used
+-                  by v2beta1 HelmReleases.
+-                format: int64
+-                type: integer
+-              lastAttemptedReleaseAction:
+-                description: |-
+-                  LastAttemptedReleaseAction is the last release action performed for this
+-                  HelmRelease. It is used to determine the active remediation strategy.
+-
+-                  Note: this field is provisional to the v2beta2 API, and not actively used
+-                  by v2beta1 HelmReleases.
+-                type: string
+-              lastAttemptedRevision:
+-                description: LastAttemptedRevision is the revision of the last reconciliation
+-                  attempt.
+-                type: string
+-              lastAttemptedValuesChecksum:
+-                description: |-
+-                  LastAttemptedValuesChecksum is the SHA1 checksum of the values of the last
+-                  reconciliation attempt.
+-                type: string
+-              lastHandledForceAt:
+-                description: |-
+-                  LastHandledForceAt holds the value of the most recent force request
+-                  value, so a change of the annotation value can be detected.
+-
+-                  Note: this field is provisional to the v2beta2 API, and not actively used
+-                  by v2beta1 HelmReleases.
+-                type: string
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              lastHandledResetAt:
+-                description: |-
+-                  LastHandledResetAt holds the value of the most recent reset request
+-                  value, so a change of the annotation value can be detected.
+-
+-                  Note: this field is provisional to the v2beta2 API, and not actively used
+-                  by v2beta1 HelmReleases.
+-                type: string
+-              lastReleaseRevision:
+-                description: LastReleaseRevision is the revision of the last successful
+-                  Helm release.
+-                type: integer
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation.
+-                format: int64
+-                type: integer
+-              observedPostRenderersDigest:
+-                description: |-
+-                  ObservedPostRenderersDigest is the digest for the post-renderers of
+-                  the last successful reconciliation attempt.
+-                type: string
+-              storageNamespace:
+-                description: |-
+-                  StorageNamespace is the namespace of the Helm release storage for the
+-                  current release.
+-
+-                  Note: this field is provisional to the v2beta2 API, and not actively used
+-                  by v2beta1 HelmReleases.
+-                type: string
+-              upgradeFailures:
+-                description: |-
+-                  UpgradeFailures is the upgrade failure count against the latest desired
+-                  state. It is reset after a successful reconciliation.
+-                format: int64
+-                type: integer
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    deprecated: true
+-    deprecationWarning: v2beta2 HelmRelease is deprecated, upgrade to v2
+-    name: v2beta2
+-    schema:
+-      openAPIV3Schema:
+-        description: HelmRelease is the Schema for the helmreleases API
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: HelmReleaseSpec defines the desired state of a Helm release.
+-            properties:
+-              chart:
+-                description: |-
+-                  Chart defines the template of the v1beta2.HelmChart that should be created
+-                  for this HelmRelease.
+-                properties:
+-                  metadata:
+-                    description: ObjectMeta holds the template for metadata like labels
+-                      and annotations.
+-                    properties:
+-                      annotations:
+-                        additionalProperties:
+-                          type: string
+-                        description: |-
+-                          Annotations is an unstructured key value map stored with a resource that may be
+-                          set by external tools to store and retrieve arbitrary metadata. They are not
+-                          queryable and should be preserved when modifying objects.
+-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+-                        type: object
+-                      labels:
+-                        additionalProperties:
+-                          type: string
+-                        description: |-
+-                          Map of string keys and values that can be used to organize and categorize
+-                          (scope and select) objects.
+-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+-                        type: object
+-                    type: object
+-                  spec:
+-                    description: Spec holds the template for the v1beta2.HelmChartSpec
+-                      for this HelmRelease.
+-                    properties:
+-                      chart:
+-                        description: The name or path the Helm chart is available
+-                          at in the SourceRef.
+-                        maxLength: 2048
+-                        minLength: 1
+-                        type: string
+-                      ignoreMissingValuesFiles:
+-                        description: IgnoreMissingValuesFiles controls whether to
+-                          silently ignore missing values files rather than failing.
+-                        type: boolean
+-                      interval:
+-                        description: |-
+-                          Interval at which to check the v1.Source for updates. Defaults to
+-                          'HelmReleaseSpec.Interval'.
+-                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                        type: string
+-                      reconcileStrategy:
+-                        default: ChartVersion
+-                        description: |-
+-                          Determines what enables the creation of a new artifact. Valid values are
+-                          ('ChartVersion', 'Revision').
+-                          See the documentation of the values for an explanation on their behavior.
+-                          Defaults to ChartVersion when omitted.
+-                        enum:
+-                        - ChartVersion
+-                        - Revision
+-                        type: string
+-                      sourceRef:
+-                        description: The name and namespace of the v1.Source the chart
+-                          is available at.
+-                        properties:
+-                          apiVersion:
+-                            description: APIVersion of the referent.
+-                            type: string
+-                          kind:
+-                            description: Kind of the referent.
+-                            enum:
+-                            - HelmRepository
+-                            - GitRepository
+-                            - Bucket
+-                            type: string
+-                          name:
+-                            description: Name of the referent.
+-                            maxLength: 253
+-                            minLength: 1
+-                            type: string
+-                          namespace:
+-                            description: Namespace of the referent.
+-                            maxLength: 63
+-                            minLength: 1
+-                            type: string
+-                        required:
+-                        - kind
+-                        - name
+-                        type: object
+-                      valuesFile:
+-                        description: |-
+-                          Alternative values file to use as the default chart values, expected to
+-                          be a relative path in the SourceRef. Deprecated in favor of ValuesFiles,
+-                          for backwards compatibility the file defined here is merged before the
+-                          ValuesFiles items. Ignored when omitted.
+-                        type: string
+-                      valuesFiles:
+-                        description: |-
+-                          Alternative list of values files to use as the chart values (values.yaml
+-                          is not included by default), expected to be a relative path in the SourceRef.
+-                          Values files are merged in the order of this list with the last file overriding
+-                          the first. Ignored when omitted.
+-                        items:
+-                          type: string
+-                        type: array
+-                      verify:
+-                        description: |-
+-                          Verify contains the secret name containing the trusted public keys
+-                          used to verify the signature and specifies which provider to use to check
+-                          whether OCI image is authentic.
+-                          This field is only supported for OCI sources.
+-                          Chart dependencies, which are not bundled in the umbrella chart artifact,
+-                          are not verified.
+-                        properties:
+-                          provider:
+-                            default: cosign
+-                            description: Provider specifies the technology used to
+-                              sign the OCI Helm chart.
+-                            enum:
+-                            - cosign
+-                            - notation
+-                            type: string
+-                          secretRef:
+-                            description: |-
+-                              SecretRef specifies the Kubernetes Secret containing the
+-                              trusted public keys.
+-                            properties:
+-                              name:
+-                                description: Name of the referent.
+-                                type: string
+-                            required:
+-                            - name
+-                            type: object
+-                        required:
+-                        - provider
+-                        type: object
+-                      version:
+-                        default: '*'
+-                        description: |-
+-                          Version semver expression, ignored for charts from v1beta2.GitRepository and
+-                          v1beta2.Bucket sources. Defaults to latest when omitted.
+-                        type: string
+-                    required:
+-                    - chart
+-                    - sourceRef
+-                    type: object
+-                required:
+-                - spec
+-                type: object
+-              chartRef:
+-                description: |-
+-                  ChartRef holds a reference to a source controller resource containing the
+-                  Helm chart artifact.
+-
+-                  Note: this field is provisional to the v2 API, and not actively used
+-                  by v2beta2 HelmReleases.
+-                properties:
+-                  apiVersion:
+-                    description: APIVersion of the referent.
+-                    type: string
+-                  kind:
+-                    description: Kind of the referent.
+-                    enum:
+-                    - OCIRepository
+-                    - HelmChart
+-                    type: string
+-                  name:
+-                    description: Name of the referent.
+-                    maxLength: 253
+-                    minLength: 1
+-                    type: string
+-                  namespace:
+-                    description: |-
+-                      Namespace of the referent, defaults to the namespace of the Kubernetes
+-                      resource object that contains the reference.
+-                    maxLength: 63
+-                    minLength: 1
+-                    type: string
+-                required:
+-                - kind
+-                - name
+-                type: object
+-              dependsOn:
+-                description: |-
+-                  DependsOn may contain a meta.NamespacedObjectReference slice with
+-                  references to HelmRelease resources that must be ready before this HelmRelease
+-                  can be reconciled.
+-                items:
+-                  description: |-
+-                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+-                    namespace.
+-                  properties:
+-                    name:
+-                      description: Name of the referent.
+-                      type: string
+-                    namespace:
+-                      description: Namespace of the referent, when not specified it
+-                        acts as LocalObjectReference.
+-                      type: string
+-                  required:
+-                  - name
+-                  type: object
+-                type: array
+-              driftDetection:
+-                description: |-
+-                  DriftDetection holds the configuration for detecting and handling
+-                  differences between the manifest in the Helm storage and the resources
+-                  currently existing in the cluster.
+-                properties:
+-                  ignore:
+-                    description: |-
+-                      Ignore contains a list of rules for specifying which changes to ignore
+-                      during diffing.
+-                    items:
+-                      description: |-
+-                        IgnoreRule defines a rule to selectively disregard specific changes during
+-                        the drift detection process.
+-                      properties:
+-                        paths:
+-                          description: |-
+-                            Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from
+-                            consideration in a Kubernetes object.
+-                          items:
+-                            type: string
+-                          type: array
+-                        target:
+-                          description: |-
+-                            Target is a selector for specifying Kubernetes objects to which this
+-                            rule applies.
+-                            If Target is not set, the Paths will be ignored for all Kubernetes
+-                            objects within the manifest of the Helm release.
+-                          properties:
+-                            annotationSelector:
+-                              description: |-
+-                                AnnotationSelector is a string that follows the label selection expression
+-                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                It matches with the resource annotations.
+-                              type: string
+-                            group:
+-                              description: |-
+-                                Group is the API group to select resources from.
+-                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                              type: string
+-                            kind:
+-                              description: |-
+-                                Kind of the API Group to select resources from.
+-                                Together with Group and Version it is capable of unambiguously
+-                                identifying and/or selecting resources.
+-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                              type: string
+-                            labelSelector:
+-                              description: |-
+-                                LabelSelector is a string that follows the label selection expression
+-                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                It matches with the resource labels.
+-                              type: string
+-                            name:
+-                              description: Name to match resources with.
+-                              type: string
+-                            namespace:
+-                              description: Namespace to select resources from.
+-                              type: string
+-                            version:
+-                              description: |-
+-                                Version of the API Group to select resources from.
+-                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                              type: string
+-                          type: object
+-                      required:
+-                      - paths
+-                      type: object
+-                    type: array
+-                  mode:
+-                    description: |-
+-                      Mode defines how differences should be handled between the Helm manifest
+-                      and the manifest currently applied to the cluster.
+-                      If not explicitly set, it defaults to DiffModeDisabled.
+-                    enum:
+-                    - enabled
+-                    - warn
+-                    - disabled
+-                    type: string
+-                type: object
+-              install:
+-                description: Install holds the configuration for Helm install actions
+-                  for this HelmRelease.
+-                properties:
+-                  crds:
+-                    description: |-
+-                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+-                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+-                      `Create` or `CreateReplace`. Default is `Create` and if omitted
+-                      CRDs are installed but not updated.
+-
+-                      Skip: do neither install nor replace (update) any CRDs.
+-
+-                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+-
+-                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+-                      but not deleted.
+-
+-                      By default, CRDs are applied (installed) during Helm install action.
+-                      With this option users can opt in to CRD replace existing CRDs on Helm
+-                      install actions, which is not (yet) natively supported by Helm.
+-                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+-                    enum:
+-                    - Skip
+-                    - Create
+-                    - CreateReplace
+-                    type: string
+-                  createNamespace:
+-                    description: |-
+-                      CreateNamespace tells the Helm install action to create the
+-                      HelmReleaseSpec.TargetNamespace if it does not exist yet.
+-                      On uninstall, the namespace will not be garbage collected.
+-                    type: boolean
+-                  disableHooks:
+-                    description: DisableHooks prevents hooks from running during the
+-                      Helm install action.
+-                    type: boolean
+-                  disableOpenAPIValidation:
+-                    description: |-
+-                      DisableOpenAPIValidation prevents the Helm install action from validating
+-                      rendered templates against the Kubernetes OpenAPI Schema.
+-                    type: boolean
+-                  disableWait:
+-                    description: |-
+-                      DisableWait disables the waiting for resources to be ready after a Helm
+-                      install has been performed.
+-                    type: boolean
+-                  disableWaitForJobs:
+-                    description: |-
+-                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+-                      install has been performed.
+-                    type: boolean
+-                  remediation:
+-                    description: |-
+-                      Remediation holds the remediation configuration for when the Helm install
+-                      action for the HelmRelease fails. The default is to not perform any action.
+-                    properties:
+-                      ignoreTestFailures:
+-                        description: |-
+-                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+-                          tests are run after an install action but fail. Defaults to
+-                          'Test.IgnoreFailures'.
+-                        type: boolean
+-                      remediateLastFailure:
+-                        description: |-
+-                          RemediateLastFailure tells the controller to remediate the last failure, when
+-                          no retries remain. Defaults to 'false'.
+-                        type: boolean
+-                      retries:
+-                        description: |-
+-                          Retries is the number of retries that should be attempted on failures before
+-                          bailing. Remediation, using an uninstall, is performed between each attempt.
+-                          Defaults to '0', a negative integer equals to unlimited retries.
+-                        type: integer
+-                    type: object
+-                  replace:
+-                    description: |-
+-                      Replace tells the Helm install action to re-use the 'ReleaseName', but only
+-                      if that name is a deleted release which remains in the history.
+-                    type: boolean
+-                  skipCRDs:
+-                    description: |-
+-                      SkipCRDs tells the Helm install action to not install any CRDs. By default,
+-                      CRDs are installed if not already present.
+-
+-                      Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
+-                    type: boolean
+-                  timeout:
+-                    description: |-
+-                      Timeout is the time to wait for any individual Kubernetes operation (like
+-                      Jobs for hooks) during the performance of a Helm install action. Defaults to
+-                      'HelmReleaseSpec.Timeout'.
+-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                    type: string
+-                type: object
+-              interval:
+-                description: Interval at which to reconcile the Helm release.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              kubeConfig:
+-                description: |-
+-                  KubeConfig for reconciling the HelmRelease on a remote cluster.
+-                  When used in combination with HelmReleaseSpec.ServiceAccountName,
+-                  forces the controller to act on behalf of that Service Account at the
+-                  target cluster.
+-                  If the --default-service-account flag is set, its value will be used as
+-                  a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+-                  is empty.
+-                properties:
+-                  secretRef:
+-                    description: |-
+-                      SecretRef holds the name of a secret that contains a key with
+-                      the kubeconfig file as the value. If no key is set, the key will default
+-                      to 'value'.
+-                      It is recommended that the kubeconfig is self-contained, and the secret
+-                      is regularly updated if credentials such as a cloud-access-token expire.
+-                      Cloud specific `cmd-path` auth helpers will not function without adding
+-                      binaries and credentials to the Pod that is responsible for reconciling
+-                      Kubernetes resources.
+-                    properties:
+-                      key:
+-                        description: Key in the Secret, when not specified an implementation-specific
+-                          default key is used.
+-                        type: string
+-                      name:
+-                        description: Name of the Secret.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - secretRef
+-                type: object
+-              maxHistory:
+-                description: |-
+-                  MaxHistory is the number of revisions saved by Helm for this HelmRelease.
+-                  Use '0' for an unlimited number of revisions; defaults to '5'.
+-                type: integer
+-              persistentClient:
+-                description: |-
+-                  PersistentClient tells the controller to use a persistent Kubernetes
+-                  client for this release. When enabled, the client will be reused for the
+-                  duration of the reconciliation, instead of being created and destroyed
+-                  for each (step of a) Helm action.
+-
+-                  This can improve performance, but may cause issues with some Helm charts
+-                  that for example do create Custom Resource Definitions during installation
+-                  outside Helm's CRD lifecycle hooks, which are then not observed to be
+-                  available by e.g. post-install hooks.
+-
+-                  If not set, it defaults to true.
+-                type: boolean
+-              postRenderers:
+-                description: |-
+-                  PostRenderers holds an array of Helm PostRenderers, which will be applied in order
+-                  of their definition.
+-                items:
+-                  description: PostRenderer contains a Helm PostRenderer specification.
+-                  properties:
+-                    kustomize:
+-                      description: Kustomization to apply as PostRenderer.
+-                      properties:
+-                        images:
+-                          description: |-
+-                            Images is a list of (image name, new name, new tag or digest)
+-                            for changing image names, tags or digests. This can also be achieved with a
+-                            patch, but this operator is simpler to specify.
+-                          items:
+-                            description: Image contains an image name, a new name,
+-                              a new tag or digest, which will replace the original
+-                              name and tag.
+-                            properties:
+-                              digest:
+-                                description: |-
+-                                  Digest is the value used to replace the original image tag.
+-                                  If digest is present NewTag value is ignored.
+-                                type: string
+-                              name:
+-                                description: Name is a tag-less image name.
+-                                type: string
+-                              newName:
+-                                description: NewName is the value used to replace
+-                                  the original name.
+-                                type: string
+-                              newTag:
+-                                description: NewTag is the value used to replace the
+-                                  original tag.
+-                                type: string
+-                            required:
+-                            - name
+-                            type: object
+-                          type: array
+-                        patches:
+-                          description: |-
+-                            Strategic merge and JSON patches, defined as inline YAML objects,
+-                            capable of targeting objects based on kind, label and annotation selectors.
+-                          items:
+-                            description: |-
+-                              Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+-                              be applied to.
+-                            properties:
+-                              patch:
+-                                description: |-
+-                                  Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+-                                  an array of operation objects.
+-                                type: string
+-                              target:
+-                                description: Target points to the resources that the
+-                                  patch document should be applied to.
+-                                properties:
+-                                  annotationSelector:
+-                                    description: |-
+-                                      AnnotationSelector is a string that follows the label selection expression
+-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                      It matches with the resource annotations.
+-                                    type: string
+-                                  group:
+-                                    description: |-
+-                                      Group is the API group to select resources from.
+-                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                                    type: string
+-                                  kind:
+-                                    description: |-
+-                                      Kind of the API Group to select resources from.
+-                                      Together with Group and Version it is capable of unambiguously
+-                                      identifying and/or selecting resources.
+-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                                    type: string
+-                                  labelSelector:
+-                                    description: |-
+-                                      LabelSelector is a string that follows the label selection expression
+-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                      It matches with the resource labels.
+-                                    type: string
+-                                  name:
+-                                    description: Name to match resources with.
+-                                    type: string
+-                                  namespace:
+-                                    description: Namespace to select resources from.
+-                                    type: string
+-                                  version:
+-                                    description: |-
+-                                      Version of the API Group to select resources from.
+-                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                                    type: string
+-                                type: object
+-                            required:
+-                            - patch
+-                            type: object
+-                          type: array
+-                        patchesJson6902:
+-                          description: |-
+-                            JSON 6902 patches, defined as inline YAML objects.
+-                            Deprecated: use Patches instead.
+-                          items:
+-                            description: JSON6902Patch contains a JSON6902 patch and
+-                              the target the patch should be applied to.
+-                            properties:
+-                              patch:
+-                                description: Patch contains the JSON6902 patch document
+-                                  with an array of operation objects.
+-                                items:
+-                                  description: |-
+-                                    JSON6902 is a JSON6902 operation object.
+-                                    https://datatracker.ietf.org/doc/html/rfc6902#section-4
+-                                  properties:
+-                                    from:
+-                                      description: |-
+-                                        From contains a JSON-pointer value that references a location within the target document where the operation is
+-                                        performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
+-                                      type: string
+-                                    op:
+-                                      description: |-
+-                                        Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
+-                                        "test".
+-                                        https://datatracker.ietf.org/doc/html/rfc6902#section-4
+-                                      enum:
+-                                      - test
+-                                      - remove
+-                                      - add
+-                                      - replace
+-                                      - move
+-                                      - copy
+-                                      type: string
+-                                    path:
+-                                      description: |-
+-                                        Path contains the JSON-pointer value that references a location within the target document where the operation
+-                                        is performed. The meaning of the value depends on the value of Op.
+-                                      type: string
+-                                    value:
+-                                      description: |-
+-                                        Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
+-                                        account by all operations.
+-                                      x-kubernetes-preserve-unknown-fields: true
+-                                  required:
+-                                  - op
+-                                  - path
+-                                  type: object
+-                                type: array
+-                              target:
+-                                description: Target points to the resources that the
+-                                  patch document should be applied to.
+-                                properties:
+-                                  annotationSelector:
+-                                    description: |-
+-                                      AnnotationSelector is a string that follows the label selection expression
+-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                      It matches with the resource annotations.
+-                                    type: string
+-                                  group:
+-                                    description: |-
+-                                      Group is the API group to select resources from.
+-                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                                    type: string
+-                                  kind:
+-                                    description: |-
+-                                      Kind of the API Group to select resources from.
+-                                      Together with Group and Version it is capable of unambiguously
+-                                      identifying and/or selecting resources.
+-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                                    type: string
+-                                  labelSelector:
+-                                    description: |-
+-                                      LabelSelector is a string that follows the label selection expression
+-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                                      It matches with the resource labels.
+-                                    type: string
+-                                  name:
+-                                    description: Name to match resources with.
+-                                    type: string
+-                                  namespace:
+-                                    description: Namespace to select resources from.
+-                                    type: string
+-                                  version:
+-                                    description: |-
+-                                      Version of the API Group to select resources from.
+-                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                                    type: string
+-                                type: object
+-                            required:
+-                            - patch
+-                            - target
+-                            type: object
+-                          type: array
+-                        patchesStrategicMerge:
+-                          description: |-
+-                            Strategic merge patches, defined as inline YAML objects.
+-                            Deprecated: use Patches instead.
+-                          items:
+-                            x-kubernetes-preserve-unknown-fields: true
+-                          type: array
+-                      type: object
+-                  type: object
+-                type: array
+-              releaseName:
+-                description: |-
+-                  ReleaseName used for the Helm release. Defaults to a composition of
+-                  '[TargetNamespace-]Name'.
+-                maxLength: 53
+-                minLength: 1
+-                type: string
+-              rollback:
+-                description: Rollback holds the configuration for Helm rollback actions
+-                  for this HelmRelease.
+-                properties:
+-                  cleanupOnFail:
+-                    description: |-
+-                      CleanupOnFail allows deletion of new resources created during the Helm
+-                      rollback action when it fails.
+-                    type: boolean
+-                  disableHooks:
+-                    description: DisableHooks prevents hooks from running during the
+-                      Helm rollback action.
+-                    type: boolean
+-                  disableWait:
+-                    description: |-
+-                      DisableWait disables the waiting for resources to be ready after a Helm
+-                      rollback has been performed.
+-                    type: boolean
+-                  disableWaitForJobs:
+-                    description: |-
+-                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+-                      rollback has been performed.
+-                    type: boolean
+-                  force:
+-                    description: Force forces resource updates through a replacement
+-                      strategy.
+-                    type: boolean
+-                  recreate:
+-                    description: Recreate performs pod restarts for the resource if
+-                      applicable.
+-                    type: boolean
+-                  timeout:
+-                    description: |-
+-                      Timeout is the time to wait for any individual Kubernetes operation (like
+-                      Jobs for hooks) during the performance of a Helm rollback action. Defaults to
+-                      'HelmReleaseSpec.Timeout'.
+-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                    type: string
+-                type: object
+-              serviceAccountName:
+-                description: |-
+-                  The name of the Kubernetes service account to impersonate
+-                  when reconciling this HelmRelease.
+-                maxLength: 253
+-                minLength: 1
+-                type: string
+-              storageNamespace:
+-                description: |-
+-                  StorageNamespace used for the Helm storage.
+-                  Defaults to the namespace of the HelmRelease.
+-                maxLength: 63
+-                minLength: 1
+-                type: string
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend reconciliation for this HelmRelease,
+-                  it does not apply to already started reconciliations. Defaults to false.
+-                type: boolean
+-              targetNamespace:
+-                description: |-
+-                  TargetNamespace to target when performing operations for the HelmRelease.
+-                  Defaults to the namespace of the HelmRelease.
+-                maxLength: 63
+-                minLength: 1
+-                type: string
+-              test:
+-                description: Test holds the configuration for Helm test actions for
+-                  this HelmRelease.
+-                properties:
+-                  enable:
+-                    description: |-
+-                      Enable enables Helm test actions for this HelmRelease after an Helm install
+-                      or upgrade action has been performed.
+-                    type: boolean
+-                  filters:
+-                    description: Filters is a list of tests to run or exclude from
+-                      running.
+-                    items:
+-                      description: Filter holds the configuration for individual Helm
+-                        test filters.
+-                      properties:
+-                        exclude:
+-                          description: Exclude specifies whether the named test should
+-                            be excluded.
+-                          type: boolean
+-                        name:
+-                          description: Name is the name of the test.
+-                          maxLength: 253
+-                          minLength: 1
+-                          type: string
+-                      required:
+-                      - name
+-                      type: object
+-                    type: array
+-                  ignoreFailures:
+-                    description: |-
+-                      IgnoreFailures tells the controller to skip remediation when the Helm tests
+-                      are run but fail. Can be overwritten for tests run after install or upgrade
+-                      actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
+-                    type: boolean
+-                  timeout:
+-                    description: |-
+-                      Timeout is the time to wait for any individual Kubernetes operation during
+-                      the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
+-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                    type: string
+-                type: object
+-              timeout:
+-                description: |-
+-                  Timeout is the time to wait for any individual Kubernetes operation (like Jobs
+-                  for hooks) during the performance of a Helm action. Defaults to '5m0s'.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              uninstall:
+-                description: Uninstall holds the configuration for Helm uninstall
+-                  actions for this HelmRelease.
+-                properties:
+-                  deletionPropagation:
+-                    default: background
+-                    description: |-
+-                      DeletionPropagation specifies the deletion propagation policy when
+-                      a Helm uninstall is performed.
+-                    enum:
+-                    - background
+-                    - foreground
+-                    - orphan
+-                    type: string
+-                  disableHooks:
+-                    description: DisableHooks prevents hooks from running during the
+-                      Helm rollback action.
+-                    type: boolean
+-                  disableWait:
+-                    description: |-
+-                      DisableWait disables waiting for all the resources to be deleted after
+-                      a Helm uninstall is performed.
+-                    type: boolean
+-                  keepHistory:
+-                    description: |-
+-                      KeepHistory tells Helm to remove all associated resources and mark the
+-                      release as deleted, but retain the release history.
+-                    type: boolean
+-                  timeout:
+-                    description: |-
+-                      Timeout is the time to wait for any individual Kubernetes operation (like
+-                      Jobs for hooks) during the performance of a Helm uninstall action. Defaults
+-                      to 'HelmReleaseSpec.Timeout'.
+-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                    type: string
+-                type: object
+-              upgrade:
+-                description: Upgrade holds the configuration for Helm upgrade actions
+-                  for this HelmRelease.
+-                properties:
+-                  cleanupOnFail:
+-                    description: |-
+-                      CleanupOnFail allows deletion of new resources created during the Helm
+-                      upgrade action when it fails.
+-                    type: boolean
+-                  crds:
+-                    description: |-
+-                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+-                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+-                      `Create` or `CreateReplace`. Default is `Skip` and if omitted
+-                      CRDs are neither installed nor upgraded.
+-
+-                      Skip: do neither install nor replace (update) any CRDs.
+-
+-                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+-
+-                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+-                      but not deleted.
+-
+-                      By default, CRDs are not applied during Helm upgrade action. With this
+-                      option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
+-                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+-                    enum:
+-                    - Skip
+-                    - Create
+-                    - CreateReplace
+-                    type: string
+-                  disableHooks:
+-                    description: DisableHooks prevents hooks from running during the
+-                      Helm upgrade action.
+-                    type: boolean
+-                  disableOpenAPIValidation:
+-                    description: |-
+-                      DisableOpenAPIValidation prevents the Helm upgrade action from validating
+-                      rendered templates against the Kubernetes OpenAPI Schema.
+-                    type: boolean
+-                  disableWait:
+-                    description: |-
+-                      DisableWait disables the waiting for resources to be ready after a Helm
+-                      upgrade has been performed.
+-                    type: boolean
+-                  disableWaitForJobs:
+-                    description: |-
+-                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+-                      upgrade has been performed.
+-                    type: boolean
+-                  force:
+-                    description: Force forces resource updates through a replacement
+-                      strategy.
+-                    type: boolean
+-                  preserveValues:
+-                    description: |-
+-                      PreserveValues will make Helm reuse the last release's values and merge in
+-                      overrides from 'Values'. Setting this flag makes the HelmRelease
+-                      non-declarative.
+-                    type: boolean
+-                  remediation:
+-                    description: |-
+-                      Remediation holds the remediation configuration for when the Helm upgrade
+-                      action for the HelmRelease fails. The default is to not perform any action.
+-                    properties:
+-                      ignoreTestFailures:
+-                        description: |-
+-                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+-                          tests are run after an upgrade action but fail.
+-                          Defaults to 'Test.IgnoreFailures'.
+-                        type: boolean
+-                      remediateLastFailure:
+-                        description: |-
+-                          RemediateLastFailure tells the controller to remediate the last failure, when
+-                          no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
+-                        type: boolean
+-                      retries:
+-                        description: |-
+-                          Retries is the number of retries that should be attempted on failures before
+-                          bailing. Remediation, using 'Strategy', is performed between each attempt.
+-                          Defaults to '0', a negative integer equals to unlimited retries.
+-                        type: integer
+-                      strategy:
+-                        description: Strategy to use for failure remediation. Defaults
+-                          to 'rollback'.
+-                        enum:
+-                        - rollback
+-                        - uninstall
+-                        type: string
+-                    type: object
+-                  timeout:
+-                    description: |-
+-                      Timeout is the time to wait for any individual Kubernetes operation (like
+-                      Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
+-                      'HelmReleaseSpec.Timeout'.
+-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                    type: string
+-                type: object
+-              values:
+-                description: Values holds the values for this Helm release.
+-                x-kubernetes-preserve-unknown-fields: true
+-              valuesFrom:
+-                description: |-
+-                  ValuesFrom holds references to resources containing Helm values for this HelmRelease,
+-                  and information about how they should be merged.
+-                items:
+-                  description: |-
+-                    ValuesReference contains a reference to a resource containing Helm values,
+-                    and optionally the key they can be found at.
+-                  properties:
+-                    kind:
+-                      description: Kind of the values referent, valid values are ('Secret',
+-                        'ConfigMap').
+-                      enum:
+-                      - Secret
+-                      - ConfigMap
+-                      type: string
+-                    name:
+-                      description: |-
+-                        Name of the values referent. Should reside in the same namespace as the
+-                        referring resource.
+-                      maxLength: 253
+-                      minLength: 1
+-                      type: string
+-                    optional:
+-                      description: |-
+-                        Optional marks this ValuesReference as optional. When set, a not found error
+-                        for the values reference is ignored, but any ValuesKey, TargetPath or
+-                        transient error will still result in a reconciliation failure.
+-                      type: boolean
+-                    targetPath:
+-                      description: |-
+-                        TargetPath is the YAML dot notation path the value should be merged at. When
+-                        set, the ValuesKey is expected to be a single flat value. Defaults to 'None',
+-                        which results in the values getting merged at the root.
+-                      maxLength: 250
+-                      pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
+-                      type: string
+-                    valuesKey:
+-                      description: |-
+-                        ValuesKey is the data key where the values.yaml or a specific value can be
+-                        found at. Defaults to 'values.yaml'.
+-                      maxLength: 253
+-                      pattern: ^[\-._a-zA-Z0-9]+$
+-                      type: string
+-                  required:
+-                  - kind
+-                  - name
+-                  type: object
+-                type: array
+-            required:
+-            - interval
+-            type: object
+-            x-kubernetes-validations:
+-            - message: either chart or chartRef must be set
+-              rule: (has(self.chart) && !has(self.chartRef)) || (!has(self.chart)
+-                && has(self.chartRef))
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: HelmReleaseStatus defines the observed state of a HelmRelease.
+-            properties:
+-              conditions:
+-                description: Conditions holds the conditions for the HelmRelease.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              failures:
+-                description: |-
+-                  Failures is the reconciliation failure count against the latest desired
+-                  state. It is reset after a successful reconciliation.
+-                format: int64
+-                type: integer
+-              helmChart:
+-                description: |-
+-                  HelmChart is the namespaced name of the HelmChart resource created by
+-                  the controller for the HelmRelease.
+-                type: string
+-              history:
+-                description: |-
+-                  History holds the history of Helm releases performed for this HelmRelease
+-                  up to the last successfully completed release.
+-                items:
+-                  description: |-
+-                    Snapshot captures a point-in-time copy of the status information for a Helm release,
+-                    as managed by the controller.
+-                  properties:
+-                    apiVersion:
+-                      description: |-
+-                        APIVersion is the API version of the Snapshot.
+-                        Provisional: when the calculation method of the Digest field is changed,
+-                        this field will be used to distinguish between the old and new methods.
+-                      type: string
+-                    appVersion:
+-                      description: AppVersion is the chart app version of the release
+-                        object in storage.
+-                      type: string
+-                    chartName:
+-                      description: ChartName is the chart name of the release object
+-                        in storage.
+-                      type: string
+-                    chartVersion:
+-                      description: |-
+-                        ChartVersion is the chart version of the release object in
+-                        storage.
+-                      type: string
+-                    configDigest:
+-                      description: |-
+-                        ConfigDigest is the checksum of the config (better known as
+-                        "values") of the release object in storage.
+-                        It has the format of `<algo>:<checksum>`.
+-                      type: string
+-                    deleted:
+-                      description: Deleted is when the release was deleted.
+-                      format: date-time
+-                      type: string
+-                    digest:
+-                      description: |-
+-                        Digest is the checksum of the release object in storage.
+-                        It has the format of `<algo>:<checksum>`.
+-                      type: string
+-                    firstDeployed:
+-                      description: FirstDeployed is when the release was first deployed.
+-                      format: date-time
+-                      type: string
+-                    lastDeployed:
+-                      description: LastDeployed is when the release was last deployed.
+-                      format: date-time
+-                      type: string
+-                    name:
+-                      description: Name is the name of the release.
+-                      type: string
+-                    namespace:
+-                      description: Namespace is the namespace the release is deployed
+-                        to.
+-                      type: string
+-                    ociDigest:
+-                      description: OCIDigest is the digest of the OCI artifact associated
+-                        with the release.
+-                      type: string
+-                    status:
+-                      description: Status is the current state of the release.
+-                      type: string
+-                    testHooks:
+-                      additionalProperties:
+-                        description: |-
+-                          TestHookStatus holds the status information for a test hook as observed
+-                          to be run by the controller.
+-                        properties:
+-                          lastCompleted:
+-                            description: LastCompleted is the time the test hook last
+-                              completed.
+-                            format: date-time
+-                            type: string
+-                          lastStarted:
+-                            description: LastStarted is the time the test hook was
+-                              last started.
+-                            format: date-time
+-                            type: string
+-                          phase:
+-                            description: Phase the test hook was observed to be in.
+-                            type: string
+-                        type: object
+-                      description: |-
+-                        TestHooks is the list of test hooks for the release as observed to be
+-                        run by the controller.
+-                      type: object
+-                    version:
+-                      description: Version is the version of the release object in
+-                        storage.
+-                      type: integer
+-                  required:
+-                  - chartName
+-                  - chartVersion
+-                  - configDigest
+-                  - digest
+-                  - firstDeployed
+-                  - lastDeployed
+-                  - name
+-                  - namespace
+-                  - status
+-                  - version
+-                  type: object
+-                type: array
+-              installFailures:
+-                description: |-
+-                  InstallFailures is the install failure count against the latest desired
+-                  state. It is reset after a successful reconciliation.
+-                format: int64
+-                type: integer
+-              lastAppliedRevision:
+-                description: |-
+-                  LastAppliedRevision is the revision of the last successfully applied
+-                  source.
+-                  Deprecated: the revision can now be found in the History.
+-                type: string
+-              lastAttemptedConfigDigest:
+-                description: |-
+-                  LastAttemptedConfigDigest is the digest for the config (better known as
+-                  "values") of the last reconciliation attempt.
+-                type: string
+-              lastAttemptedGeneration:
+-                description: |-
+-                  LastAttemptedGeneration is the last generation the controller attempted
+-                  to reconcile.
+-                format: int64
+-                type: integer
+-              lastAttemptedReleaseAction:
+-                description: |-
+-                  LastAttemptedReleaseAction is the last release action performed for this
+-                  HelmRelease. It is used to determine the active remediation strategy.
+-                enum:
+-                - install
+-                - upgrade
+-                type: string
+-              lastAttemptedRevision:
+-                description: |-
+-                  LastAttemptedRevision is the Source revision of the last reconciliation
+-                  attempt. For OCIRepository  sources, the 12 first characters of the digest are
+-                  appended to the chart version e.g. "1.2.3+1234567890ab".
+-                type: string
+-              lastAttemptedRevisionDigest:
+-                description: |-
+-                  LastAttemptedRevisionDigest is the digest of the last reconciliation attempt.
+-                  This is only set for OCIRepository sources.
+-                type: string
+-              lastAttemptedValuesChecksum:
+-                description: |-
+-                  LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
+-                  reconciliation attempt.
+-                  Deprecated: Use LastAttemptedConfigDigest instead.
+-                type: string
+-              lastHandledForceAt:
+-                description: |-
+-                  LastHandledForceAt holds the value of the most recent force request
+-                  value, so a change of the annotation value can be detected.
+-                type: string
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              lastHandledResetAt:
+-                description: |-
+-                  LastHandledResetAt holds the value of the most recent reset request
+-                  value, so a change of the annotation value can be detected.
+-                type: string
+-              lastReleaseRevision:
+-                description: |-
+-                  LastReleaseRevision is the revision of the last successful Helm release.
+-                  Deprecated: Use History instead.
+-                type: integer
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation.
+-                format: int64
+-                type: integer
+-              observedPostRenderersDigest:
+-                description: |-
+-                  ObservedPostRenderersDigest is the digest for the post-renderers of
+-                  the last successful reconciliation attempt.
+-                type: string
+-              storageNamespace:
+-                description: |-
+-                  StorageNamespace is the namespace of the Helm release storage for the
+-                  current release.
+-                maxLength: 63
+-                minLength: 1
+-                type: string
+-              upgradeFailures:
+-                description: |-
+-                  UpgradeFailures is the upgrade failure count against the latest desired
+-                  state. It is reset after a successful reconciliation.
+-                format: int64
+-                type: integer
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+diff --git a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_helmrepositories.source.toolkit.fluxcd.io.yaml b/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_helmrepositories.source.toolkit.fluxcd.io.yaml
+deleted file mode 100644
+index 9d7733b6d0..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_helmrepositories.source.toolkit.fluxcd.io.yaml
++++ /dev/null
+@@ -1,848 +0,0 @@
+-apiVersion: apiextensions.k8s.io/v1
+-kind: CustomResourceDefinition
+-metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: v0.16.1
+-  labels:
+-    app.kubernetes.io/component: source-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: helmrepositories.source.toolkit.fluxcd.io
+-spec:
+-  group: source.toolkit.fluxcd.io
+-  names:
+-    kind: HelmRepository
+-    listKind: HelmRepositoryList
+-    plural: helmrepositories
+-    shortNames:
+-    - helmrepo
+-    singular: helmrepository
+-  scope: Namespaced
+-  versions:
+-  - additionalPrinterColumns:
+-    - jsonPath: .spec.url
+-      name: URL
+-      type: string
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    name: v1
+-    schema:
+-      openAPIV3Schema:
+-        description: HelmRepository is the Schema for the helmrepositories API.
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: |-
+-              HelmRepositorySpec specifies the required configuration to produce an
+-              Artifact for a Helm repository index YAML.
+-            properties:
+-              accessFrom:
+-                description: |-
+-                  AccessFrom specifies an Access Control List for allowing cross-namespace
+-                  references to this object.
+-                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+-                properties:
+-                  namespaceSelectors:
+-                    description: |-
+-                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+-                      Items in this list are evaluated using a logical OR operation.
+-                    items:
+-                      description: |-
+-                        NamespaceSelector selects the namespaces to which this ACL applies.
+-                        An empty map of MatchLabels matches all namespaces in a cluster.
+-                      properties:
+-                        matchLabels:
+-                          additionalProperties:
+-                            type: string
+-                          description: |-
+-                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+-                          type: object
+-                      type: object
+-                    type: array
+-                required:
+-                - namespaceSelectors
+-                type: object
+-              certSecretRef:
+-                description: |-
+-                  CertSecretRef can be given the name of a Secret containing
+-                  either or both of
+-
+-                  - a PEM-encoded client certificate (`tls.crt`) and private
+-                  key (`tls.key`);
+-                  - a PEM-encoded CA certificate (`ca.crt`)
+-
+-                  and whichever are supplied, will be used for connecting to the
+-                  registry. The client cert and key are useful if you are
+-                  authenticating with a certificate; the CA cert is useful if
+-                  you are using a self-signed server certificate. The Secret must
+-                  be of type `Opaque` or `kubernetes.io/tls`.
+-
+-                  It takes precedence over the values specified in the Secret referred
+-                  to by `.spec.secretRef`.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              insecure:
+-                description: |-
+-                  Insecure allows connecting to a non-TLS HTTP container registry.
+-                  This field is only taken into account if the .spec.type field is set to 'oci'.
+-                type: boolean
+-              interval:
+-                description: |-
+-                  Interval at which the HelmRepository URL is checked for updates.
+-                  This interval is approximate and may be subject to jitter to ensure
+-                  efficient use of resources.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              passCredentials:
+-                description: |-
+-                  PassCredentials allows the credentials from the SecretRef to be passed
+-                  on to a host that does not match the host as defined in URL.
+-                  This may be required if the host of the advertised chart URLs in the
+-                  index differ from the defined URL.
+-                  Enabling this should be done with caution, as it can potentially result
+-                  in credentials getting stolen in a MITM-attack.
+-                type: boolean
+-              provider:
+-                default: generic
+-                description: |-
+-                  Provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+-                  This field is optional, and only taken into account if the .spec.type field is set to 'oci'.
+-                  When not specified, defaults to 'generic'.
+-                enum:
+-                - generic
+-                - aws
+-                - azure
+-                - gcp
+-                type: string
+-              secretRef:
+-                description: |-
+-                  SecretRef specifies the Secret containing authentication credentials
+-                  for the HelmRepository.
+-                  For HTTP/S basic auth the secret must contain 'username' and 'password'
+-                  fields.
+-                  Support for TLS auth using the 'certFile' and 'keyFile', and/or 'caFile'
+-                  keys is deprecated. Please use `.spec.certSecretRef` instead.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend the reconciliation of this
+-                  HelmRepository.
+-                type: boolean
+-              timeout:
+-                description: |-
+-                  Timeout is used for the index fetch operation for an HTTPS helm repository,
+-                  and for remote OCI Repository operations like pulling for an OCI helm
+-                  chart by the associated HelmChart.
+-                  Its default value is 60s.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+-                type: string
+-              type:
+-                description: |-
+-                  Type of the HelmRepository.
+-                  When this field is set to  "oci", the URL field value must be prefixed with "oci://".
+-                enum:
+-                - default
+-                - oci
+-                type: string
+-              url:
+-                description: |-
+-                  URL of the Helm repository, a valid URL contains at least a protocol and
+-                  host.
+-                pattern: ^(http|https|oci)://.*$
+-                type: string
+-            required:
+-            - url
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: HelmRepositoryStatus records the observed state of the HelmRepository.
+-            properties:
+-              artifact:
+-                description: Artifact represents the last successful HelmRepository
+-                  reconciliation.
+-                properties:
+-                  digest:
+-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+-                    type: string
+-                  lastUpdateTime:
+-                    description: |-
+-                      LastUpdateTime is the timestamp corresponding to the last update of the
+-                      Artifact.
+-                    format: date-time
+-                    type: string
+-                  metadata:
+-                    additionalProperties:
+-                      type: string
+-                    description: Metadata holds upstream information such as OCI annotations.
+-                    type: object
+-                  path:
+-                    description: |-
+-                      Path is the relative file path of the Artifact. It can be used to locate
+-                      the file in the root of the Artifact storage on the local file system of
+-                      the controller managing the Source.
+-                    type: string
+-                  revision:
+-                    description: |-
+-                      Revision is a human-readable identifier traceable in the origin source
+-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+-                    type: string
+-                  size:
+-                    description: Size is the number of bytes in the file.
+-                    format: int64
+-                    type: integer
+-                  url:
+-                    description: |-
+-                      URL is the HTTP address of the Artifact as exposed by the controller
+-                      managing the Source. It can be used to retrieve the Artifact for
+-                      consumption, e.g. by another controller applying the Artifact contents.
+-                    type: string
+-                required:
+-                - lastUpdateTime
+-                - path
+-                - revision
+-                - url
+-                type: object
+-              conditions:
+-                description: Conditions holds the conditions for the HelmRepository.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: |-
+-                  ObservedGeneration is the last observed generation of the HelmRepository
+-                  object.
+-                format: int64
+-                type: integer
+-              url:
+-                description: |-
+-                  URL is the dynamic fetch link for the latest Artifact.
+-                  It is provided on a "best effort" basis, and using the precise
+-                  HelmRepositoryStatus.Artifact data is recommended.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: true
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .spec.url
+-      name: URL
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    deprecated: true
+-    deprecationWarning: v1beta1 HelmRepository is deprecated, upgrade to v1
+-    name: v1beta1
+-    schema:
+-      openAPIV3Schema:
+-        description: HelmRepository is the Schema for the helmrepositories API
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: HelmRepositorySpec defines the reference to a Helm repository.
+-            properties:
+-              accessFrom:
+-                description: AccessFrom defines an Access Control List for allowing
+-                  cross-namespace references to this object.
+-                properties:
+-                  namespaceSelectors:
+-                    description: |-
+-                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+-                      Items in this list are evaluated using a logical OR operation.
+-                    items:
+-                      description: |-
+-                        NamespaceSelector selects the namespaces to which this ACL applies.
+-                        An empty map of MatchLabels matches all namespaces in a cluster.
+-                      properties:
+-                        matchLabels:
+-                          additionalProperties:
+-                            type: string
+-                          description: |-
+-                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+-                          type: object
+-                      type: object
+-                    type: array
+-                required:
+-                - namespaceSelectors
+-                type: object
+-              interval:
+-                description: The interval at which to check the upstream for updates.
+-                type: string
+-              passCredentials:
+-                description: |-
+-                  PassCredentials allows the credentials from the SecretRef to be passed on to
+-                  a host that does not match the host as defined in URL.
+-                  This may be required if the host of the advertised chart URLs in the index
+-                  differ from the defined URL.
+-                  Enabling this should be done with caution, as it can potentially result in
+-                  credentials getting stolen in a MITM-attack.
+-                type: boolean
+-              secretRef:
+-                description: |-
+-                  The name of the secret containing authentication credentials for the Helm
+-                  repository.
+-                  For HTTP/S basic auth the secret must contain username and
+-                  password fields.
+-                  For TLS the secret must contain a certFile and keyFile, and/or
+-                  caFile fields.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              suspend:
+-                description: This flag tells the controller to suspend the reconciliation
+-                  of this source.
+-                type: boolean
+-              timeout:
+-                default: 60s
+-                description: The timeout of index downloading, defaults to 60s.
+-                type: string
+-              url:
+-                description: The Helm repository URL, a valid URL contains at least
+-                  a protocol and host.
+-                type: string
+-            required:
+-            - interval
+-            - url
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: HelmRepositoryStatus defines the observed state of the HelmRepository.
+-            properties:
+-              artifact:
+-                description: Artifact represents the output of the last successful
+-                  repository sync.
+-                properties:
+-                  checksum:
+-                    description: Checksum is the SHA256 checksum of the artifact.
+-                    type: string
+-                  lastUpdateTime:
+-                    description: |-
+-                      LastUpdateTime is the timestamp corresponding to the last update of this
+-                      artifact.
+-                    format: date-time
+-                    type: string
+-                  path:
+-                    description: Path is the relative file path of this artifact.
+-                    type: string
+-                  revision:
+-                    description: |-
+-                      Revision is a human readable identifier traceable in the origin source
+-                      system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
+-                      chart version, etc.
+-                    type: string
+-                  url:
+-                    description: URL is the HTTP address of this artifact.
+-                    type: string
+-                required:
+-                - lastUpdateTime
+-                - path
+-                - url
+-                type: object
+-              conditions:
+-                description: Conditions holds the conditions for the HelmRepository.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation.
+-                format: int64
+-                type: integer
+-              url:
+-                description: URL is the download link for the last index fetched.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .spec.url
+-      name: URL
+-      type: string
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    deprecated: true
+-    deprecationWarning: v1beta2 HelmRepository is deprecated, upgrade to v1
+-    name: v1beta2
+-    schema:
+-      openAPIV3Schema:
+-        description: HelmRepository is the Schema for the helmrepositories API.
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: |-
+-              HelmRepositorySpec specifies the required configuration to produce an
+-              Artifact for a Helm repository index YAML.
+-            properties:
+-              accessFrom:
+-                description: |-
+-                  AccessFrom specifies an Access Control List for allowing cross-namespace
+-                  references to this object.
+-                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+-                properties:
+-                  namespaceSelectors:
+-                    description: |-
+-                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+-                      Items in this list are evaluated using a logical OR operation.
+-                    items:
+-                      description: |-
+-                        NamespaceSelector selects the namespaces to which this ACL applies.
+-                        An empty map of MatchLabels matches all namespaces in a cluster.
+-                      properties:
+-                        matchLabels:
+-                          additionalProperties:
+-                            type: string
+-                          description: |-
+-                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+-                          type: object
+-                      type: object
+-                    type: array
+-                required:
+-                - namespaceSelectors
+-                type: object
+-              certSecretRef:
+-                description: |-
+-                  CertSecretRef can be given the name of a Secret containing
+-                  either or both of
+-
+-                  - a PEM-encoded client certificate (`tls.crt`) and private
+-                  key (`tls.key`);
+-                  - a PEM-encoded CA certificate (`ca.crt`)
+-
+-                  and whichever are supplied, will be used for connecting to the
+-                  registry. The client cert and key are useful if you are
+-                  authenticating with a certificate; the CA cert is useful if
+-                  you are using a self-signed server certificate. The Secret must
+-                  be of type `Opaque` or `kubernetes.io/tls`.
+-
+-                  It takes precedence over the values specified in the Secret referred
+-                  to by `.spec.secretRef`.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              insecure:
+-                description: |-
+-                  Insecure allows connecting to a non-TLS HTTP container registry.
+-                  This field is only taken into account if the .spec.type field is set to 'oci'.
+-                type: boolean
+-              interval:
+-                description: |-
+-                  Interval at which the HelmRepository URL is checked for updates.
+-                  This interval is approximate and may be subject to jitter to ensure
+-                  efficient use of resources.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              passCredentials:
+-                description: |-
+-                  PassCredentials allows the credentials from the SecretRef to be passed
+-                  on to a host that does not match the host as defined in URL.
+-                  This may be required if the host of the advertised chart URLs in the
+-                  index differ from the defined URL.
+-                  Enabling this should be done with caution, as it can potentially result
+-                  in credentials getting stolen in a MITM-attack.
+-                type: boolean
+-              provider:
+-                default: generic
+-                description: |-
+-                  Provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+-                  This field is optional, and only taken into account if the .spec.type field is set to 'oci'.
+-                  When not specified, defaults to 'generic'.
+-                enum:
+-                - generic
+-                - aws
+-                - azure
+-                - gcp
+-                type: string
+-              secretRef:
+-                description: |-
+-                  SecretRef specifies the Secret containing authentication credentials
+-                  for the HelmRepository.
+-                  For HTTP/S basic auth the secret must contain 'username' and 'password'
+-                  fields.
+-                  Support for TLS auth using the 'certFile' and 'keyFile', and/or 'caFile'
+-                  keys is deprecated. Please use `.spec.certSecretRef` instead.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend the reconciliation of this
+-                  HelmRepository.
+-                type: boolean
+-              timeout:
+-                description: |-
+-                  Timeout is used for the index fetch operation for an HTTPS helm repository,
+-                  and for remote OCI Repository operations like pulling for an OCI helm
+-                  chart by the associated HelmChart.
+-                  Its default value is 60s.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+-                type: string
+-              type:
+-                description: |-
+-                  Type of the HelmRepository.
+-                  When this field is set to  "oci", the URL field value must be prefixed with "oci://".
+-                enum:
+-                - default
+-                - oci
+-                type: string
+-              url:
+-                description: |-
+-                  URL of the Helm repository, a valid URL contains at least a protocol and
+-                  host.
+-                pattern: ^(http|https|oci)://.*$
+-                type: string
+-            required:
+-            - url
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: HelmRepositoryStatus records the observed state of the HelmRepository.
+-            properties:
+-              artifact:
+-                description: Artifact represents the last successful HelmRepository
+-                  reconciliation.
+-                properties:
+-                  digest:
+-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+-                    type: string
+-                  lastUpdateTime:
+-                    description: |-
+-                      LastUpdateTime is the timestamp corresponding to the last update of the
+-                      Artifact.
+-                    format: date-time
+-                    type: string
+-                  metadata:
+-                    additionalProperties:
+-                      type: string
+-                    description: Metadata holds upstream information such as OCI annotations.
+-                    type: object
+-                  path:
+-                    description: |-
+-                      Path is the relative file path of the Artifact. It can be used to locate
+-                      the file in the root of the Artifact storage on the local file system of
+-                      the controller managing the Source.
+-                    type: string
+-                  revision:
+-                    description: |-
+-                      Revision is a human-readable identifier traceable in the origin source
+-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+-                    type: string
+-                  size:
+-                    description: Size is the number of bytes in the file.
+-                    format: int64
+-                    type: integer
+-                  url:
+-                    description: |-
+-                      URL is the HTTP address of the Artifact as exposed by the controller
+-                      managing the Source. It can be used to retrieve the Artifact for
+-                      consumption, e.g. by another controller applying the Artifact contents.
+-                    type: string
+-                required:
+-                - lastUpdateTime
+-                - path
+-                - revision
+-                - url
+-                type: object
+-              conditions:
+-                description: Conditions holds the conditions for the HelmRepository.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: |-
+-                  ObservedGeneration is the last observed generation of the HelmRepository
+-                  object.
+-                format: int64
+-                type: integer
+-              url:
+-                description: |-
+-                  URL is the dynamic fetch link for the latest Artifact.
+-                  It is provided on a "best effort" basis, and using the precise
+-                  HelmRepositoryStatus.Artifact data is recommended.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+diff --git a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_kustomizations.kustomize.toolkit.fluxcd.io.yaml b/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_kustomizations.kustomize.toolkit.fluxcd.io.yaml
+deleted file mode 100644
+index 84dbd5f128..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_kustomizations.kustomize.toolkit.fluxcd.io.yaml
++++ /dev/null
+@@ -1,1788 +0,0 @@
+-apiVersion: apiextensions.k8s.io/v1
+-kind: CustomResourceDefinition
+-metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: v0.16.1
+-  labels:
+-    app.kubernetes.io/component: kustomize-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: kustomizations.kustomize.toolkit.fluxcd.io
+-spec:
+-  group: kustomize.toolkit.fluxcd.io
+-  names:
+-    kind: Kustomization
+-    listKind: KustomizationList
+-    plural: kustomizations
+-    shortNames:
+-    - ks
+-    singular: kustomization
+-  scope: Namespaced
+-  versions:
+-  - additionalPrinterColumns:
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    name: v1
+-    schema:
+-      openAPIV3Schema:
+-        description: Kustomization is the Schema for the kustomizations API.
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: |-
+-              KustomizationSpec defines the configuration to calculate the desired state
+-              from a Source using Kustomize.
+-            properties:
+-              commonMetadata:
+-                description: |-
+-                  CommonMetadata specifies the common labels and annotations that are
+-                  applied to all resources. Any existing label or annotation will be
+-                  overridden if its key matches a common one.
+-                properties:
+-                  annotations:
+-                    additionalProperties:
+-                      type: string
+-                    description: Annotations to be added to the object's metadata.
+-                    type: object
+-                  labels:
+-                    additionalProperties:
+-                      type: string
+-                    description: Labels to be added to the object's metadata.
+-                    type: object
+-                type: object
+-              components:
+-                description: Components specifies relative paths to specifications
+-                  of other Components.
+-                items:
+-                  type: string
+-                type: array
+-              decryption:
+-                description: Decrypt Kubernetes secrets before applying them on the
+-                  cluster.
+-                properties:
+-                  provider:
+-                    description: Provider is the name of the decryption engine.
+-                    enum:
+-                    - sops
+-                    type: string
+-                  secretRef:
+-                    description: |-
+-                      The secret name containing the private OpenPGP keys used for decryption.
+-                      A static credential for a cloud provider defined inside the Secret
+-                      takes priority to secret-less authentication with the ServiceAccountName
+-                      field.
+-                    properties:
+-                      name:
+-                        description: Name of the referent.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                  serviceAccountName:
+-                    description: |-
+-                      ServiceAccountName is the name of the service account used to
+-                      authenticate with KMS services from cloud providers. If a
+-                      static credential for a given cloud provider is defined
+-                      inside the Secret referenced by SecretRef, that static
+-                      credential takes priority.
+-                    type: string
+-                required:
+-                - provider
+-                type: object
+-              deletionPolicy:
+-                description: |-
+-                  DeletionPolicy can be used to control garbage collection when this
+-                  Kustomization is deleted. Valid values are ('MirrorPrune', 'Delete',
+-                  'WaitForTermination', 'Orphan'). 'MirrorPrune' mirrors the Prune field
+-                  (orphan if false, delete if true). Defaults to 'MirrorPrune'.
+-                enum:
+-                - MirrorPrune
+-                - Delete
+-                - WaitForTermination
+-                - Orphan
+-                type: string
+-              dependsOn:
+-                description: |-
+-                  DependsOn may contain a meta.NamespacedObjectReference slice
+-                  with references to Kustomization resources that must be ready before this
+-                  Kustomization can be reconciled.
+-                items:
+-                  description: |-
+-                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+-                    namespace.
+-                  properties:
+-                    name:
+-                      description: Name of the referent.
+-                      type: string
+-                    namespace:
+-                      description: Namespace of the referent, when not specified it
+-                        acts as LocalObjectReference.
+-                      type: string
+-                  required:
+-                  - name
+-                  type: object
+-                type: array
+-              force:
+-                default: false
+-                description: |-
+-                  Force instructs the controller to recreate resources
+-                  when patching fails due to an immutable field change.
+-                type: boolean
+-              healthCheckExprs:
+-                description: |-
+-                  HealthCheckExprs is a list of healthcheck expressions for evaluating the
+-                  health of custom resources using Common Expression Language (CEL).
+-                  The expressions are evaluated only when Wait or HealthChecks are specified.
+-                items:
+-                  description: CustomHealthCheck defines the health check for custom
+-                    resources.
+-                  properties:
+-                    apiVersion:
+-                      description: APIVersion of the custom resource under evaluation.
+-                      type: string
+-                    current:
+-                      description: |-
+-                        Current is the CEL expression that determines if the status
+-                        of the custom resource has reached the desired state.
+-                      type: string
+-                    failed:
+-                      description: |-
+-                        Failed is the CEL expression that determines if the status
+-                        of the custom resource has failed to reach the desired state.
+-                      type: string
+-                    inProgress:
+-                      description: |-
+-                        InProgress is the CEL expression that determines if the status
+-                        of the custom resource has not yet reached the desired state.
+-                      type: string
+-                    kind:
+-                      description: Kind of the custom resource under evaluation.
+-                      type: string
+-                  required:
+-                  - apiVersion
+-                  - current
+-                  - kind
+-                  type: object
+-                type: array
+-              healthChecks:
+-                description: A list of resources to be included in the health assessment.
+-                items:
+-                  description: |-
+-                    NamespacedObjectKindReference contains enough information to locate the typed referenced Kubernetes resource object
+-                    in any namespace.
+-                  properties:
+-                    apiVersion:
+-                      description: API version of the referent, if not specified the
+-                        Kubernetes preferred version will be used.
+-                      type: string
+-                    kind:
+-                      description: Kind of the referent.
+-                      type: string
+-                    name:
+-                      description: Name of the referent.
+-                      type: string
+-                    namespace:
+-                      description: Namespace of the referent, when not specified it
+-                        acts as LocalObjectReference.
+-                      type: string
+-                  required:
+-                  - kind
+-                  - name
+-                  type: object
+-                type: array
+-              images:
+-                description: |-
+-                  Images is a list of (image name, new name, new tag or digest)
+-                  for changing image names, tags or digests. This can also be achieved with a
+-                  patch, but this operator is simpler to specify.
+-                items:
+-                  description: Image contains an image name, a new name, a new tag
+-                    or digest, which will replace the original name and tag.
+-                  properties:
+-                    digest:
+-                      description: |-
+-                        Digest is the value used to replace the original image tag.
+-                        If digest is present NewTag value is ignored.
+-                      type: string
+-                    name:
+-                      description: Name is a tag-less image name.
+-                      type: string
+-                    newName:
+-                      description: NewName is the value used to replace the original
+-                        name.
+-                      type: string
+-                    newTag:
+-                      description: NewTag is the value used to replace the original
+-                        tag.
+-                      type: string
+-                  required:
+-                  - name
+-                  type: object
+-                type: array
+-              interval:
+-                description: |-
+-                  The interval at which to reconcile the Kustomization.
+-                  This interval is approximate and may be subject to jitter to ensure
+-                  efficient use of resources.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              kubeConfig:
+-                description: |-
+-                  The KubeConfig for reconciling the Kustomization on a remote cluster.
+-                  When used in combination with KustomizationSpec.ServiceAccountName,
+-                  forces the controller to act on behalf of that Service Account at the
+-                  target cluster.
+-                  If the --default-service-account flag is set, its value will be used as
+-                  a controller level fallback for when KustomizationSpec.ServiceAccountName
+-                  is empty.
+-                properties:
+-                  secretRef:
+-                    description: |-
+-                      SecretRef holds the name of a secret that contains a key with
+-                      the kubeconfig file as the value. If no key is set, the key will default
+-                      to 'value'.
+-                      It is recommended that the kubeconfig is self-contained, and the secret
+-                      is regularly updated if credentials such as a cloud-access-token expire.
+-                      Cloud specific `cmd-path` auth helpers will not function without adding
+-                      binaries and credentials to the Pod that is responsible for reconciling
+-                      Kubernetes resources.
+-                    properties:
+-                      key:
+-                        description: Key in the Secret, when not specified an implementation-specific
+-                          default key is used.
+-                        type: string
+-                      name:
+-                        description: Name of the Secret.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - secretRef
+-                type: object
+-              namePrefix:
+-                description: NamePrefix will prefix the names of all managed resources.
+-                maxLength: 200
+-                minLength: 1
+-                type: string
+-              nameSuffix:
+-                description: NameSuffix will suffix the names of all managed resources.
+-                maxLength: 200
+-                minLength: 1
+-                type: string
+-              patches:
+-                description: |-
+-                  Strategic merge and JSON patches, defined as inline YAML objects,
+-                  capable of targeting objects based on kind, label and annotation selectors.
+-                items:
+-                  description: |-
+-                    Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+-                    be applied to.
+-                  properties:
+-                    patch:
+-                      description: |-
+-                        Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+-                        an array of operation objects.
+-                      type: string
+-                    target:
+-                      description: Target points to the resources that the patch document
+-                        should be applied to.
+-                      properties:
+-                        annotationSelector:
+-                          description: |-
+-                            AnnotationSelector is a string that follows the label selection expression
+-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                            It matches with the resource annotations.
+-                          type: string
+-                        group:
+-                          description: |-
+-                            Group is the API group to select resources from.
+-                            Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                          type: string
+-                        kind:
+-                          description: |-
+-                            Kind of the API Group to select resources from.
+-                            Together with Group and Version it is capable of unambiguously
+-                            identifying and/or selecting resources.
+-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                          type: string
+-                        labelSelector:
+-                          description: |-
+-                            LabelSelector is a string that follows the label selection expression
+-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                            It matches with the resource labels.
+-                          type: string
+-                        name:
+-                          description: Name to match resources with.
+-                          type: string
+-                        namespace:
+-                          description: Namespace to select resources from.
+-                          type: string
+-                        version:
+-                          description: |-
+-                            Version of the API Group to select resources from.
+-                            Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                          type: string
+-                      type: object
+-                  required:
+-                  - patch
+-                  type: object
+-                type: array
+-              path:
+-                description: |-
+-                  Path to the directory containing the kustomization.yaml file, or the
+-                  set of plain YAMLs a kustomization.yaml should be generated for.
+-                  Defaults to 'None', which translates to the root path of the SourceRef.
+-                type: string
+-              postBuild:
+-                description: |-
+-                  PostBuild describes which actions to perform on the YAML manifest
+-                  generated by building the kustomize overlay.
+-                properties:
+-                  substitute:
+-                    additionalProperties:
+-                      type: string
+-                    description: |-
+-                      Substitute holds a map of key/value pairs.
+-                      The variables defined in your YAML manifests that match any of the keys
+-                      defined in the map will be substituted with the set value.
+-                      Includes support for bash string replacement functions
+-                      e.g. ${var:=default}, ${var:position} and ${var/substring/replacement}.
+-                    type: object
+-                  substituteFrom:
+-                    description: |-
+-                      SubstituteFrom holds references to ConfigMaps and Secrets containing
+-                      the variables and their values to be substituted in the YAML manifests.
+-                      The ConfigMap and the Secret data keys represent the var names, and they
+-                      must match the vars declared in the manifests for the substitution to
+-                      happen.
+-                    items:
+-                      description: |-
+-                        SubstituteReference contains a reference to a resource containing
+-                        the variables name and value.
+-                      properties:
+-                        kind:
+-                          description: Kind of the values referent, valid values are
+-                            ('Secret', 'ConfigMap').
+-                          enum:
+-                          - Secret
+-                          - ConfigMap
+-                          type: string
+-                        name:
+-                          description: |-
+-                            Name of the values referent. Should reside in the same namespace as the
+-                            referring resource.
+-                          maxLength: 253
+-                          minLength: 1
+-                          type: string
+-                        optional:
+-                          default: false
+-                          description: |-
+-                            Optional indicates whether the referenced resource must exist, or whether to
+-                            tolerate its absence. If true and the referenced resource is absent, proceed
+-                            as if the resource was present but empty, without any variables defined.
+-                          type: boolean
+-                      required:
+-                      - kind
+-                      - name
+-                      type: object
+-                    type: array
+-                type: object
+-              prune:
+-                description: Prune enables garbage collection.
+-                type: boolean
+-              retryInterval:
+-                description: |-
+-                  The interval at which to retry a previously failed reconciliation.
+-                  When not specified, the controller uses the KustomizationSpec.Interval
+-                  value to retry failures.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              serviceAccountName:
+-                description: |-
+-                  The name of the Kubernetes service account to impersonate
+-                  when reconciling this Kustomization.
+-                type: string
+-              sourceRef:
+-                description: Reference of the source where the kustomization file
+-                  is.
+-                properties:
+-                  apiVersion:
+-                    description: API version of the referent.
+-                    type: string
+-                  kind:
+-                    description: Kind of the referent.
+-                    enum:
+-                    - OCIRepository
+-                    - GitRepository
+-                    - Bucket
+-                    type: string
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                  namespace:
+-                    description: |-
+-                      Namespace of the referent, defaults to the namespace of the Kubernetes
+-                      resource object that contains the reference.
+-                    type: string
+-                required:
+-                - kind
+-                - name
+-                type: object
+-              suspend:
+-                description: |-
+-                  This flag tells the controller to suspend subsequent kustomize executions,
+-                  it does not apply to already started executions. Defaults to false.
+-                type: boolean
+-              targetNamespace:
+-                description: |-
+-                  TargetNamespace sets or overrides the namespace in the
+-                  kustomization.yaml file.
+-                maxLength: 63
+-                minLength: 1
+-                type: string
+-              timeout:
+-                description: |-
+-                  Timeout for validation, apply and health checking operations.
+-                  Defaults to 'Interval' duration.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              wait:
+-                description: |-
+-                  Wait instructs the controller to check the health of all the reconciled
+-                  resources. When enabled, the HealthChecks are ignored. Defaults to false.
+-                type: boolean
+-            required:
+-            - interval
+-            - prune
+-            - sourceRef
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: KustomizationStatus defines the observed state of a kustomization.
+-            properties:
+-              conditions:
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              inventory:
+-                description: |-
+-                  Inventory contains the list of Kubernetes resource object references that
+-                  have been successfully applied.
+-                properties:
+-                  entries:
+-                    description: Entries of Kubernetes resource object references.
+-                    items:
+-                      description: ResourceRef contains the information necessary
+-                        to locate a resource within a cluster.
+-                      properties:
+-                        id:
+-                          description: |-
+-                            ID is the string representation of the Kubernetes resource object's metadata,
+-                            in the format '<namespace>_<name>_<group>_<kind>'.
+-                          type: string
+-                        v:
+-                          description: Version is the API version of the Kubernetes
+-                            resource object's kind.
+-                          type: string
+-                      required:
+-                      - id
+-                      - v
+-                      type: object
+-                    type: array
+-                required:
+-                - entries
+-                type: object
+-              lastAppliedOriginRevision:
+-                description: |-
+-                  The last successfully applied origin revision.
+-                  Equals the origin revision of the applied Artifact from the referenced Source.
+-                  Usually present on the Metadata of the applied Artifact and depends on the
+-                  Source type, e.g. for OCI it's the value associated with the key
+-                  "org.opencontainers.image.revision".
+-                type: string
+-              lastAppliedRevision:
+-                description: |-
+-                  The last successfully applied revision.
+-                  Equals the Revision of the applied Artifact from the referenced Source.
+-                type: string
+-              lastAttemptedRevision:
+-                description: LastAttemptedRevision is the revision of the last reconciliation
+-                  attempt.
+-                type: string
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: ObservedGeneration is the last reconciled generation.
+-                format: int64
+-                type: integer
+-            type: object
+-        type: object
+-    served: true
+-    storage: true
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    deprecated: true
+-    deprecationWarning: v1beta1 Kustomization is deprecated, upgrade to v1
+-    name: v1beta1
+-    schema:
+-      openAPIV3Schema:
+-        description: Kustomization is the Schema for the kustomizations API.
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: KustomizationSpec defines the desired state of a kustomization.
+-            properties:
+-              decryption:
+-                description: Decrypt Kubernetes secrets before applying them on the
+-                  cluster.
+-                properties:
+-                  provider:
+-                    description: Provider is the name of the decryption engine.
+-                    enum:
+-                    - sops
+-                    type: string
+-                  secretRef:
+-                    description: The secret name containing the private OpenPGP keys
+-                      used for decryption.
+-                    properties:
+-                      name:
+-                        description: Name of the referent.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - provider
+-                type: object
+-              dependsOn:
+-                description: |-
+-                  DependsOn may contain a meta.NamespacedObjectReference slice
+-                  with references to Kustomization resources that must be ready before this
+-                  Kustomization can be reconciled.
+-                items:
+-                  description: |-
+-                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+-                    namespace.
+-                  properties:
+-                    name:
+-                      description: Name of the referent.
+-                      type: string
+-                    namespace:
+-                      description: Namespace of the referent, when not specified it
+-                        acts as LocalObjectReference.
+-                      type: string
+-                  required:
+-                  - name
+-                  type: object
+-                type: array
+-              force:
+-                default: false
+-                description: |-
+-                  Force instructs the controller to recreate resources
+-                  when patching fails due to an immutable field change.
+-                type: boolean
+-              healthChecks:
+-                description: A list of resources to be included in the health assessment.
+-                items:
+-                  description: |-
+-                    NamespacedObjectKindReference contains enough information to locate the typed referenced Kubernetes resource object
+-                    in any namespace.
+-                  properties:
+-                    apiVersion:
+-                      description: API version of the referent, if not specified the
+-                        Kubernetes preferred version will be used.
+-                      type: string
+-                    kind:
+-                      description: Kind of the referent.
+-                      type: string
+-                    name:
+-                      description: Name of the referent.
+-                      type: string
+-                    namespace:
+-                      description: Namespace of the referent, when not specified it
+-                        acts as LocalObjectReference.
+-                      type: string
+-                  required:
+-                  - kind
+-                  - name
+-                  type: object
+-                type: array
+-              images:
+-                description: |-
+-                  Images is a list of (image name, new name, new tag or digest)
+-                  for changing image names, tags or digests. This can also be achieved with a
+-                  patch, but this operator is simpler to specify.
+-                items:
+-                  description: Image contains an image name, a new name, a new tag
+-                    or digest, which will replace the original name and tag.
+-                  properties:
+-                    digest:
+-                      description: |-
+-                        Digest is the value used to replace the original image tag.
+-                        If digest is present NewTag value is ignored.
+-                      type: string
+-                    name:
+-                      description: Name is a tag-less image name.
+-                      type: string
+-                    newName:
+-                      description: NewName is the value used to replace the original
+-                        name.
+-                      type: string
+-                    newTag:
+-                      description: NewTag is the value used to replace the original
+-                        tag.
+-                      type: string
+-                  required:
+-                  - name
+-                  type: object
+-                type: array
+-              interval:
+-                description: The interval at which to reconcile the Kustomization.
+-                type: string
+-              kubeConfig:
+-                description: |-
+-                  The KubeConfig for reconciling the Kustomization on a remote cluster.
+-                  When specified, KubeConfig takes precedence over ServiceAccountName.
+-                properties:
+-                  secretRef:
+-                    description: |-
+-                      SecretRef holds the name to a secret that contains a 'value' key with
+-                      the kubeconfig file as the value. It must be in the same namespace as
+-                      the Kustomization.
+-                      It is recommended that the kubeconfig is self-contained, and the secret
+-                      is regularly updated if credentials such as a cloud-access-token expire.
+-                      Cloud specific `cmd-path` auth helpers will not function without adding
+-                      binaries and credentials to the Pod that is responsible for reconciling
+-                      the Kustomization.
+-                    properties:
+-                      name:
+-                        description: Name of the referent.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - secretRef
+-                type: object
+-              patches:
+-                description: |-
+-                  Strategic merge and JSON patches, defined as inline YAML objects,
+-                  capable of targeting objects based on kind, label and annotation selectors.
+-                items:
+-                  description: |-
+-                    Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+-                    be applied to.
+-                  properties:
+-                    patch:
+-                      description: |-
+-                        Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+-                        an array of operation objects.
+-                      type: string
+-                    target:
+-                      description: Target points to the resources that the patch document
+-                        should be applied to.
+-                      properties:
+-                        annotationSelector:
+-                          description: |-
+-                            AnnotationSelector is a string that follows the label selection expression
+-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                            It matches with the resource annotations.
+-                          type: string
+-                        group:
+-                          description: |-
+-                            Group is the API group to select resources from.
+-                            Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                          type: string
+-                        kind:
+-                          description: |-
+-                            Kind of the API Group to select resources from.
+-                            Together with Group and Version it is capable of unambiguously
+-                            identifying and/or selecting resources.
+-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                          type: string
+-                        labelSelector:
+-                          description: |-
+-                            LabelSelector is a string that follows the label selection expression
+-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                            It matches with the resource labels.
+-                          type: string
+-                        name:
+-                          description: Name to match resources with.
+-                          type: string
+-                        namespace:
+-                          description: Namespace to select resources from.
+-                          type: string
+-                        version:
+-                          description: |-
+-                            Version of the API Group to select resources from.
+-                            Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                          type: string
+-                      type: object
+-                  required:
+-                  - patch
+-                  type: object
+-                type: array
+-              patchesJson6902:
+-                description: JSON 6902 patches, defined as inline YAML objects.
+-                items:
+-                  description: JSON6902Patch contains a JSON6902 patch and the target
+-                    the patch should be applied to.
+-                  properties:
+-                    patch:
+-                      description: Patch contains the JSON6902 patch document with
+-                        an array of operation objects.
+-                      items:
+-                        description: |-
+-                          JSON6902 is a JSON6902 operation object.
+-                          https://datatracker.ietf.org/doc/html/rfc6902#section-4
+-                        properties:
+-                          from:
+-                            description: |-
+-                              From contains a JSON-pointer value that references a location within the target document where the operation is
+-                              performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
+-                            type: string
+-                          op:
+-                            description: |-
+-                              Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
+-                              "test".
+-                              https://datatracker.ietf.org/doc/html/rfc6902#section-4
+-                            enum:
+-                            - test
+-                            - remove
+-                            - add
+-                            - replace
+-                            - move
+-                            - copy
+-                            type: string
+-                          path:
+-                            description: |-
+-                              Path contains the JSON-pointer value that references a location within the target document where the operation
+-                              is performed. The meaning of the value depends on the value of Op.
+-                            type: string
+-                          value:
+-                            description: |-
+-                              Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
+-                              account by all operations.
+-                            x-kubernetes-preserve-unknown-fields: true
+-                        required:
+-                        - op
+-                        - path
+-                        type: object
+-                      type: array
+-                    target:
+-                      description: Target points to the resources that the patch document
+-                        should be applied to.
+-                      properties:
+-                        annotationSelector:
+-                          description: |-
+-                            AnnotationSelector is a string that follows the label selection expression
+-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                            It matches with the resource annotations.
+-                          type: string
+-                        group:
+-                          description: |-
+-                            Group is the API group to select resources from.
+-                            Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                          type: string
+-                        kind:
+-                          description: |-
+-                            Kind of the API Group to select resources from.
+-                            Together with Group and Version it is capable of unambiguously
+-                            identifying and/or selecting resources.
+-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                          type: string
+-                        labelSelector:
+-                          description: |-
+-                            LabelSelector is a string that follows the label selection expression
+-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                            It matches with the resource labels.
+-                          type: string
+-                        name:
+-                          description: Name to match resources with.
+-                          type: string
+-                        namespace:
+-                          description: Namespace to select resources from.
+-                          type: string
+-                        version:
+-                          description: |-
+-                            Version of the API Group to select resources from.
+-                            Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                          type: string
+-                      type: object
+-                  required:
+-                  - patch
+-                  - target
+-                  type: object
+-                type: array
+-              patchesStrategicMerge:
+-                description: Strategic merge patches, defined as inline YAML objects.
+-                items:
+-                  x-kubernetes-preserve-unknown-fields: true
+-                type: array
+-              path:
+-                description: |-
+-                  Path to the directory containing the kustomization.yaml file, or the
+-                  set of plain YAMLs a kustomization.yaml should be generated for.
+-                  Defaults to 'None', which translates to the root path of the SourceRef.
+-                type: string
+-              postBuild:
+-                description: |-
+-                  PostBuild describes which actions to perform on the YAML manifest
+-                  generated by building the kustomize overlay.
+-                properties:
+-                  substitute:
+-                    additionalProperties:
+-                      type: string
+-                    description: |-
+-                      Substitute holds a map of key/value pairs.
+-                      The variables defined in your YAML manifests
+-                      that match any of the keys defined in the map
+-                      will be substituted with the set value.
+-                      Includes support for bash string replacement functions
+-                      e.g. ${var:=default}, ${var:position} and ${var/substring/replacement}.
+-                    type: object
+-                  substituteFrom:
+-                    description: |-
+-                      SubstituteFrom holds references to ConfigMaps and Secrets containing
+-                      the variables and their values to be substituted in the YAML manifests.
+-                      The ConfigMap and the Secret data keys represent the var names and they
+-                      must match the vars declared in the manifests for the substitution to happen.
+-                    items:
+-                      description: |-
+-                        SubstituteReference contains a reference to a resource containing
+-                        the variables name and value.
+-                      properties:
+-                        kind:
+-                          description: Kind of the values referent, valid values are
+-                            ('Secret', 'ConfigMap').
+-                          enum:
+-                          - Secret
+-                          - ConfigMap
+-                          type: string
+-                        name:
+-                          description: |-
+-                            Name of the values referent. Should reside in the same namespace as the
+-                            referring resource.
+-                          maxLength: 253
+-                          minLength: 1
+-                          type: string
+-                      required:
+-                      - kind
+-                      - name
+-                      type: object
+-                    type: array
+-                type: object
+-              prune:
+-                description: Prune enables garbage collection.
+-                type: boolean
+-              retryInterval:
+-                description: |-
+-                  The interval at which to retry a previously failed reconciliation.
+-                  When not specified, the controller uses the KustomizationSpec.Interval
+-                  value to retry failures.
+-                type: string
+-              serviceAccountName:
+-                description: |-
+-                  The name of the Kubernetes service account to impersonate
+-                  when reconciling this Kustomization.
+-                type: string
+-              sourceRef:
+-                description: Reference of the source where the kustomization file
+-                  is.
+-                properties:
+-                  apiVersion:
+-                    description: API version of the referent
+-                    type: string
+-                  kind:
+-                    description: Kind of the referent
+-                    enum:
+-                    - GitRepository
+-                    - Bucket
+-                    type: string
+-                  name:
+-                    description: Name of the referent
+-                    type: string
+-                  namespace:
+-                    description: Namespace of the referent, defaults to the Kustomization
+-                      namespace
+-                    type: string
+-                required:
+-                - kind
+-                - name
+-                type: object
+-              suspend:
+-                description: |-
+-                  This flag tells the controller to suspend subsequent kustomize executions,
+-                  it does not apply to already started executions. Defaults to false.
+-                type: boolean
+-              targetNamespace:
+-                description: |-
+-                  TargetNamespace sets or overrides the namespace in the
+-                  kustomization.yaml file.
+-                maxLength: 63
+-                minLength: 1
+-                type: string
+-              timeout:
+-                description: |-
+-                  Timeout for validation, apply and health checking operations.
+-                  Defaults to 'Interval' duration.
+-                type: string
+-              validation:
+-                description: |-
+-                  Validate the Kubernetes objects before applying them on the cluster.
+-                  The validation strategy can be 'client' (local dry-run), 'server'
+-                  (APIServer dry-run) or 'none'.
+-                  When 'Force' is 'true', validation will fallback to 'client' if set to
+-                  'server' because server-side validation is not supported in this scenario.
+-                enum:
+-                - none
+-                - client
+-                - server
+-                type: string
+-            required:
+-            - interval
+-            - prune
+-            - sourceRef
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: KustomizationStatus defines the observed state of a kustomization.
+-            properties:
+-              conditions:
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              lastAppliedRevision:
+-                description: |-
+-                  The last successfully applied revision.
+-                  The revision format for Git sources is <branch|tag>/<commit-sha>.
+-                type: string
+-              lastAttemptedRevision:
+-                description: LastAttemptedRevision is the revision of the last reconciliation
+-                  attempt.
+-                type: string
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: ObservedGeneration is the last reconciled generation.
+-                format: int64
+-                type: integer
+-              snapshot:
+-                description: The last successfully applied revision metadata.
+-                properties:
+-                  checksum:
+-                    description: The manifests sha1 checksum.
+-                    type: string
+-                  entries:
+-                    description: A list of Kubernetes kinds grouped by namespace.
+-                    items:
+-                      description: |-
+-                        Snapshot holds the metadata of namespaced
+-                        Kubernetes objects
+-                      properties:
+-                        kinds:
+-                          additionalProperties:
+-                            type: string
+-                          description: The list of Kubernetes kinds.
+-                          type: object
+-                        namespace:
+-                          description: The namespace of this entry.
+-                          type: string
+-                      required:
+-                      - kinds
+-                      type: object
+-                    type: array
+-                required:
+-                - checksum
+-                - entries
+-                type: object
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    deprecated: true
+-    deprecationWarning: v1beta2 Kustomization is deprecated, upgrade to v1
+-    name: v1beta2
+-    schema:
+-      openAPIV3Schema:
+-        description: Kustomization is the Schema for the kustomizations API.
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: KustomizationSpec defines the configuration to calculate
+-              the desired state from a Source using Kustomize.
+-            properties:
+-              commonMetadata:
+-                description: |-
+-                  CommonMetadata specifies the common labels and annotations that are applied to all resources.
+-                  Any existing label or annotation will be overridden if its key matches a common one.
+-                properties:
+-                  annotations:
+-                    additionalProperties:
+-                      type: string
+-                    description: Annotations to be added to the object's metadata.
+-                    type: object
+-                  labels:
+-                    additionalProperties:
+-                      type: string
+-                    description: Labels to be added to the object's metadata.
+-                    type: object
+-                type: object
+-              components:
+-                description: Components specifies relative paths to specifications
+-                  of other Components.
+-                items:
+-                  type: string
+-                type: array
+-              decryption:
+-                description: Decrypt Kubernetes secrets before applying them on the
+-                  cluster.
+-                properties:
+-                  provider:
+-                    description: Provider is the name of the decryption engine.
+-                    enum:
+-                    - sops
+-                    type: string
+-                  secretRef:
+-                    description: The secret name containing the private OpenPGP keys
+-                      used for decryption.
+-                    properties:
+-                      name:
+-                        description: Name of the referent.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - provider
+-                type: object
+-              dependsOn:
+-                description: |-
+-                  DependsOn may contain a meta.NamespacedObjectReference slice
+-                  with references to Kustomization resources that must be ready before this
+-                  Kustomization can be reconciled.
+-                items:
+-                  description: |-
+-                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+-                    namespace.
+-                  properties:
+-                    name:
+-                      description: Name of the referent.
+-                      type: string
+-                    namespace:
+-                      description: Namespace of the referent, when not specified it
+-                        acts as LocalObjectReference.
+-                      type: string
+-                  required:
+-                  - name
+-                  type: object
+-                type: array
+-              force:
+-                default: false
+-                description: |-
+-                  Force instructs the controller to recreate resources
+-                  when patching fails due to an immutable field change.
+-                type: boolean
+-              healthChecks:
+-                description: A list of resources to be included in the health assessment.
+-                items:
+-                  description: |-
+-                    NamespacedObjectKindReference contains enough information to locate the typed referenced Kubernetes resource object
+-                    in any namespace.
+-                  properties:
+-                    apiVersion:
+-                      description: API version of the referent, if not specified the
+-                        Kubernetes preferred version will be used.
+-                      type: string
+-                    kind:
+-                      description: Kind of the referent.
+-                      type: string
+-                    name:
+-                      description: Name of the referent.
+-                      type: string
+-                    namespace:
+-                      description: Namespace of the referent, when not specified it
+-                        acts as LocalObjectReference.
+-                      type: string
+-                  required:
+-                  - kind
+-                  - name
+-                  type: object
+-                type: array
+-              images:
+-                description: |-
+-                  Images is a list of (image name, new name, new tag or digest)
+-                  for changing image names, tags or digests. This can also be achieved with a
+-                  patch, but this operator is simpler to specify.
+-                items:
+-                  description: Image contains an image name, a new name, a new tag
+-                    or digest, which will replace the original name and tag.
+-                  properties:
+-                    digest:
+-                      description: |-
+-                        Digest is the value used to replace the original image tag.
+-                        If digest is present NewTag value is ignored.
+-                      type: string
+-                    name:
+-                      description: Name is a tag-less image name.
+-                      type: string
+-                    newName:
+-                      description: NewName is the value used to replace the original
+-                        name.
+-                      type: string
+-                    newTag:
+-                      description: NewTag is the value used to replace the original
+-                        tag.
+-                      type: string
+-                  required:
+-                  - name
+-                  type: object
+-                type: array
+-              interval:
+-                description: The interval at which to reconcile the Kustomization.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              kubeConfig:
+-                description: |-
+-                  The KubeConfig for reconciling the Kustomization on a remote cluster.
+-                  When used in combination with KustomizationSpec.ServiceAccountName,
+-                  forces the controller to act on behalf of that Service Account at the
+-                  target cluster.
+-                  If the --default-service-account flag is set, its value will be used as
+-                  a controller level fallback for when KustomizationSpec.ServiceAccountName
+-                  is empty.
+-                properties:
+-                  secretRef:
+-                    description: |-
+-                      SecretRef holds the name of a secret that contains a key with
+-                      the kubeconfig file as the value. If no key is set, the key will default
+-                      to 'value'.
+-                      It is recommended that the kubeconfig is self-contained, and the secret
+-                      is regularly updated if credentials such as a cloud-access-token expire.
+-                      Cloud specific `cmd-path` auth helpers will not function without adding
+-                      binaries and credentials to the Pod that is responsible for reconciling
+-                      Kubernetes resources.
+-                    properties:
+-                      key:
+-                        description: Key in the Secret, when not specified an implementation-specific
+-                          default key is used.
+-                        type: string
+-                      name:
+-                        description: Name of the Secret.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - secretRef
+-                type: object
+-              patches:
+-                description: |-
+-                  Strategic merge and JSON patches, defined as inline YAML objects,
+-                  capable of targeting objects based on kind, label and annotation selectors.
+-                items:
+-                  description: |-
+-                    Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+-                    be applied to.
+-                  properties:
+-                    patch:
+-                      description: |-
+-                        Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+-                        an array of operation objects.
+-                      type: string
+-                    target:
+-                      description: Target points to the resources that the patch document
+-                        should be applied to.
+-                      properties:
+-                        annotationSelector:
+-                          description: |-
+-                            AnnotationSelector is a string that follows the label selection expression
+-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                            It matches with the resource annotations.
+-                          type: string
+-                        group:
+-                          description: |-
+-                            Group is the API group to select resources from.
+-                            Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                          type: string
+-                        kind:
+-                          description: |-
+-                            Kind of the API Group to select resources from.
+-                            Together with Group and Version it is capable of unambiguously
+-                            identifying and/or selecting resources.
+-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                          type: string
+-                        labelSelector:
+-                          description: |-
+-                            LabelSelector is a string that follows the label selection expression
+-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                            It matches with the resource labels.
+-                          type: string
+-                        name:
+-                          description: Name to match resources with.
+-                          type: string
+-                        namespace:
+-                          description: Namespace to select resources from.
+-                          type: string
+-                        version:
+-                          description: |-
+-                            Version of the API Group to select resources from.
+-                            Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                          type: string
+-                      type: object
+-                  required:
+-                  - patch
+-                  type: object
+-                type: array
+-              patchesJson6902:
+-                description: |-
+-                  JSON 6902 patches, defined as inline YAML objects.
+-                  Deprecated: Use Patches instead.
+-                items:
+-                  description: JSON6902Patch contains a JSON6902 patch and the target
+-                    the patch should be applied to.
+-                  properties:
+-                    patch:
+-                      description: Patch contains the JSON6902 patch document with
+-                        an array of operation objects.
+-                      items:
+-                        description: |-
+-                          JSON6902 is a JSON6902 operation object.
+-                          https://datatracker.ietf.org/doc/html/rfc6902#section-4
+-                        properties:
+-                          from:
+-                            description: |-
+-                              From contains a JSON-pointer value that references a location within the target document where the operation is
+-                              performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
+-                            type: string
+-                          op:
+-                            description: |-
+-                              Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
+-                              "test".
+-                              https://datatracker.ietf.org/doc/html/rfc6902#section-4
+-                            enum:
+-                            - test
+-                            - remove
+-                            - add
+-                            - replace
+-                            - move
+-                            - copy
+-                            type: string
+-                          path:
+-                            description: |-
+-                              Path contains the JSON-pointer value that references a location within the target document where the operation
+-                              is performed. The meaning of the value depends on the value of Op.
+-                            type: string
+-                          value:
+-                            description: |-
+-                              Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
+-                              account by all operations.
+-                            x-kubernetes-preserve-unknown-fields: true
+-                        required:
+-                        - op
+-                        - path
+-                        type: object
+-                      type: array
+-                    target:
+-                      description: Target points to the resources that the patch document
+-                        should be applied to.
+-                      properties:
+-                        annotationSelector:
+-                          description: |-
+-                            AnnotationSelector is a string that follows the label selection expression
+-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                            It matches with the resource annotations.
+-                          type: string
+-                        group:
+-                          description: |-
+-                            Group is the API group to select resources from.
+-                            Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                          type: string
+-                        kind:
+-                          description: |-
+-                            Kind of the API Group to select resources from.
+-                            Together with Group and Version it is capable of unambiguously
+-                            identifying and/or selecting resources.
+-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                          type: string
+-                        labelSelector:
+-                          description: |-
+-                            LabelSelector is a string that follows the label selection expression
+-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+-                            It matches with the resource labels.
+-                          type: string
+-                        name:
+-                          description: Name to match resources with.
+-                          type: string
+-                        namespace:
+-                          description: Namespace to select resources from.
+-                          type: string
+-                        version:
+-                          description: |-
+-                            Version of the API Group to select resources from.
+-                            Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+-                          type: string
+-                      type: object
+-                  required:
+-                  - patch
+-                  - target
+-                  type: object
+-                type: array
+-              patchesStrategicMerge:
+-                description: |-
+-                  Strategic merge patches, defined as inline YAML objects.
+-                  Deprecated: Use Patches instead.
+-                items:
+-                  x-kubernetes-preserve-unknown-fields: true
+-                type: array
+-              path:
+-                description: |-
+-                  Path to the directory containing the kustomization.yaml file, or the
+-                  set of plain YAMLs a kustomization.yaml should be generated for.
+-                  Defaults to 'None', which translates to the root path of the SourceRef.
+-                type: string
+-              postBuild:
+-                description: |-
+-                  PostBuild describes which actions to perform on the YAML manifest
+-                  generated by building the kustomize overlay.
+-                properties:
+-                  substitute:
+-                    additionalProperties:
+-                      type: string
+-                    description: |-
+-                      Substitute holds a map of key/value pairs.
+-                      The variables defined in your YAML manifests
+-                      that match any of the keys defined in the map
+-                      will be substituted with the set value.
+-                      Includes support for bash string replacement functions
+-                      e.g. ${var:=default}, ${var:position} and ${var/substring/replacement}.
+-                    type: object
+-                  substituteFrom:
+-                    description: |-
+-                      SubstituteFrom holds references to ConfigMaps and Secrets containing
+-                      the variables and their values to be substituted in the YAML manifests.
+-                      The ConfigMap and the Secret data keys represent the var names and they
+-                      must match the vars declared in the manifests for the substitution to happen.
+-                    items:
+-                      description: |-
+-                        SubstituteReference contains a reference to a resource containing
+-                        the variables name and value.
+-                      properties:
+-                        kind:
+-                          description: Kind of the values referent, valid values are
+-                            ('Secret', 'ConfigMap').
+-                          enum:
+-                          - Secret
+-                          - ConfigMap
+-                          type: string
+-                        name:
+-                          description: |-
+-                            Name of the values referent. Should reside in the same namespace as the
+-                            referring resource.
+-                          maxLength: 253
+-                          minLength: 1
+-                          type: string
+-                        optional:
+-                          default: false
+-                          description: |-
+-                            Optional indicates whether the referenced resource must exist, or whether to
+-                            tolerate its absence. If true and the referenced resource is absent, proceed
+-                            as if the resource was present but empty, without any variables defined.
+-                          type: boolean
+-                      required:
+-                      - kind
+-                      - name
+-                      type: object
+-                    type: array
+-                type: object
+-              prune:
+-                description: Prune enables garbage collection.
+-                type: boolean
+-              retryInterval:
+-                description: |-
+-                  The interval at which to retry a previously failed reconciliation.
+-                  When not specified, the controller uses the KustomizationSpec.Interval
+-                  value to retry failures.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              serviceAccountName:
+-                description: |-
+-                  The name of the Kubernetes service account to impersonate
+-                  when reconciling this Kustomization.
+-                type: string
+-              sourceRef:
+-                description: Reference of the source where the kustomization file
+-                  is.
+-                properties:
+-                  apiVersion:
+-                    description: API version of the referent.
+-                    type: string
+-                  kind:
+-                    description: Kind of the referent.
+-                    enum:
+-                    - OCIRepository
+-                    - GitRepository
+-                    - Bucket
+-                    type: string
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                  namespace:
+-                    description: Namespace of the referent, defaults to the namespace
+-                      of the Kubernetes resource object that contains the reference.
+-                    type: string
+-                required:
+-                - kind
+-                - name
+-                type: object
+-              suspend:
+-                description: |-
+-                  This flag tells the controller to suspend subsequent kustomize executions,
+-                  it does not apply to already started executions. Defaults to false.
+-                type: boolean
+-              targetNamespace:
+-                description: |-
+-                  TargetNamespace sets or overrides the namespace in the
+-                  kustomization.yaml file.
+-                maxLength: 63
+-                minLength: 1
+-                type: string
+-              timeout:
+-                description: |-
+-                  Timeout for validation, apply and health checking operations.
+-                  Defaults to 'Interval' duration.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              validation:
+-                description: 'Deprecated: Not used in v1beta2.'
+-                enum:
+-                - none
+-                - client
+-                - server
+-                type: string
+-              wait:
+-                description: |-
+-                  Wait instructs the controller to check the health of all the reconciled resources.
+-                  When enabled, the HealthChecks are ignored. Defaults to false.
+-                type: boolean
+-            required:
+-            - interval
+-            - prune
+-            - sourceRef
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: KustomizationStatus defines the observed state of a kustomization.
+-            properties:
+-              conditions:
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              inventory:
+-                description: Inventory contains the list of Kubernetes resource object
+-                  references that have been successfully applied.
+-                properties:
+-                  entries:
+-                    description: Entries of Kubernetes resource object references.
+-                    items:
+-                      description: ResourceRef contains the information necessary
+-                        to locate a resource within a cluster.
+-                      properties:
+-                        id:
+-                          description: |-
+-                            ID is the string representation of the Kubernetes resource object's metadata,
+-                            in the format '<namespace>_<name>_<group>_<kind>'.
+-                          type: string
+-                        v:
+-                          description: Version is the API version of the Kubernetes
+-                            resource object's kind.
+-                          type: string
+-                      required:
+-                      - id
+-                      - v
+-                      type: object
+-                    type: array
+-                required:
+-                - entries
+-                type: object
+-              lastAppliedRevision:
+-                description: |-
+-                  The last successfully applied revision.
+-                  Equals the Revision of the applied Artifact from the referenced Source.
+-                type: string
+-              lastAttemptedRevision:
+-                description: LastAttemptedRevision is the revision of the last reconciliation
+-                  attempt.
+-                type: string
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: ObservedGeneration is the last reconciled generation.
+-                format: int64
+-                type: integer
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+diff --git a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_ocirepositories.source.toolkit.fluxcd.io.yaml b/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_ocirepositories.source.toolkit.fluxcd.io.yaml
+deleted file mode 100644
+index 8f9b4eb500..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_ocirepositories.source.toolkit.fluxcd.io.yaml
++++ /dev/null
+@@ -1,825 +0,0 @@
+-apiVersion: apiextensions.k8s.io/v1
+-kind: CustomResourceDefinition
+-metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: v0.16.1
+-  labels:
+-    app.kubernetes.io/component: source-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: ocirepositories.source.toolkit.fluxcd.io
+-spec:
+-  group: source.toolkit.fluxcd.io
+-  names:
+-    kind: OCIRepository
+-    listKind: OCIRepositoryList
+-    plural: ocirepositories
+-    shortNames:
+-    - ocirepo
+-    singular: ocirepository
+-  scope: Namespaced
+-  versions:
+-  - additionalPrinterColumns:
+-    - jsonPath: .spec.url
+-      name: URL
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    name: v1
+-    schema:
+-      openAPIV3Schema:
+-        description: OCIRepository is the Schema for the ocirepositories API
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: OCIRepositorySpec defines the desired state of OCIRepository
+-            properties:
+-              certSecretRef:
+-                description: |-
+-                  CertSecretRef can be given the name of a Secret containing
+-                  either or both of
+-
+-                  - a PEM-encoded client certificate (`tls.crt`) and private
+-                  key (`tls.key`);
+-                  - a PEM-encoded CA certificate (`ca.crt`)
+-
+-                  and whichever are supplied, will be used for connecting to the
+-                  registry. The client cert and key are useful if you are
+-                  authenticating with a certificate; the CA cert is useful if
+-                  you are using a self-signed server certificate. The Secret must
+-                  be of type `Opaque` or `kubernetes.io/tls`.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              ignore:
+-                description: |-
+-                  Ignore overrides the set of excluded patterns in the .sourceignore format
+-                  (which is the same as .gitignore). If not provided, a default will be used,
+-                  consult the documentation for your version to find out what those are.
+-                type: string
+-              insecure:
+-                description: Insecure allows connecting to a non-TLS HTTP container
+-                  registry.
+-                type: boolean
+-              interval:
+-                description: |-
+-                  Interval at which the OCIRepository URL is checked for updates.
+-                  This interval is approximate and may be subject to jitter to ensure
+-                  efficient use of resources.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              layerSelector:
+-                description: |-
+-                  LayerSelector specifies which layer should be extracted from the OCI artifact.
+-                  When not specified, the first layer found in the artifact is selected.
+-                properties:
+-                  mediaType:
+-                    description: |-
+-                      MediaType specifies the OCI media type of the layer
+-                      which should be extracted from the OCI Artifact. The
+-                      first layer matching this type is selected.
+-                    type: string
+-                  operation:
+-                    description: |-
+-                      Operation specifies how the selected layer should be processed.
+-                      By default, the layer compressed content is extracted to storage.
+-                      When the operation is set to 'copy', the layer compressed content
+-                      is persisted to storage as it is.
+-                    enum:
+-                    - extract
+-                    - copy
+-                    type: string
+-                type: object
+-              provider:
+-                default: generic
+-                description: |-
+-                  The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+-                  When not specified, defaults to 'generic'.
+-                enum:
+-                - generic
+-                - aws
+-                - azure
+-                - gcp
+-                type: string
+-              proxySecretRef:
+-                description: |-
+-                  ProxySecretRef specifies the Secret containing the proxy configuration
+-                  to use while communicating with the container registry.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              ref:
+-                description: |-
+-                  The OCI reference to pull and monitor for changes,
+-                  defaults to the latest tag.
+-                properties:
+-                  digest:
+-                    description: |-
+-                      Digest is the image digest to pull, takes precedence over SemVer.
+-                      The value should be in the format 'sha256:<HASH>'.
+-                    type: string
+-                  semver:
+-                    description: |-
+-                      SemVer is the range of tags to pull selecting the latest within
+-                      the range, takes precedence over Tag.
+-                    type: string
+-                  semverFilter:
+-                    description: SemverFilter is a regex pattern to filter the tags
+-                      within the SemVer range.
+-                    type: string
+-                  tag:
+-                    description: Tag is the image tag to pull, defaults to latest.
+-                    type: string
+-                type: object
+-              secretRef:
+-                description: |-
+-                  SecretRef contains the secret name containing the registry login
+-                  credentials to resolve image metadata.
+-                  The secret must be of type kubernetes.io/dockerconfigjson.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              serviceAccountName:
+-                description: |-
+-                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+-                  the image pull if the service account has attached pull secrets. For more information:
+-                  https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
+-                type: string
+-              suspend:
+-                description: This flag tells the controller to suspend the reconciliation
+-                  of this source.
+-                type: boolean
+-              timeout:
+-                default: 60s
+-                description: The timeout for remote OCI Repository operations like
+-                  pulling, defaults to 60s.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+-                type: string
+-              url:
+-                description: |-
+-                  URL is a reference to an OCI artifact repository hosted
+-                  on a remote container registry.
+-                pattern: ^oci://.*$
+-                type: string
+-              verify:
+-                description: |-
+-                  Verify contains the secret name containing the trusted public keys
+-                  used to verify the signature and specifies which provider to use to check
+-                  whether OCI image is authentic.
+-                properties:
+-                  matchOIDCIdentity:
+-                    description: |-
+-                      MatchOIDCIdentity specifies the identity matching criteria to use
+-                      while verifying an OCI artifact which was signed using Cosign keyless
+-                      signing. The artifact's identity is deemed to be verified if any of the
+-                      specified matchers match against the identity.
+-                    items:
+-                      description: |-
+-                        OIDCIdentityMatch specifies options for verifying the certificate identity,
+-                        i.e. the issuer and the subject of the certificate.
+-                      properties:
+-                        issuer:
+-                          description: |-
+-                            Issuer specifies the regex pattern to match against to verify
+-                            the OIDC issuer in the Fulcio certificate. The pattern must be a
+-                            valid Go regular expression.
+-                          type: string
+-                        subject:
+-                          description: |-
+-                            Subject specifies the regex pattern to match against to verify
+-                            the identity subject in the Fulcio certificate. The pattern must
+-                            be a valid Go regular expression.
+-                          type: string
+-                      required:
+-                      - issuer
+-                      - subject
+-                      type: object
+-                    type: array
+-                  provider:
+-                    default: cosign
+-                    description: Provider specifies the technology used to sign the
+-                      OCI Artifact.
+-                    enum:
+-                    - cosign
+-                    - notation
+-                    type: string
+-                  secretRef:
+-                    description: |-
+-                      SecretRef specifies the Kubernetes Secret containing the
+-                      trusted public keys.
+-                    properties:
+-                      name:
+-                        description: Name of the referent.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - provider
+-                type: object
+-            required:
+-            - interval
+-            - url
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: OCIRepositoryStatus defines the observed state of OCIRepository
+-            properties:
+-              artifact:
+-                description: Artifact represents the output of the last successful
+-                  OCI Repository sync.
+-                properties:
+-                  digest:
+-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+-                    type: string
+-                  lastUpdateTime:
+-                    description: |-
+-                      LastUpdateTime is the timestamp corresponding to the last update of the
+-                      Artifact.
+-                    format: date-time
+-                    type: string
+-                  metadata:
+-                    additionalProperties:
+-                      type: string
+-                    description: Metadata holds upstream information such as OCI annotations.
+-                    type: object
+-                  path:
+-                    description: |-
+-                      Path is the relative file path of the Artifact. It can be used to locate
+-                      the file in the root of the Artifact storage on the local file system of
+-                      the controller managing the Source.
+-                    type: string
+-                  revision:
+-                    description: |-
+-                      Revision is a human-readable identifier traceable in the origin source
+-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+-                    type: string
+-                  size:
+-                    description: Size is the number of bytes in the file.
+-                    format: int64
+-                    type: integer
+-                  url:
+-                    description: |-
+-                      URL is the HTTP address of the Artifact as exposed by the controller
+-                      managing the Source. It can be used to retrieve the Artifact for
+-                      consumption, e.g. by another controller applying the Artifact contents.
+-                    type: string
+-                required:
+-                - lastUpdateTime
+-                - path
+-                - revision
+-                - url
+-                type: object
+-              conditions:
+-                description: Conditions holds the conditions for the OCIRepository.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation.
+-                format: int64
+-                type: integer
+-              observedIgnore:
+-                description: |-
+-                  ObservedIgnore is the observed exclusion patterns used for constructing
+-                  the source artifact.
+-                type: string
+-              observedLayerSelector:
+-                description: |-
+-                  ObservedLayerSelector is the observed layer selector used for constructing
+-                  the source artifact.
+-                properties:
+-                  mediaType:
+-                    description: |-
+-                      MediaType specifies the OCI media type of the layer
+-                      which should be extracted from the OCI Artifact. The
+-                      first layer matching this type is selected.
+-                    type: string
+-                  operation:
+-                    description: |-
+-                      Operation specifies how the selected layer should be processed.
+-                      By default, the layer compressed content is extracted to storage.
+-                      When the operation is set to 'copy', the layer compressed content
+-                      is persisted to storage as it is.
+-                    enum:
+-                    - extract
+-                    - copy
+-                    type: string
+-                type: object
+-              url:
+-                description: URL is the download link for the artifact output of the
+-                  last OCI Repository sync.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: true
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .spec.url
+-      name: URL
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    deprecated: true
+-    deprecationWarning: v1beta2 OCIRepository is deprecated, upgrade to v1
+-    name: v1beta2
+-    schema:
+-      openAPIV3Schema:
+-        description: OCIRepository is the Schema for the ocirepositories API
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: OCIRepositorySpec defines the desired state of OCIRepository
+-            properties:
+-              certSecretRef:
+-                description: |-
+-                  CertSecretRef can be given the name of a Secret containing
+-                  either or both of
+-
+-                  - a PEM-encoded client certificate (`tls.crt`) and private
+-                  key (`tls.key`);
+-                  - a PEM-encoded CA certificate (`ca.crt`)
+-
+-                  and whichever are supplied, will be used for connecting to the
+-                  registry. The client cert and key are useful if you are
+-                  authenticating with a certificate; the CA cert is useful if
+-                  you are using a self-signed server certificate. The Secret must
+-                  be of type `Opaque` or `kubernetes.io/tls`.
+-
+-                  Note: Support for the `caFile`, `certFile` and `keyFile` keys have
+-                  been deprecated.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              ignore:
+-                description: |-
+-                  Ignore overrides the set of excluded patterns in the .sourceignore format
+-                  (which is the same as .gitignore). If not provided, a default will be used,
+-                  consult the documentation for your version to find out what those are.
+-                type: string
+-              insecure:
+-                description: Insecure allows connecting to a non-TLS HTTP container
+-                  registry.
+-                type: boolean
+-              interval:
+-                description: |-
+-                  Interval at which the OCIRepository URL is checked for updates.
+-                  This interval is approximate and may be subject to jitter to ensure
+-                  efficient use of resources.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              layerSelector:
+-                description: |-
+-                  LayerSelector specifies which layer should be extracted from the OCI artifact.
+-                  When not specified, the first layer found in the artifact is selected.
+-                properties:
+-                  mediaType:
+-                    description: |-
+-                      MediaType specifies the OCI media type of the layer
+-                      which should be extracted from the OCI Artifact. The
+-                      first layer matching this type is selected.
+-                    type: string
+-                  operation:
+-                    description: |-
+-                      Operation specifies how the selected layer should be processed.
+-                      By default, the layer compressed content is extracted to storage.
+-                      When the operation is set to 'copy', the layer compressed content
+-                      is persisted to storage as it is.
+-                    enum:
+-                    - extract
+-                    - copy
+-                    type: string
+-                type: object
+-              provider:
+-                default: generic
+-                description: |-
+-                  The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+-                  When not specified, defaults to 'generic'.
+-                enum:
+-                - generic
+-                - aws
+-                - azure
+-                - gcp
+-                type: string
+-              proxySecretRef:
+-                description: |-
+-                  ProxySecretRef specifies the Secret containing the proxy configuration
+-                  to use while communicating with the container registry.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              ref:
+-                description: |-
+-                  The OCI reference to pull and monitor for changes,
+-                  defaults to the latest tag.
+-                properties:
+-                  digest:
+-                    description: |-
+-                      Digest is the image digest to pull, takes precedence over SemVer.
+-                      The value should be in the format 'sha256:<HASH>'.
+-                    type: string
+-                  semver:
+-                    description: |-
+-                      SemVer is the range of tags to pull selecting the latest within
+-                      the range, takes precedence over Tag.
+-                    type: string
+-                  semverFilter:
+-                    description: SemverFilter is a regex pattern to filter the tags
+-                      within the SemVer range.
+-                    type: string
+-                  tag:
+-                    description: Tag is the image tag to pull, defaults to latest.
+-                    type: string
+-                type: object
+-              secretRef:
+-                description: |-
+-                  SecretRef contains the secret name containing the registry login
+-                  credentials to resolve image metadata.
+-                  The secret must be of type kubernetes.io/dockerconfigjson.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              serviceAccountName:
+-                description: |-
+-                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+-                  the image pull if the service account has attached pull secrets. For more information:
+-                  https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
+-                type: string
+-              suspend:
+-                description: This flag tells the controller to suspend the reconciliation
+-                  of this source.
+-                type: boolean
+-              timeout:
+-                default: 60s
+-                description: The timeout for remote OCI Repository operations like
+-                  pulling, defaults to 60s.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+-                type: string
+-              url:
+-                description: |-
+-                  URL is a reference to an OCI artifact repository hosted
+-                  on a remote container registry.
+-                pattern: ^oci://.*$
+-                type: string
+-              verify:
+-                description: |-
+-                  Verify contains the secret name containing the trusted public keys
+-                  used to verify the signature and specifies which provider to use to check
+-                  whether OCI image is authentic.
+-                properties:
+-                  matchOIDCIdentity:
+-                    description: |-
+-                      MatchOIDCIdentity specifies the identity matching criteria to use
+-                      while verifying an OCI artifact which was signed using Cosign keyless
+-                      signing. The artifact's identity is deemed to be verified if any of the
+-                      specified matchers match against the identity.
+-                    items:
+-                      description: |-
+-                        OIDCIdentityMatch specifies options for verifying the certificate identity,
+-                        i.e. the issuer and the subject of the certificate.
+-                      properties:
+-                        issuer:
+-                          description: |-
+-                            Issuer specifies the regex pattern to match against to verify
+-                            the OIDC issuer in the Fulcio certificate. The pattern must be a
+-                            valid Go regular expression.
+-                          type: string
+-                        subject:
+-                          description: |-
+-                            Subject specifies the regex pattern to match against to verify
+-                            the identity subject in the Fulcio certificate. The pattern must
+-                            be a valid Go regular expression.
+-                          type: string
+-                      required:
+-                      - issuer
+-                      - subject
+-                      type: object
+-                    type: array
+-                  provider:
+-                    default: cosign
+-                    description: Provider specifies the technology used to sign the
+-                      OCI Artifact.
+-                    enum:
+-                    - cosign
+-                    - notation
+-                    type: string
+-                  secretRef:
+-                    description: |-
+-                      SecretRef specifies the Kubernetes Secret containing the
+-                      trusted public keys.
+-                    properties:
+-                      name:
+-                        description: Name of the referent.
+-                        type: string
+-                    required:
+-                    - name
+-                    type: object
+-                required:
+-                - provider
+-                type: object
+-            required:
+-            - interval
+-            - url
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: OCIRepositoryStatus defines the observed state of OCIRepository
+-            properties:
+-              artifact:
+-                description: Artifact represents the output of the last successful
+-                  OCI Repository sync.
+-                properties:
+-                  digest:
+-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+-                    type: string
+-                  lastUpdateTime:
+-                    description: |-
+-                      LastUpdateTime is the timestamp corresponding to the last update of the
+-                      Artifact.
+-                    format: date-time
+-                    type: string
+-                  metadata:
+-                    additionalProperties:
+-                      type: string
+-                    description: Metadata holds upstream information such as OCI annotations.
+-                    type: object
+-                  path:
+-                    description: |-
+-                      Path is the relative file path of the Artifact. It can be used to locate
+-                      the file in the root of the Artifact storage on the local file system of
+-                      the controller managing the Source.
+-                    type: string
+-                  revision:
+-                    description: |-
+-                      Revision is a human-readable identifier traceable in the origin source
+-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+-                    type: string
+-                  size:
+-                    description: Size is the number of bytes in the file.
+-                    format: int64
+-                    type: integer
+-                  url:
+-                    description: |-
+-                      URL is the HTTP address of the Artifact as exposed by the controller
+-                      managing the Source. It can be used to retrieve the Artifact for
+-                      consumption, e.g. by another controller applying the Artifact contents.
+-                    type: string
+-                required:
+-                - lastUpdateTime
+-                - path
+-                - revision
+-                - url
+-                type: object
+-              conditions:
+-                description: Conditions holds the conditions for the OCIRepository.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              contentConfigChecksum:
+-                description: |-
+-                  ContentConfigChecksum is a checksum of all the configurations related to
+-                  the content of the source artifact:
+-                   - .spec.ignore
+-                   - .spec.layerSelector
+-                  observed in .status.observedGeneration version of the object. This can
+-                  be used to determine if the content configuration has changed and the
+-                  artifact needs to be rebuilt.
+-                  It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`.
+-
+-                  Deprecated: Replaced with explicit fields for observed artifact content
+-                  config in the status.
+-                type: string
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation.
+-                format: int64
+-                type: integer
+-              observedIgnore:
+-                description: |-
+-                  ObservedIgnore is the observed exclusion patterns used for constructing
+-                  the source artifact.
+-                type: string
+-              observedLayerSelector:
+-                description: |-
+-                  ObservedLayerSelector is the observed layer selector used for constructing
+-                  the source artifact.
+-                properties:
+-                  mediaType:
+-                    description: |-
+-                      MediaType specifies the OCI media type of the layer
+-                      which should be extracted from the OCI Artifact. The
+-                      first layer matching this type is selected.
+-                    type: string
+-                  operation:
+-                    description: |-
+-                      Operation specifies how the selected layer should be processed.
+-                      By default, the layer compressed content is extracted to storage.
+-                      When the operation is set to 'copy', the layer compressed content
+-                      is persisted to storage as it is.
+-                    enum:
+-                    - extract
+-                    - copy
+-                    type: string
+-                type: object
+-              url:
+-                description: URL is the download link for the artifact output of the
+-                  last OCI Repository sync.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+diff --git a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_providers.notification.toolkit.fluxcd.io.yaml b/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_providers.notification.toolkit.fluxcd.io.yaml
+deleted file mode 100644
+index 22b1577938..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_providers.notification.toolkit.fluxcd.io.yaml
++++ /dev/null
+@@ -1,560 +0,0 @@
+-apiVersion: apiextensions.k8s.io/v1
+-kind: CustomResourceDefinition
+-metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: v0.16.1
+-  labels:
+-    app.kubernetes.io/component: notification-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: providers.notification.toolkit.fluxcd.io
+-spec:
+-  group: notification.toolkit.fluxcd.io
+-  names:
+-    kind: Provider
+-    listKind: ProviderList
+-    plural: providers
+-    singular: provider
+-  scope: Namespaced
+-  versions:
+-  - additionalPrinterColumns:
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    deprecated: true
+-    deprecationWarning: v1beta1 Provider is deprecated, upgrade to v1beta3
+-    name: v1beta1
+-    schema:
+-      openAPIV3Schema:
+-        description: Provider is the Schema for the providers API
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: ProviderSpec defines the desired state of Provider
+-            properties:
+-              address:
+-                description: HTTP/S webhook address of this provider
+-                pattern: ^(http|https)://
+-                type: string
+-              certSecretRef:
+-                description: |-
+-                  CertSecretRef can be given the name of a secret containing
+-                  a PEM-encoded CA certificate (`caFile`)
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              channel:
+-                description: Alert channel for this provider
+-                type: string
+-              proxy:
+-                description: HTTP/S address of the proxy
+-                pattern: ^(http|https)://
+-                type: string
+-              secretRef:
+-                description: |-
+-                  Secret reference containing the provider webhook URL
+-                  using "address" as data key
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              suspend:
+-                description: |-
+-                  This flag tells the controller to suspend subsequent events handling.
+-                  Defaults to false.
+-                type: boolean
+-              timeout:
+-                description: Timeout for sending alerts to the provider.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+-                type: string
+-              type:
+-                description: Type of provider
+-                enum:
+-                - slack
+-                - discord
+-                - msteams
+-                - rocket
+-                - generic
+-                - generic-hmac
+-                - github
+-                - gitlab
+-                - bitbucket
+-                - azuredevops
+-                - googlechat
+-                - webex
+-                - sentry
+-                - azureeventhub
+-                - telegram
+-                - lark
+-                - matrix
+-                - opsgenie
+-                - alertmanager
+-                - grafana
+-                - githubdispatch
+-                type: string
+-              username:
+-                description: Bot username for this provider
+-                type: string
+-            required:
+-            - type
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: ProviderStatus defines the observed state of Provider
+-            properties:
+-              conditions:
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              observedGeneration:
+-                description: ObservedGeneration is the last reconciled generation.
+-                format: int64
+-                type: integer
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    deprecated: true
+-    deprecationWarning: v1beta2 Provider is deprecated, upgrade to v1beta3
+-    name: v1beta2
+-    schema:
+-      openAPIV3Schema:
+-        description: Provider is the Schema for the providers API.
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: ProviderSpec defines the desired state of the Provider.
+-            properties:
+-              address:
+-                description: |-
+-                  Address specifies the endpoint, in a generic sense, to where alerts are sent.
+-                  What kind of endpoint depends on the specific Provider type being used.
+-                  For the generic Provider, for example, this is an HTTP/S address.
+-                  For other Provider types this could be a project ID or a namespace.
+-                maxLength: 2048
+-                type: string
+-              certSecretRef:
+-                description: |-
+-                  CertSecretRef specifies the Secret containing
+-                  a PEM-encoded CA certificate (in the `ca.crt` key).
+-
+-                  Note: Support for the `caFile` key has
+-                  been deprecated.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              channel:
+-                description: Channel specifies the destination channel where events
+-                  should be posted.
+-                maxLength: 2048
+-                type: string
+-              interval:
+-                description: Interval at which to reconcile the Provider with its
+-                  Secret references.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              proxy:
+-                description: Proxy the HTTP/S address of the proxy server.
+-                maxLength: 2048
+-                pattern: ^(http|https)://.*$
+-                type: string
+-              secretRef:
+-                description: |-
+-                  SecretRef specifies the Secret containing the authentication
+-                  credentials for this Provider.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend subsequent
+-                  events handling for this Provider.
+-                type: boolean
+-              timeout:
+-                description: Timeout for sending alerts to the Provider.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+-                type: string
+-              type:
+-                description: Type specifies which Provider implementation to use.
+-                enum:
+-                - slack
+-                - discord
+-                - msteams
+-                - rocket
+-                - generic
+-                - generic-hmac
+-                - github
+-                - gitlab
+-                - gitea
+-                - bitbucketserver
+-                - bitbucket
+-                - azuredevops
+-                - googlechat
+-                - googlepubsub
+-                - webex
+-                - sentry
+-                - azureeventhub
+-                - telegram
+-                - lark
+-                - matrix
+-                - opsgenie
+-                - alertmanager
+-                - grafana
+-                - githubdispatch
+-                - pagerduty
+-                - datadog
+-                type: string
+-              username:
+-                description: Username specifies the name under which events are posted.
+-                maxLength: 2048
+-                type: string
+-            required:
+-            - type
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: ProviderStatus defines the observed state of the Provider.
+-            properties:
+-              conditions:
+-                description: Conditions holds the conditions for the Provider.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: ObservedGeneration is the last reconciled generation.
+-                format: int64
+-                type: integer
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    name: v1beta3
+-    schema:
+-      openAPIV3Schema:
+-        description: Provider is the Schema for the providers API
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: ProviderSpec defines the desired state of the Provider.
+-            properties:
+-              address:
+-                description: |-
+-                  Address specifies the endpoint, in a generic sense, to where alerts are sent.
+-                  What kind of endpoint depends on the specific Provider type being used.
+-                  For the generic Provider, for example, this is an HTTP/S address.
+-                  For other Provider types this could be a project ID or a namespace.
+-                maxLength: 2048
+-                type: string
+-              certSecretRef:
+-                description: |-
+-                  CertSecretRef specifies the Secret containing
+-                  a PEM-encoded CA certificate (in the `ca.crt` key).
+-
+-                  Note: Support for the `caFile` key has
+-                  been deprecated.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              channel:
+-                description: Channel specifies the destination channel where events
+-                  should be posted.
+-                maxLength: 2048
+-                type: string
+-              commitStatusExpr:
+-                description: |-
+-                  CommitStatusExpr is a CEL expression that evaluates to a string value
+-                  that can be used to generate a custom commit status message for use
+-                  with eligible Provider types (github, gitlab, gitea, bitbucketserver,
+-                  bitbucket, azuredevops). Supported variables are: event, provider,
+-                  and alert.
+-                type: string
+-              interval:
+-                description: |-
+-                  Interval at which to reconcile the Provider with its Secret references.
+-                  Deprecated and not used in v1beta3.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              proxy:
+-                description: Proxy the HTTP/S address of the proxy server.
+-                maxLength: 2048
+-                pattern: ^(http|https)://.*$
+-                type: string
+-              secretRef:
+-                description: |-
+-                  SecretRef specifies the Secret containing the authentication
+-                  credentials for this Provider.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              serviceAccountName:
+-                description: |-
+-                  ServiceAccountName is the name of the service account used to
+-                  authenticate with services from cloud providers. An error is thrown if a
+-                  static credential is also defined inside the Secret referenced by the
+-                  SecretRef.
+-                type: string
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend subsequent
+-                  events handling for this Provider.
+-                type: boolean
+-              timeout:
+-                description: Timeout for sending alerts to the Provider.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+-                type: string
+-              type:
+-                description: Type specifies which Provider implementation to use.
+-                enum:
+-                - slack
+-                - discord
+-                - msteams
+-                - rocket
+-                - generic
+-                - generic-hmac
+-                - github
+-                - gitlab
+-                - gitea
+-                - bitbucketserver
+-                - bitbucket
+-                - azuredevops
+-                - googlechat
+-                - googlepubsub
+-                - webex
+-                - sentry
+-                - azureeventhub
+-                - telegram
+-                - lark
+-                - matrix
+-                - opsgenie
+-                - alertmanager
+-                - grafana
+-                - githubdispatch
+-                - pagerduty
+-                - datadog
+-                - nats
+-                type: string
+-              username:
+-                description: Username specifies the name under which events are posted.
+-                maxLength: 2048
+-                type: string
+-            required:
+-            - type
+-            type: object
+-            x-kubernetes-validations:
+-            - message: spec.commitStatusExpr is only supported for the 'github', 'gitlab',
+-                'gitea', 'bitbucketserver', 'bitbucket', 'azuredevops' provider types
+-              rule: self.type == 'github' || self.type == 'gitlab' || self.type ==
+-                'gitea' || self.type == 'bitbucketserver' || self.type == 'bitbucket'
+-                || self.type == 'azuredevops' || !has(self.commitStatusExpr)
+-        type: object
+-    served: true
+-    storage: true
+-    subresources: {}
+diff --git a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_receivers.notification.toolkit.fluxcd.io.yaml b/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_receivers.notification.toolkit.fluxcd.io.yaml
+deleted file mode 100644
+index c1e489cc42..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/apiextensions.k8s.io_v1_customresourcedefinition_receivers.notification.toolkit.fluxcd.io.yaml
++++ /dev/null
+@@ -1,683 +0,0 @@
+-apiVersion: apiextensions.k8s.io/v1
+-kind: CustomResourceDefinition
+-metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: v0.16.1
+-  labels:
+-    app.kubernetes.io/component: notification-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: receivers.notification.toolkit.fluxcd.io
+-spec:
+-  group: notification.toolkit.fluxcd.io
+-  names:
+-    kind: Receiver
+-    listKind: ReceiverList
+-    plural: receivers
+-    singular: receiver
+-  scope: Namespaced
+-  versions:
+-  - additionalPrinterColumns:
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    name: v1
+-    schema:
+-      openAPIV3Schema:
+-        description: Receiver is the Schema for the receivers API.
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: ReceiverSpec defines the desired state of the Receiver.
+-            properties:
+-              events:
+-                description: |-
+-                  Events specifies the list of event types to handle,
+-                  e.g. 'push' for GitHub or 'Push Hook' for GitLab.
+-                items:
+-                  type: string
+-                type: array
+-              interval:
+-                default: 10m
+-                description: Interval at which to reconcile the Receiver with its
+-                  Secret references.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              resourceFilter:
+-                description: |-
+-                  ResourceFilter is a CEL expression expected to return a boolean that is
+-                  evaluated for each resource referenced in the Resources field when a
+-                  webhook is received. If the expression returns false then the controller
+-                  will not request a reconciliation for the resource.
+-                  When the expression is specified the controller will parse it and mark
+-                  the object as terminally failed if the expression is invalid or does not
+-                  return a boolean.
+-                type: string
+-              resources:
+-                description: A list of resources to be notified about changes.
+-                items:
+-                  description: |-
+-                    CrossNamespaceObjectReference contains enough information to let you locate the
+-                    typed referenced object at cluster level
+-                  properties:
+-                    apiVersion:
+-                      description: API version of the referent
+-                      type: string
+-                    kind:
+-                      description: Kind of the referent
+-                      enum:
+-                      - Bucket
+-                      - GitRepository
+-                      - Kustomization
+-                      - HelmRelease
+-                      - HelmChart
+-                      - HelmRepository
+-                      - ImageRepository
+-                      - ImagePolicy
+-                      - ImageUpdateAutomation
+-                      - OCIRepository
+-                      type: string
+-                    matchLabels:
+-                      additionalProperties:
+-                        type: string
+-                      description: |-
+-                        MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+-                        MatchLabels requires the name to be set to `*`.
+-                      type: object
+-                    name:
+-                      description: |-
+-                        Name of the referent
+-                        If multiple resources are targeted `*` may be set.
+-                      maxLength: 253
+-                      minLength: 1
+-                      type: string
+-                    namespace:
+-                      description: Namespace of the referent
+-                      maxLength: 253
+-                      minLength: 1
+-                      type: string
+-                  required:
+-                  - kind
+-                  - name
+-                  type: object
+-                type: array
+-              secretRef:
+-                description: |-
+-                  SecretRef specifies the Secret containing the token used
+-                  to validate the payload authenticity.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend subsequent
+-                  events handling for this receiver.
+-                type: boolean
+-              type:
+-                description: |-
+-                  Type of webhook sender, used to determine
+-                  the validation procedure and payload deserialization.
+-                enum:
+-                - generic
+-                - generic-hmac
+-                - github
+-                - gitlab
+-                - bitbucket
+-                - harbor
+-                - dockerhub
+-                - quay
+-                - gcr
+-                - nexus
+-                - acr
+-                - cdevents
+-                type: string
+-            required:
+-            - resources
+-            - secretRef
+-            - type
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: ReceiverStatus defines the observed state of the Receiver.
+-            properties:
+-              conditions:
+-                description: Conditions holds the conditions for the Receiver.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation of
+-                  the Receiver object.
+-                format: int64
+-                type: integer
+-              webhookPath:
+-                description: |-
+-                  WebhookPath is the generated incoming webhook address in the format
+-                  of '/hook/sha256sum(token+name+namespace)'.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: true
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    deprecated: true
+-    deprecationWarning: v1beta1 Receiver is deprecated, upgrade to v1
+-    name: v1beta1
+-    schema:
+-      openAPIV3Schema:
+-        description: Receiver is the Schema for the receivers API
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: ReceiverSpec defines the desired state of Receiver
+-            properties:
+-              events:
+-                description: |-
+-                  A list of events to handle,
+-                  e.g. 'push' for GitHub or 'Push Hook' for GitLab.
+-                items:
+-                  type: string
+-                type: array
+-              resources:
+-                description: A list of resources to be notified about changes.
+-                items:
+-                  description: |-
+-                    CrossNamespaceObjectReference contains enough information to let you locate the
+-                    typed referenced object at cluster level
+-                  properties:
+-                    apiVersion:
+-                      description: API version of the referent
+-                      type: string
+-                    kind:
+-                      description: Kind of the referent
+-                      enum:
+-                      - Bucket
+-                      - GitRepository
+-                      - Kustomization
+-                      - HelmRelease
+-                      - HelmChart
+-                      - HelmRepository
+-                      - ImageRepository
+-                      - ImagePolicy
+-                      - ImageUpdateAutomation
+-                      - OCIRepository
+-                      type: string
+-                    matchLabels:
+-                      additionalProperties:
+-                        type: string
+-                      description: |-
+-                        MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+-                      type: object
+-                    name:
+-                      description: Name of the referent
+-                      maxLength: 53
+-                      minLength: 1
+-                      type: string
+-                    namespace:
+-                      description: Namespace of the referent
+-                      maxLength: 53
+-                      minLength: 1
+-                      type: string
+-                  required:
+-                  - kind
+-                  - name
+-                  type: object
+-                type: array
+-              secretRef:
+-                description: |-
+-                  Secret reference containing the token used
+-                  to validate the payload authenticity
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              suspend:
+-                description: |-
+-                  This flag tells the controller to suspend subsequent events handling.
+-                  Defaults to false.
+-                type: boolean
+-              type:
+-                description: |-
+-                  Type of webhook sender, used to determine
+-                  the validation procedure and payload deserialization.
+-                enum:
+-                - generic
+-                - generic-hmac
+-                - github
+-                - gitlab
+-                - bitbucket
+-                - harbor
+-                - dockerhub
+-                - quay
+-                - gcr
+-                - nexus
+-                - acr
+-                type: string
+-            required:
+-            - resources
+-            - secretRef
+-            - type
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: ReceiverStatus defines the observed state of Receiver
+-            properties:
+-              conditions:
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation.
+-                format: int64
+-                type: integer
+-              url:
+-                description: |-
+-                  Generated webhook URL in the format
+-                  of '/hook/sha256sum(token+name+namespace)'.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+-  - additionalPrinterColumns:
+-    - jsonPath: .metadata.creationTimestamp
+-      name: Age
+-      type: date
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+-      name: Ready
+-      type: string
+-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+-      name: Status
+-      type: string
+-    deprecated: true
+-    deprecationWarning: v1beta2 Receiver is deprecated, upgrade to v1
+-    name: v1beta2
+-    schema:
+-      openAPIV3Schema:
+-        description: Receiver is the Schema for the receivers API.
+-        properties:
+-          apiVersion:
+-            description: |-
+-              APIVersion defines the versioned schema of this representation of an object.
+-              Servers should convert recognized schemas to the latest internal value, and
+-              may reject unrecognized values.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+-            type: string
+-          kind:
+-            description: |-
+-              Kind is a string value representing the REST resource this object represents.
+-              Servers may infer this from the endpoint the client submits requests to.
+-              Cannot be updated.
+-              In CamelCase.
+-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+-            type: string
+-          metadata:
+-            type: object
+-          spec:
+-            description: ReceiverSpec defines the desired state of the Receiver.
+-            properties:
+-              events:
+-                description: |-
+-                  Events specifies the list of event types to handle,
+-                  e.g. 'push' for GitHub or 'Push Hook' for GitLab.
+-                items:
+-                  type: string
+-                type: array
+-              interval:
+-                description: Interval at which to reconcile the Receiver with its
+-                  Secret references.
+-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+-                type: string
+-              resources:
+-                description: A list of resources to be notified about changes.
+-                items:
+-                  description: |-
+-                    CrossNamespaceObjectReference contains enough information to let you locate the
+-                    typed referenced object at cluster level
+-                  properties:
+-                    apiVersion:
+-                      description: API version of the referent
+-                      type: string
+-                    kind:
+-                      description: Kind of the referent
+-                      enum:
+-                      - Bucket
+-                      - GitRepository
+-                      - Kustomization
+-                      - HelmRelease
+-                      - HelmChart
+-                      - HelmRepository
+-                      - ImageRepository
+-                      - ImagePolicy
+-                      - ImageUpdateAutomation
+-                      - OCIRepository
+-                      type: string
+-                    matchLabels:
+-                      additionalProperties:
+-                        type: string
+-                      description: |-
+-                        MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+-                        MatchLabels requires the name to be set to `*`.
+-                      type: object
+-                    name:
+-                      description: |-
+-                        Name of the referent
+-                        If multiple resources are targeted `*` may be set.
+-                      maxLength: 253
+-                      minLength: 1
+-                      type: string
+-                    namespace:
+-                      description: Namespace of the referent
+-                      maxLength: 253
+-                      minLength: 1
+-                      type: string
+-                  required:
+-                  - kind
+-                  - name
+-                  type: object
+-                type: array
+-              secretRef:
+-                description: |-
+-                  SecretRef specifies the Secret containing the token used
+-                  to validate the payload authenticity.
+-                properties:
+-                  name:
+-                    description: Name of the referent.
+-                    type: string
+-                required:
+-                - name
+-                type: object
+-              suspend:
+-                description: |-
+-                  Suspend tells the controller to suspend subsequent
+-                  events handling for this receiver.
+-                type: boolean
+-              type:
+-                description: |-
+-                  Type of webhook sender, used to determine
+-                  the validation procedure and payload deserialization.
+-                enum:
+-                - generic
+-                - generic-hmac
+-                - github
+-                - gitlab
+-                - bitbucket
+-                - harbor
+-                - dockerhub
+-                - quay
+-                - gcr
+-                - nexus
+-                - acr
+-                type: string
+-            required:
+-            - resources
+-            - secretRef
+-            - type
+-            type: object
+-          status:
+-            default:
+-              observedGeneration: -1
+-            description: ReceiverStatus defines the observed state of the Receiver.
+-            properties:
+-              conditions:
+-                description: Conditions holds the conditions for the Receiver.
+-                items:
+-                  description: Condition contains details for one aspect of the current
+-                    state of this API Resource.
+-                  properties:
+-                    lastTransitionTime:
+-                      description: |-
+-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+-                      format: date-time
+-                      type: string
+-                    message:
+-                      description: |-
+-                        message is a human readable message indicating details about the transition.
+-                        This may be an empty string.
+-                      maxLength: 32768
+-                      type: string
+-                    observedGeneration:
+-                      description: |-
+-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+-                        with respect to the current state of the instance.
+-                      format: int64
+-                      minimum: 0
+-                      type: integer
+-                    reason:
+-                      description: |-
+-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+-                        Producers of specific condition types may define expected values and meanings for this field,
+-                        and whether the values are considered a guaranteed API.
+-                        The value should be a CamelCase string.
+-                        This field may not be empty.
+-                      maxLength: 1024
+-                      minLength: 1
+-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+-                      type: string
+-                    status:
+-                      description: status of the condition, one of True, False, Unknown.
+-                      enum:
+-                      - "True"
+-                      - "False"
+-                      - Unknown
+-                      type: string
+-                    type:
+-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+-                      maxLength: 316
+-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+-                      type: string
+-                  required:
+-                  - lastTransitionTime
+-                  - message
+-                  - reason
+-                  - status
+-                  - type
+-                  type: object
+-                type: array
+-              lastHandledReconcileAt:
+-                description: |-
+-                  LastHandledReconcileAt holds the value of the most recent
+-                  reconcile request value, so a change of the annotation value
+-                  can be detected.
+-                type: string
+-              observedGeneration:
+-                description: ObservedGeneration is the last observed generation of
+-                  the Receiver object.
+-                format: int64
+-                type: integer
+-              url:
+-                description: |-
+-                  URL is the generated incoming webhook address in the format
+-                  of '/hook/sha256sum(token+name+namespace)'.
+-                  Deprecated: Replaced by WebhookPath.
+-                type: string
+-              webhookPath:
+-                description: |-
+-                  WebhookPath is the generated incoming webhook address in the format
+-                  of '/hook/sha256sum(token+name+namespace)'.
+-                type: string
+-            type: object
+-        type: object
+-    served: true
+-    storage: false
+-    subresources:
+-      status: {}
+diff --git a/applications/kommander-flux/2.6.1/templates/apps_v1_deployment_helm-controller.yaml b/applications/kommander-flux/2.6.1/templates/apps_v1_deployment_helm-controller.yaml
+deleted file mode 100644
+index a2e5e13f67..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/apps_v1_deployment_helm-controller.yaml
++++ /dev/null
+@@ -1,94 +0,0 @@
+-apiVersion: apps/v1
+-kind: Deployment
+-metadata:
+-  labels:
+-    app.kubernetes.io/component: helm-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-    control-plane: controller
+-  name: helm-controller
+-  namespace: kommander-flux
+-spec:
+-  replicas: 1
+-  selector:
+-    matchLabels:
+-      app: helm-controller
+-  template:
+-    metadata:
+-      annotations:
+-        prometheus.io/port: "8080"
+-        prometheus.io/scrape: "true"
+-      labels:
+-        app: helm-controller
+-    spec:
+-      containers:
+-      - args:
+-        - --events-addr=http://notification-controller.kommander-flux.svc.cluster.local./
+-        - --watch-all-namespaces=true
+-        - --log-level=info
+-        - --log-encoding=json
+-        - --enable-leader-election
+-        - --feature-gates=OOMWatch=true
+-        env:
+-        - name: RUNTIME_NAMESPACE
+-          valueFrom:
+-            fieldRef:
+-              fieldPath: metadata.namespace
+-        - name: GOMAXPROCS
+-          valueFrom:
+-            resourceFieldRef:
+-              containerName: manager
+-              resource: limits.cpu
+-        - name: GOMEMLIMIT
+-          valueFrom:
+-            resourceFieldRef:
+-              containerName: manager
+-              resource: limits.memory
+-        image: ghcr.io/fluxcd/helm-controller:v1.3.0
+-        imagePullPolicy: IfNotPresent
+-        livenessProbe:
+-          httpGet:
+-            path: /healthz
+-            port: healthz
+-        name: manager
+-        ports:
+-        - containerPort: 8080
+-          name: http-prom
+-          protocol: TCP
+-        - containerPort: 9440
+-          name: healthz
+-          protocol: TCP
+-        readinessProbe:
+-          httpGet:
+-            path: /readyz
+-            port: healthz
+-        resources:
+-          limits:
+-            cpu: 2000m
+-            memory: 2Gi
+-          requests:
+-            cpu: 500m
+-            memory: 250Mi
+-        securityContext:
+-          allowPrivilegeEscalation: false
+-          capabilities:
+-            drop:
+-            - ALL
+-          readOnlyRootFilesystem: true
+-          runAsNonRoot: true
+-          seccompProfile:
+-            type: RuntimeDefault
+-        volumeMounts:
+-        - mountPath: /tmp
+-          name: temp
+-      nodeSelector:
+-        kubernetes.io/os: linux
+-      priorityClassName: system-cluster-critical
+-      securityContext:
+-        fsGroup: 1337
+-      serviceAccountName: helm-controller
+-      terminationGracePeriodSeconds: 600
+-      volumes:
+-      - emptyDir: {}
+-        name: temp
+diff --git a/applications/kommander-flux/2.6.1/templates/apps_v1_deployment_kustomize-controller.yaml b/applications/kommander-flux/2.6.1/templates/apps_v1_deployment_kustomize-controller.yaml
+deleted file mode 100644
+index b6877f41ce..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/apps_v1_deployment_kustomize-controller.yaml
++++ /dev/null
+@@ -1,95 +0,0 @@
+-apiVersion: apps/v1
+-kind: Deployment
+-metadata:
+-  labels:
+-    app.kubernetes.io/component: kustomize-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-    control-plane: controller
+-  name: kustomize-controller
+-  namespace: kommander-flux
+-spec:
+-  replicas: 1
+-  selector:
+-    matchLabels:
+-      app: kustomize-controller
+-  template:
+-    metadata:
+-      annotations:
+-        prometheus.io/port: "8080"
+-        prometheus.io/scrape: "true"
+-      labels:
+-        app: kustomize-controller
+-    spec:
+-      containers:
+-      - args:
+-        - --events-addr=http://notification-controller.kommander-flux.svc.cluster.local./
+-        - --watch-all-namespaces=true
+-        - --log-level=info
+-        - --log-encoding=json
+-        - --enable-leader-election
+-        - --no-remote-bases=true
+-        - --concurrent=15
+-        env:
+-        - name: RUNTIME_NAMESPACE
+-          valueFrom:
+-            fieldRef:
+-              fieldPath: metadata.namespace
+-        - name: GOMAXPROCS
+-          valueFrom:
+-            resourceFieldRef:
+-              containerName: manager
+-              resource: limits.cpu
+-        - name: GOMEMLIMIT
+-          valueFrom:
+-            resourceFieldRef:
+-              containerName: manager
+-              resource: limits.memory
+-        image: ghcr.io/fluxcd/kustomize-controller:v1.6.0
+-        imagePullPolicy: IfNotPresent
+-        livenessProbe:
+-          httpGet:
+-            path: /healthz
+-            port: healthz
+-        name: manager
+-        ports:
+-        - containerPort: 8080
+-          name: http-prom
+-          protocol: TCP
+-        - containerPort: 9440
+-          name: healthz
+-          protocol: TCP
+-        readinessProbe:
+-          httpGet:
+-            path: /readyz
+-            port: healthz
+-        resources:
+-          limits:
+-            cpu: 2500m
+-            memory: 1Gi
+-          requests:
+-            cpu: 250m
+-            memory: 150Mi
+-        securityContext:
+-          allowPrivilegeEscalation: false
+-          capabilities:
+-            drop:
+-            - ALL
+-          readOnlyRootFilesystem: true
+-          runAsNonRoot: true
+-          seccompProfile:
+-            type: RuntimeDefault
+-        volumeMounts:
+-        - mountPath: /tmp
+-          name: temp
+-      nodeSelector:
+-        kubernetes.io/os: linux
+-      priorityClassName: system-cluster-critical
+-      securityContext:
+-        fsGroup: 1337
+-      serviceAccountName: kustomize-controller
+-      terminationGracePeriodSeconds: 60
+-      volumes:
+-      - emptyDir: {}
+-        name: temp
+diff --git a/applications/kommander-flux/2.6.1/templates/apps_v1_deployment_notification-controller.yaml b/applications/kommander-flux/2.6.1/templates/apps_v1_deployment_notification-controller.yaml
+deleted file mode 100644
+index 8bbaaa6f42..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/apps_v1_deployment_notification-controller.yaml
++++ /dev/null
+@@ -1,98 +0,0 @@
+-apiVersion: apps/v1
+-kind: Deployment
+-metadata:
+-  labels:
+-    app.kubernetes.io/component: notification-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-    control-plane: controller
+-  name: notification-controller
+-  namespace: kommander-flux
+-spec:
+-  replicas: 1
+-  selector:
+-    matchLabels:
+-      app: notification-controller
+-  template:
+-    metadata:
+-      annotations:
+-        prometheus.io/port: "8080"
+-        prometheus.io/scrape: "true"
+-      labels:
+-        app: notification-controller
+-    spec:
+-      containers:
+-      - args:
+-        - --watch-all-namespaces=true
+-        - --log-level=info
+-        - --log-encoding=json
+-        - --enable-leader-election
+-        env:
+-        - name: RUNTIME_NAMESPACE
+-          valueFrom:
+-            fieldRef:
+-              fieldPath: metadata.namespace
+-        - name: GOMAXPROCS
+-          valueFrom:
+-            resourceFieldRef:
+-              containerName: manager
+-              resource: limits.cpu
+-        - name: GOMEMLIMIT
+-          valueFrom:
+-            resourceFieldRef:
+-              containerName: manager
+-              resource: limits.memory
+-        image: ghcr.io/fluxcd/notification-controller:v1.6.0
+-        imagePullPolicy: IfNotPresent
+-        livenessProbe:
+-          httpGet:
+-            path: /healthz
+-            port: healthz
+-        name: manager
+-        ports:
+-        - containerPort: 9090
+-          name: http
+-          protocol: TCP
+-        - containerPort: 9292
+-          name: http-webhook
+-          protocol: TCP
+-        - containerPort: 8080
+-          name: http-prom
+-          protocol: TCP
+-        - containerPort: 9440
+-          name: healthz
+-          protocol: TCP
+-        readinessProbe:
+-          httpGet:
+-            path: /readyz
+-            port: healthz
+-        resources:
+-          limits:
+-            cpu: 1000m
+-            memory: 1Gi
+-          requests:
+-            cpu: 100m
+-            memory: 64Mi
+-        securityContext:
+-          allowPrivilegeEscalation: false
+-          capabilities:
+-            drop:
+-            - ALL
+-          readOnlyRootFilesystem: true
+-          runAsNonRoot: true
+-          seccompProfile:
+-            type: RuntimeDefault
+-        volumeMounts:
+-        - mountPath: /tmp
+-          name: temp
+-      nodeSelector:
+-        kubernetes.io/os: linux
+-      priorityClassName: system-cluster-critical
+-      securityContext:
+-        fsGroup: 1337
+-      serviceAccountName: notification-controller
+-      terminationGracePeriodSeconds: 10
+-      volumes:
+-      - emptyDir: {}
+-        name: temp
+diff --git a/applications/kommander-flux/2.6.1/templates/apps_v1_deployment_source-controller.yaml b/applications/kommander-flux/2.6.1/templates/apps_v1_deployment_source-controller.yaml
+deleted file mode 100644
+index 2739ab63e0..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/apps_v1_deployment_source-controller.yaml
++++ /dev/null
+@@ -1,106 +0,0 @@
+-apiVersion: apps/v1
+-kind: Deployment
+-metadata:
+-  labels:
+-    app.kubernetes.io/component: source-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-    control-plane: controller
+-  name: source-controller
+-  namespace: kommander-flux
+-spec:
+-  replicas: 1
+-  selector:
+-    matchLabels:
+-      app: source-controller
+-  strategy:
+-    type: Recreate
+-  template:
+-    metadata:
+-      annotations:
+-        prometheus.io/port: "8080"
+-        prometheus.io/scrape: "true"
+-      labels:
+-        app: source-controller
+-    spec:
+-      containers:
+-      - args:
+-        - --events-addr=http://notification-controller.kommander-flux.svc.cluster.local./
+-        - --watch-all-namespaces=true
+-        - --log-level=info
+-        - --log-encoding=json
+-        - --enable-leader-election
+-        - --storage-path=/data
+-        - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+-        env:
+-        - name: RUNTIME_NAMESPACE
+-          valueFrom:
+-            fieldRef:
+-              fieldPath: metadata.namespace
+-        - name: TUF_ROOT
+-          value: /tmp/.sigstore
+-        - name: GOMAXPROCS
+-          valueFrom:
+-            resourceFieldRef:
+-              containerName: manager
+-              resource: limits.cpu
+-        - name: GOMEMLIMIT
+-          valueFrom:
+-            resourceFieldRef:
+-              containerName: manager
+-              resource: limits.memory
+-        image: ghcr.io/fluxcd/source-controller:v1.6.0
+-        imagePullPolicy: IfNotPresent
+-        livenessProbe:
+-          httpGet:
+-            path: /healthz
+-            port: healthz
+-        name: manager
+-        ports:
+-        - containerPort: 9090
+-          name: http
+-          protocol: TCP
+-        - containerPort: 8080
+-          name: http-prom
+-          protocol: TCP
+-        - containerPort: 9440
+-          name: healthz
+-          protocol: TCP
+-        readinessProbe:
+-          httpGet:
+-            path: /
+-            port: http
+-        resources:
+-          limits:
+-            cpu: 2000m
+-            memory: 1Gi
+-          requests:
+-            cpu: 250m
+-            memory: 100Mi
+-        securityContext:
+-          allowPrivilegeEscalation: false
+-          capabilities:
+-            drop:
+-            - ALL
+-          readOnlyRootFilesystem: true
+-          runAsNonRoot: true
+-          seccompProfile:
+-            type: RuntimeDefault
+-        volumeMounts:
+-        - mountPath: /data
+-          name: data
+-        - mountPath: /tmp
+-          name: tmp
+-      nodeSelector:
+-        kubernetes.io/os: linux
+-      priorityClassName: system-cluster-critical
+-      securityContext:
+-        fsGroup: 1337
+-      serviceAccountName: source-controller
+-      terminationGracePeriodSeconds: 10
+-      volumes:
+-      - emptyDir: {}
+-        name: data
+-      - emptyDir: {}
+-        name: tmp
+diff --git a/applications/kommander-flux/2.6.1/templates/kustomization.yaml b/applications/kommander-flux/2.6.1/templates/kustomization.yaml
+deleted file mode 100644
+index e8b4f11e73..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/kustomization.yaml
++++ /dev/null
+@@ -1,35 +0,0 @@
+-apiVersion: kustomize.config.k8s.io/v1beta1
+-kind: Kustomization
+-resources:
+-- apiextensions.k8s.io_v1_customresourcedefinition_alerts.notification.toolkit.fluxcd.io.yaml
+-- apiextensions.k8s.io_v1_customresourcedefinition_buckets.source.toolkit.fluxcd.io.yaml
+-- apiextensions.k8s.io_v1_customresourcedefinition_gitrepositories.source.toolkit.fluxcd.io.yaml
+-- apiextensions.k8s.io_v1_customresourcedefinition_helmcharts.source.toolkit.fluxcd.io.yaml
+-- apiextensions.k8s.io_v1_customresourcedefinition_helmreleases.helm.toolkit.fluxcd.io.yaml
+-- apiextensions.k8s.io_v1_customresourcedefinition_helmrepositories.source.toolkit.fluxcd.io.yaml
+-- apiextensions.k8s.io_v1_customresourcedefinition_kustomizations.kustomize.toolkit.fluxcd.io.yaml
+-- apiextensions.k8s.io_v1_customresourcedefinition_ocirepositories.source.toolkit.fluxcd.io.yaml
+-- apiextensions.k8s.io_v1_customresourcedefinition_providers.notification.toolkit.fluxcd.io.yaml
+-- apiextensions.k8s.io_v1_customresourcedefinition_receivers.notification.toolkit.fluxcd.io.yaml
+-- apps_v1_deployment_helm-controller.yaml
+-- apps_v1_deployment_kustomize-controller.yaml
+-- apps_v1_deployment_notification-controller.yaml
+-- apps_v1_deployment_source-controller.yaml
+-- networking.k8s.io_v1_networkpolicy_allow-egress.yaml
+-- networking.k8s.io_v1_networkpolicy_allow-scraping.yaml
+-- networking.k8s.io_v1_networkpolicy_allow-source.yaml
+-- networking.k8s.io_v1_networkpolicy_allow-webhooks.yaml
+-- rbac.authorization.k8s.io_v1_clusterrole_crd-controller-kommander-flux.yaml
+-- rbac.authorization.k8s.io_v1_clusterrole_flux-edit-kommander-flux.yaml
+-- rbac.authorization.k8s.io_v1_clusterrole_flux-view-kommander-flux.yaml
+-- rbac.authorization.k8s.io_v1_clusterrolebinding_cluster-reconciler-kommander-flux.yaml
+-- rbac.authorization.k8s.io_v1_clusterrolebinding_crd-controller-kommander-flux.yaml
+-- v1_namespace_kommander-flux.yaml
+-- v1_resourcequota_critical-pods-kommander-flux.yaml
+-- v1_service_notification-controller.yaml
+-- v1_service_source-controller.yaml
+-- v1_service_webhook-receiver.yaml
+-- v1_serviceaccount_helm-controller.yaml
+-- v1_serviceaccount_kustomize-controller.yaml
+-- v1_serviceaccount_notification-controller.yaml
+-- v1_serviceaccount_source-controller.yaml
+diff --git a/applications/kommander-flux/2.6.1/templates/networking.k8s.io_v1_networkpolicy_allow-egress.yaml b/applications/kommander-flux/2.6.1/templates/networking.k8s.io_v1_networkpolicy_allow-egress.yaml
+deleted file mode 100644
+index ec721cb443..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/networking.k8s.io_v1_networkpolicy_allow-egress.yaml
++++ /dev/null
+@@ -1,19 +0,0 @@
+-apiVersion: networking.k8s.io/v1
+-kind: NetworkPolicy
+-metadata:
+-  labels:
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: allow-egress
+-  namespace: kommander-flux
+-spec:
+-  egress:
+-  - {}
+-  ingress:
+-  - from:
+-    - podSelector: {}
+-  podSelector: {}
+-  policyTypes:
+-  - Ingress
+-  - Egress
+diff --git a/applications/kommander-flux/2.6.1/templates/networking.k8s.io_v1_networkpolicy_allow-scraping.yaml b/applications/kommander-flux/2.6.1/templates/networking.k8s.io_v1_networkpolicy_allow-scraping.yaml
+deleted file mode 100644
+index 7dda410b6b..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/networking.k8s.io_v1_networkpolicy_allow-scraping.yaml
++++ /dev/null
+@@ -1,19 +0,0 @@
+-apiVersion: networking.k8s.io/v1
+-kind: NetworkPolicy
+-metadata:
+-  labels:
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: allow-scraping
+-  namespace: kommander-flux
+-spec:
+-  ingress:
+-  - from:
+-    - namespaceSelector: {}
+-    ports:
+-    - port: 8080
+-      protocol: TCP
+-  podSelector: {}
+-  policyTypes:
+-  - Ingress
+diff --git a/applications/kommander-flux/2.6.1/templates/networking.k8s.io_v1_networkpolicy_allow-webhooks.yaml b/applications/kommander-flux/2.6.1/templates/networking.k8s.io_v1_networkpolicy_allow-webhooks.yaml
+deleted file mode 100644
+index 19834e2fb9..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/networking.k8s.io_v1_networkpolicy_allow-webhooks.yaml
++++ /dev/null
+@@ -1,18 +0,0 @@
+-apiVersion: networking.k8s.io/v1
+-kind: NetworkPolicy
+-metadata:
+-  labels:
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: allow-webhooks
+-  namespace: kommander-flux
+-spec:
+-  ingress:
+-  - from:
+-    - namespaceSelector: {}
+-  podSelector:
+-    matchLabels:
+-      app: notification-controller
+-  policyTypes:
+-  - Ingress
+diff --git a/applications/kommander-flux/2.6.1/templates/v1_service_notification-controller.yaml b/applications/kommander-flux/2.6.1/templates/v1_service_notification-controller.yaml
+deleted file mode 100644
+index 768e87be09..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/v1_service_notification-controller.yaml
++++ /dev/null
+@@ -1,20 +0,0 @@
+-apiVersion: v1
+-kind: Service
+-metadata:
+-  labels:
+-    app.kubernetes.io/component: notification-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-    control-plane: controller
+-  name: notification-controller
+-  namespace: kommander-flux
+-spec:
+-  ports:
+-  - name: http
+-    port: 80
+-    protocol: TCP
+-    targetPort: http
+-  selector:
+-    app: notification-controller
+-  type: ClusterIP
+diff --git a/applications/kommander-flux/2.6.1/templates/v1_service_source-controller.yaml b/applications/kommander-flux/2.6.1/templates/v1_service_source-controller.yaml
+deleted file mode 100644
+index 2fe5dd6d7c..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/v1_service_source-controller.yaml
++++ /dev/null
+@@ -1,20 +0,0 @@
+-apiVersion: v1
+-kind: Service
+-metadata:
+-  labels:
+-    app.kubernetes.io/component: source-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-    control-plane: controller
+-  name: source-controller
+-  namespace: kommander-flux
+-spec:
+-  ports:
+-  - name: http
+-    port: 80
+-    protocol: TCP
+-    targetPort: http
+-  selector:
+-    app: source-controller
+-  type: ClusterIP
+diff --git a/applications/kommander-flux/2.6.1/templates/v1_service_webhook-receiver.yaml b/applications/kommander-flux/2.6.1/templates/v1_service_webhook-receiver.yaml
+deleted file mode 100644
+index 411fa2b8ec..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/v1_service_webhook-receiver.yaml
++++ /dev/null
+@@ -1,20 +0,0 @@
+-apiVersion: v1
+-kind: Service
+-metadata:
+-  labels:
+-    app.kubernetes.io/component: notification-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-    control-plane: controller
+-  name: webhook-receiver
+-  namespace: kommander-flux
+-spec:
+-  ports:
+-  - name: http
+-    port: 80
+-    protocol: TCP
+-    targetPort: http-webhook
+-  selector:
+-    app: notification-controller
+-  type: ClusterIP
+diff --git a/applications/kommander-flux/2.6.1/templates/v1_serviceaccount_helm-controller.yaml b/applications/kommander-flux/2.6.1/templates/v1_serviceaccount_helm-controller.yaml
+deleted file mode 100644
+index 4876e91b94..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/v1_serviceaccount_helm-controller.yaml
++++ /dev/null
+@@ -1,10 +0,0 @@
+-apiVersion: v1
+-kind: ServiceAccount
+-metadata:
+-  labels:
+-    app.kubernetes.io/component: helm-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: helm-controller
+-  namespace: kommander-flux
+diff --git a/applications/kommander-flux/2.6.1/templates/v1_serviceaccount_kustomize-controller.yaml b/applications/kommander-flux/2.6.1/templates/v1_serviceaccount_kustomize-controller.yaml
+deleted file mode 100644
+index 485ecc73eb..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/v1_serviceaccount_kustomize-controller.yaml
++++ /dev/null
+@@ -1,10 +0,0 @@
+-apiVersion: v1
+-kind: ServiceAccount
+-metadata:
+-  labels:
+-    app.kubernetes.io/component: kustomize-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: kustomize-controller
+-  namespace: kommander-flux
+diff --git a/applications/kommander-flux/2.6.1/templates/v1_serviceaccount_notification-controller.yaml b/applications/kommander-flux/2.6.1/templates/v1_serviceaccount_notification-controller.yaml
+deleted file mode 100644
+index 78b788efc3..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/v1_serviceaccount_notification-controller.yaml
++++ /dev/null
+@@ -1,10 +0,0 @@
+-apiVersion: v1
+-kind: ServiceAccount
+-metadata:
+-  labels:
+-    app.kubernetes.io/component: notification-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: notification-controller
+-  namespace: kommander-flux
+diff --git a/applications/kommander-flux/2.6.1/templates/v1_serviceaccount_source-controller.yaml b/applications/kommander-flux/2.6.1/templates/v1_serviceaccount_source-controller.yaml
+deleted file mode 100644
+index 8637e3b51a..0000000000
+--- a/applications/kommander-flux/2.6.1/templates/v1_serviceaccount_source-controller.yaml
++++ /dev/null
+@@ -1,10 +0,0 @@
+-apiVersion: v1
+-kind: ServiceAccount
+-metadata:
+-  labels:
+-    app.kubernetes.io/component: source-controller
+-    app.kubernetes.io/instance: kommander-flux
+-    app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
+-  name: source-controller
+-  namespace: kommander-flux
+diff --git a/applications/kommander-flux/2.6.4/helmrelease/cm.yaml b/applications/kommander-flux/2.6.4/helmrelease/cm.yaml
+new file mode 100644
+index 0000000000..fc8abecb2f
+--- /dev/null
++++ b/applications/kommander-flux/2.6.4/helmrelease/cm.yaml
+@@ -0,0 +1,15 @@
++apiVersion: v1
++kind: ConfigMap
++metadata:
++  name: kommander-flux-2.6.4-config-defaults
++  namespace: ${releaseNamespace}
++data:
++  values.yaml: |
++    ---
++    policies:
++      create: true
++    sourceController:
++      resources:
++        requests:
++          cpu: 100m
++          memory: 64Mi
+\ No newline at end of file
+diff --git a/applications/kommander-flux/2.6.4/helmrelease/helmrelease.yaml b/applications/kommander-flux/2.6.4/helmrelease/helmrelease.yaml
+new file mode 100644
+index 0000000000..bc060e64c7
+--- /dev/null
++++ b/applications/kommander-flux/2.6.4/helmrelease/helmrelease.yaml
+@@ -0,0 +1,62 @@
++apiVersion: source.toolkit.fluxcd.io/v1
++kind: OCIRepository
++metadata:
++  name: flux2
++  namespace: ${releaseNamespace}
++spec:
++  interval: 1m
++  url: "${ociRegistryURL:=oci://ghcr.io}/fluxcd-community/charts/flux2"
++  ref:
++    tag: 2.16.4
++---
++apiVersion: helm.toolkit.fluxcd.io/v2
++kind: HelmRelease
++metadata:
++  name: kommander-flux
++  namespace: ${releaseNamespace}
++spec:
++  chartRef:
++    kind: OCIRepository
++    name: flux2
++    namespace: ${releaseNamespace}
++  interval: 15s
++  install:
++    crds: CreateReplace
++    remediation:
++      retries: 30
++    createNamespace: true
++  upgrade:
++    crds: CreateReplace
++    remediation:
++      retries: 30
++  releaseName: kommander-flux
++  targetNamespace: kommander-flux
++  postRenderers:
++    - kustomize:
++        patches:
++          - target:
++              group: apps
++              version: v1
++              kind: Deployment
++            patch: |
++              - op: add
++                path: /spec/template/spec/containers/0/env/-
++                value:
++                  name: HTTP_PROXY
++                  value: ${httpProxy:-""}
++              - op: add
++                path: /spec/template/spec/containers/0/env/-
++                value:
++                  name: HTTPS_PROXY
++                  value: ${httpsProxy:-""}
++              - op: add
++                path: /spec/template/spec/containers/0/env/-
++                value:
++                  name: NO_PROXY
++                  value: ${noProxy:-""}
++  valuesFrom:
++    - kind: ConfigMap
++      name: kommander-flux-2.6.4-config-defaults
++    - kind: ConfigMap
++      name: kommander-flux-overrides
++      optional: true
+diff --git a/applications/kommander-flux/2.6.4/helmrelease/kustomization.yaml b/applications/kommander-flux/2.6.4/helmrelease/kustomization.yaml
+new file mode 100644
+index 0000000000..66c2cfc86a
+--- /dev/null
++++ b/applications/kommander-flux/2.6.4/helmrelease/kustomization.yaml
+@@ -0,0 +1,5 @@
++apiVersion: kustomize.config.k8s.io/v1beta1
++kind: Kustomization
++resources:
++  - cm.yaml
++  - helmrelease.yaml
+\ No newline at end of file
+diff --git a/applications/kommander-flux/2.6.1/kustomization.yaml b/applications/kommander-flux/2.6.4/kustomization.yaml
+similarity index 95%
+rename from applications/kommander-flux/2.6.1/kustomization.yaml
+rename to applications/kommander-flux/2.6.4/kustomization.yaml
+index 67de0916b4..81760e7f12 100644
+--- a/applications/kommander-flux/2.6.1/kustomization.yaml
++++ b/applications/kommander-flux/2.6.4/kustomization.yaml
+@@ -1,6 +1,7 @@
+ apiVersion: kustomize.config.k8s.io/v1beta1
+ kind: Kustomization
+ resources:
++  - ./helmrelease
+   - ./templates
+   - ./mirror
+ patches:
+diff --git a/applications/kommander-flux/2.6.1/metadata.yaml b/applications/kommander-flux/2.6.4/metadata.yaml
+similarity index 100%
+rename from applications/kommander-flux/2.6.1/metadata.yaml
+rename to applications/kommander-flux/2.6.4/metadata.yaml
+diff --git a/applications/kommander-flux/2.6.1/mirror/flux-oci-mirror.yaml b/applications/kommander-flux/2.6.4/mirror/flux-oci-mirror.yaml
+similarity index 100%
+rename from applications/kommander-flux/2.6.1/mirror/flux-oci-mirror.yaml
+rename to applications/kommander-flux/2.6.4/mirror/flux-oci-mirror.yaml
+diff --git a/applications/kommander-flux/2.6.1/mirror/kustomization.yaml b/applications/kommander-flux/2.6.4/mirror/kustomization.yaml
+similarity index 100%
+rename from applications/kommander-flux/2.6.1/mirror/kustomization.yaml
+rename to applications/kommander-flux/2.6.4/mirror/kustomization.yaml
+diff --git a/applications/kommander-flux/2.6.1/mirror/network-policy.yaml b/applications/kommander-flux/2.6.4/mirror/network-policy.yaml
+similarity index 100%
+rename from applications/kommander-flux/2.6.1/mirror/network-policy.yaml
+rename to applications/kommander-flux/2.6.4/mirror/network-policy.yaml
+diff --git a/applications/kommander-flux/2.6.1/patch-proxy-env-vars.yaml b/applications/kommander-flux/2.6.4/patch-proxy-env-vars.yaml
+similarity index 100%
+rename from applications/kommander-flux/2.6.1/patch-proxy-env-vars.yaml
+rename to applications/kommander-flux/2.6.4/patch-proxy-env-vars.yaml
+diff --git a/applications/kommander-flux/2.6.1/patch-source-ctrl-network-policy.yaml b/applications/kommander-flux/2.6.4/patch-source-ctrl-network-policy.yaml
+similarity index 100%
+rename from applications/kommander-flux/2.6.1/patch-source-ctrl-network-policy.yaml
+rename to applications/kommander-flux/2.6.4/patch-source-ctrl-network-policy.yaml
+diff --git a/applications/kommander-flux/2.6.4/templates/kustomization.yaml b/applications/kommander-flux/2.6.4/templates/kustomization.yaml
+new file mode 100644
+index 0000000000..04c4f2e05f
+--- /dev/null
++++ b/applications/kommander-flux/2.6.4/templates/kustomization.yaml
+@@ -0,0 +1,11 @@
++apiVersion: kustomize.config.k8s.io/v1beta1
++kind: Kustomization
++resources:
++- v1_namespace_kommander-flux.yaml
++- v1_resourcequota_critical-pods-kommander-flux.yaml
++- networking.k8s.io_v1_networkpolicy_allow-source.yaml
++- rbac.authorization.k8s.io_v1_clusterrole_crd-controller-kommander-flux.yaml
++- rbac.authorization.k8s.io_v1_clusterrole_flux-edit-kommander-flux.yaml
++- rbac.authorization.k8s.io_v1_clusterrole_flux-view-kommander-flux.yaml
++- rbac.authorization.k8s.io_v1_clusterrolebinding_cluster-reconciler-kommander-flux.yaml
++- rbac.authorization.k8s.io_v1_clusterrolebinding_crd-controller-kommander-flux.yaml
+diff --git a/applications/kommander-flux/2.6.1/templates/networking.k8s.io_v1_networkpolicy_allow-source.yaml b/applications/kommander-flux/2.6.4/templates/networking.k8s.io_v1_networkpolicy_allow-source.yaml
+similarity index 100%
+rename from applications/kommander-flux/2.6.1/templates/networking.k8s.io_v1_networkpolicy_allow-source.yaml
+rename to applications/kommander-flux/2.6.4/templates/networking.k8s.io_v1_networkpolicy_allow-source.yaml
+diff --git a/applications/kommander-flux/2.6.1/templates/rbac.authorization.k8s.io_v1_clusterrole_crd-controller-kommander-flux.yaml b/applications/kommander-flux/2.6.4/templates/rbac.authorization.k8s.io_v1_clusterrole_crd-controller-kommander-flux.yaml
+similarity index 97%
+rename from applications/kommander-flux/2.6.1/templates/rbac.authorization.k8s.io_v1_clusterrole_crd-controller-kommander-flux.yaml
+rename to applications/kommander-flux/2.6.4/templates/rbac.authorization.k8s.io_v1_clusterrole_crd-controller-kommander-flux.yaml
+index c1951912e7..bb5396ae18 100644
+--- a/applications/kommander-flux/2.6.1/templates/rbac.authorization.k8s.io_v1_clusterrole_crd-controller-kommander-flux.yaml
++++ b/applications/kommander-flux/2.6.4/templates/rbac.authorization.k8s.io_v1_clusterrole_crd-controller-kommander-flux.yaml
+@@ -4,7 +4,7 @@ metadata:
+   labels:
+     app.kubernetes.io/instance: kommander-flux
+     app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
++    app.kubernetes.io/version: v2.6.4
+   name: crd-controller-kommander-flux
+ rules:
+ - apiGroups:
+diff --git a/applications/kommander-flux/2.6.1/templates/rbac.authorization.k8s.io_v1_clusterrole_flux-edit-kommander-flux.yaml b/applications/kommander-flux/2.6.4/templates/rbac.authorization.k8s.io_v1_clusterrole_flux-edit-kommander-flux.yaml
+similarity index 93%
+rename from applications/kommander-flux/2.6.1/templates/rbac.authorization.k8s.io_v1_clusterrole_flux-edit-kommander-flux.yaml
+rename to applications/kommander-flux/2.6.4/templates/rbac.authorization.k8s.io_v1_clusterrole_flux-edit-kommander-flux.yaml
+index 7f991de256..5e07ae3560 100644
+--- a/applications/kommander-flux/2.6.1/templates/rbac.authorization.k8s.io_v1_clusterrole_flux-edit-kommander-flux.yaml
++++ b/applications/kommander-flux/2.6.4/templates/rbac.authorization.k8s.io_v1_clusterrole_flux-edit-kommander-flux.yaml
+@@ -4,7 +4,7 @@ metadata:
+   labels:
+     app.kubernetes.io/instance: kommander-flux
+     app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
++    app.kubernetes.io/version: v2.6.4
+     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+     rbac.authorization.k8s.io/aggregate-to-edit: "true"
+   name: flux-edit-kommander-flux
+diff --git a/applications/kommander-flux/2.6.1/templates/rbac.authorization.k8s.io_v1_clusterrole_flux-view-kommander-flux.yaml b/applications/kommander-flux/2.6.4/templates/rbac.authorization.k8s.io_v1_clusterrole_flux-view-kommander-flux.yaml
+similarity index 93%
+rename from applications/kommander-flux/2.6.1/templates/rbac.authorization.k8s.io_v1_clusterrole_flux-view-kommander-flux.yaml
+rename to applications/kommander-flux/2.6.4/templates/rbac.authorization.k8s.io_v1_clusterrole_flux-view-kommander-flux.yaml
+index 0649b3687f..acddac8adf 100644
+--- a/applications/kommander-flux/2.6.1/templates/rbac.authorization.k8s.io_v1_clusterrole_flux-view-kommander-flux.yaml
++++ b/applications/kommander-flux/2.6.4/templates/rbac.authorization.k8s.io_v1_clusterrole_flux-view-kommander-flux.yaml
+@@ -4,7 +4,7 @@ metadata:
+   labels:
+     app.kubernetes.io/instance: kommander-flux
+     app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
++    app.kubernetes.io/version: v2.6.4
+     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+     rbac.authorization.k8s.io/aggregate-to-edit: "true"
+     rbac.authorization.k8s.io/aggregate-to-view: "true"
+diff --git a/applications/kommander-flux/2.6.1/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_cluster-reconciler-kommander-flux.yaml b/applications/kommander-flux/2.6.4/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_cluster-reconciler-kommander-flux.yaml
+similarity index 92%
+rename from applications/kommander-flux/2.6.1/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_cluster-reconciler-kommander-flux.yaml
+rename to applications/kommander-flux/2.6.4/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_cluster-reconciler-kommander-flux.yaml
+index c6180ef833..a871ff371b 100644
+--- a/applications/kommander-flux/2.6.1/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_cluster-reconciler-kommander-flux.yaml
++++ b/applications/kommander-flux/2.6.4/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_cluster-reconciler-kommander-flux.yaml
+@@ -4,7 +4,7 @@ metadata:
+   labels:
+     app.kubernetes.io/instance: kommander-flux
+     app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
++    app.kubernetes.io/version: v2.6.4
+   name: cluster-reconciler-kommander-flux
+ roleRef:
+   apiGroup: rbac.authorization.k8s.io
+diff --git a/applications/kommander-flux/2.6.1/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_crd-controller-kommander-flux.yaml b/applications/kommander-flux/2.6.4/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_crd-controller-kommander-flux.yaml
+similarity index 95%
+rename from applications/kommander-flux/2.6.1/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_crd-controller-kommander-flux.yaml
+rename to applications/kommander-flux/2.6.4/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_crd-controller-kommander-flux.yaml
+index ada14f3fab..a3c481c0c7 100644
+--- a/applications/kommander-flux/2.6.1/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_crd-controller-kommander-flux.yaml
++++ b/applications/kommander-flux/2.6.4/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_crd-controller-kommander-flux.yaml
+@@ -4,7 +4,7 @@ metadata:
+   labels:
+     app.kubernetes.io/instance: kommander-flux
+     app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
++    app.kubernetes.io/version: v2.6.4
+   name: crd-controller-kommander-flux
+ roleRef:
+   apiGroup: rbac.authorization.k8s.io
+diff --git a/applications/kommander-flux/2.6.1/templates/v1_namespace_kommander-flux.yaml b/applications/kommander-flux/2.6.4/templates/v1_namespace_kommander-flux.yaml
+similarity index 89%
+rename from applications/kommander-flux/2.6.1/templates/v1_namespace_kommander-flux.yaml
+rename to applications/kommander-flux/2.6.4/templates/v1_namespace_kommander-flux.yaml
+index 5de72b1738..2ec47942c5 100644
+--- a/applications/kommander-flux/2.6.1/templates/v1_namespace_kommander-flux.yaml
++++ b/applications/kommander-flux/2.6.4/templates/v1_namespace_kommander-flux.yaml
+@@ -6,7 +6,7 @@ metadata:
+   labels:
+     app.kubernetes.io/instance: kommander-flux
+     app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
++    app.kubernetes.io/version: v2.6.4
+     pod-security.kubernetes.io/warn: restricted
+     pod-security.kubernetes.io/warn-version: latest
+   name: kommander-flux
+diff --git a/applications/kommander-flux/2.6.1/templates/v1_resourcequota_critical-pods-kommander-flux.yaml b/applications/kommander-flux/2.6.4/templates/v1_resourcequota_critical-pods-kommander-flux.yaml
+similarity index 91%
+rename from applications/kommander-flux/2.6.1/templates/v1_resourcequota_critical-pods-kommander-flux.yaml
+rename to applications/kommander-flux/2.6.4/templates/v1_resourcequota_critical-pods-kommander-flux.yaml
+index 533dbd39cb..ee20159a63 100644
+--- a/applications/kommander-flux/2.6.1/templates/v1_resourcequota_critical-pods-kommander-flux.yaml
++++ b/applications/kommander-flux/2.6.4/templates/v1_resourcequota_critical-pods-kommander-flux.yaml
+@@ -4,7 +4,7 @@ metadata:
+   labels:
+     app.kubernetes.io/instance: kommander-flux
+     app.kubernetes.io/part-of: flux
+-    app.kubernetes.io/version: v2.6.1
++    app.kubernetes.io/version: v2.6.4
+   name: critical-pods-kommander-flux
+   namespace: kommander-flux
+ spec:


### PR DESCRIPTION
**What problem does this PR solve?**:
Refactors Flux deployment to use HelmRelease and OCIRepository for version 2.6.4, replacing direct manifest application. This change standardizes the deployment method and integrates proxy variable injection via `postRenderers`.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
N/A

**Special notes for your reviewer**:
- **Deployment Method**: Flux is now deployed via `HelmRelease` and `OCIRepository`, moving away from individual manifest application.
- **Proxy Injection**: Proxy environment variables are injected using `postRenderers`. Please verify the robustness of JSON6902 patches for `env` arrays (ensure `env` list exists or consider setting directly in chart values).
- **Network Policies**: `allow-egress`, `allow-scraping`, and `allow-webhooks` NetworkPolicies have been removed. Confirm if these are now handled by the Flux2 chart or require re-introduction.
- **Chart Values**: Verify the validity of `policies.create` and `sourceController.resources.requests` keys in the Flux2 chart 2.16.4 values.
- **Style Consistency**: Consider unifying default value syntax (e.g., `${var:=default}` or `:-`).

**Does this PR introduce a user-facing change?**:
```release-note
CLI: Upgraded Flux to version 2.6.4 and refactored its deployment method to use HelmRelease with OCIRepository.
```

**Checklist**
- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).

---
<a href="https://cursor.com/background-agent?bcId=bc-425d69dd-5a12-4ced-8414-d322d58d2ca6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-425d69dd-5a12-4ced-8414-d322d58d2ca6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

