### PR TITLE
fix: Update all bitnami images to bitnamilegacy [release-2.15]

### DIFF
--- a/apptests/appscenarios/contants.go
+++ b/apptests/appscenarios/contants.go
@@ -20,6 +20,6 @@ const (
 	dkpCriticalPriority           = "dkp-critical-priority"
 
 	// Velero constants
-	kubetoolsImageRepository = "bitnami/kubectl"
+	kubetoolsImageRepository = "bitnamilegacy/kubectl"
 	kubetoolsImageTag        = "1.32.3"
 )

--- a/apptests/testdata/rook-ceph/manifests/persistent-volume-creator.yaml
+++ b/apptests/testdata/rook-ceph/manifests/persistent-volume-creator.yaml
@@ -53,7 +53,7 @@ spec:
           # If we use an image that is also used in k-apps then our tooling might exclude this image from tar by assuming
           # its one of the default images of kind-airgapped tooling (like calico etc.,).
           # TODO: we can make this better
-          image: bitnami/kubectl:1.28.5
+          image: bitnamilegacy/kubectl:1.28.5
           command:
             - /bin/bash
             - -c

--- a/common/build/list-images-values.yaml
+++ b/common/build/list-images-values.yaml
@@ -1,3 +1,3 @@
 secretName: unused
 commonName: unused
-kubectlImage: bitnami/kubectl:1.32.3
+kubectlImage: bitnamilegacy/kubectl:1.32.3

--- a/hack/list-images.sh
+++ b/hack/list-images.sh
@@ -190,7 +190,7 @@ done
                                   (select(.containers != null) | .containers[].image), (select(.initContainers != null) | .initContainers[].image)' \
   				./services/git-operator/*/git-operator-manifests/* \
   # we patch the cronjob image in this kustomization
-  gojq --yaml-input --raw-output 'select(.kind | test("^(?:Kustomization)$")) | .images | map("\(.name):\(.newTag)") | .[]' \
+  gojq --yaml-input --raw-output 'select(.kind | test("^(?:Kustomization)$")) | .images | map("\(.newName):\(.newTag)") | .[]' \
           ./services/git-operator/*/kustomization.yaml
 } >>"${IMAGES_FILE}"
 

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -13,7 +13,7 @@ resources:
       - url: https://github.com/aquasecurity/kube-bench
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: docker.io/bitnami/thanos:0.37.1-debian-12-r0
+  - container_image: docker.io/bitnamilegacy/thanos:0.37.1-debian-12-r0
     sources:
       - license_path: LICENSE
         ref: v${image_tag%-debian-12-r0}
@@ -509,7 +509,7 @@ resources:
       - url: https://github.com/NVIDIA/cuda-samples
         ref: v12.5
         license_path: LICENSE
-  - container_image: docker.io/bitnami/kubectl:1.32.3
+  - container_image: docker.io/bitnamilegacy/kubectl:1.32.3
     sources:
       - url: https://github.com/kubernetes/kubectl
         ref: v0${image_tag#1}
@@ -520,7 +520,7 @@ resources:
         ref: controller-v1.11.2
         license_path: LICENSE
         directory: /images/kube-webhook-certgen/rootfs
-  - container_image: docker.io/bitnami/postgres-exporter:0.16.0-debian-12-r3
+  - container_image: docker.io/bitnamilegacy/postgres-exporter:0.16.0-debian-12-r3
     sources:
       - url: https://github.com/prometheus-community/postgres_exporter
         ref: v0.12.0
@@ -530,12 +530,12 @@ resources:
       - url: https://github.com/nginx/nginx
         ref: release-${image_tag%-alpine}
         license_path: LICENSE
-  - container_image: bitnami/external-dns:0.14.2-debian-12-r7
+  - container_image: bitnamilegacy/external-dns:0.14.2-debian-12-r7
     sources:
       - url: https://github.com/kubernetes-sigs/external-dns
         ref: v${image_tag%-debian-12-r7}
         license_path: LICENSE
-  - container_image: docker.io/bitnami/postgresql:15.9.0-debian-12-r0
+  - container_image: docker.io/bitnamilegacy/postgresql:15.9.0-debian-12-r0
     sources:
       - url: https://github.com/postgres/postgres
         ref: REL_15_9
@@ -625,17 +625,17 @@ resources:
       - url: https://github.com/goharbor/harbor
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: bitnami/valkey:8.1.0-debian-12-r2
+  - container_image: bitnamilegacy/valkey:8.1.0-debian-12-r2
     sources:
       - url: https://github.com/valkey-io/valkey
         ref: ${image_tag%%-debian-*}
         license_path: COPYING
-  - container_image: bitnami/valkey-sentinel:8.1.0-debian-12-r0
+  - container_image: bitnamilegacy/valkey-sentinel:8.1.0-debian-12-r0
     sources:
       - url: https://github.com/valkey-io/valkey
         ref: ${image_tag%%-debian-*}
         license_path: COPYING
-  - container_image: bitnami/redis-exporter:1.69.0-debian-12-r4
+  - container_image: bitnamilegacy/redis-exporter:1.69.0-debian-12-r4
     sources:
       - url: https://github.com/oliver006/redis_exporter
         ref: v${image_tag%%-debian-*}

--- a/services/ai-navigator-app/0.2.10/defaults/cm.yaml
+++ b/services/ai-navigator-app/0.2.10/defaults/cm.yaml
@@ -40,6 +40,8 @@ data:
           scriptsConfigMap: ai-navigator-cluster-info-api-postgresql-initdb
       readReplicas:
         priorityClassName: dkp-high-priority
+      image:
+        repository: bitnamilegacy/postgresql
 
     # Default values for cluster-info-api
     replicaCount: 1
@@ -95,4 +97,4 @@ data:
     tolerations: []
 
     affinity: {}
-    kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}
+    kubectlImage: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}

--- a/services/cosi-driver-nutanix/0.4.0/defaults/cm.yaml
+++ b/services/cosi-driver-nutanix/0.4.0/defaults/cm.yaml
@@ -32,7 +32,7 @@ data:
     cosiBucketKit:
       enabled: true
       transformations:
-        kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}
+        kubectlImage: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}
       bucketClasses:
         - name: cosi-nutanix-nkp
           driverName: ntnx.objectstorage.k8s.io

--- a/services/dex/2.14.2/defaults/cm.yaml
+++ b/services/dex/2.14.2/defaults/cm.yaml
@@ -7,7 +7,7 @@ data:
   values.yaml: |-
     ---
     priorityClassName: "dkp-critical-priority"
-    kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}"
+    kubectlImage: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}"
     image: mesosphere/dex
     imageTag: v2.42.0-d2iq.0
     resources:

--- a/services/external-dns/7.5.6/defaults/cm.yaml
+++ b/services/external-dns/7.5.6/defaults/cm.yaml
@@ -7,6 +7,7 @@ data:
   values.yaml: |-
     priorityClassName: dkp-high-priority
     image:
+      repository: bitnamilegacy/external-dns
       tag: 0.14.2-debian-12-r7
     service:
       labels:

--- a/services/git-operator/0.1.4/kustomization.yaml
+++ b/services/git-operator/0.1.4/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
     kind: Certificate
     name: git-operator-git-webserver
 images:
-  - name: bitnami/kubectl
+  - name: bitnamilegacy/kubectl
     newTag: 1.32.3

--- a/services/git-operator/0.1.4/kustomization.yaml
+++ b/services/git-operator/0.1.4/kustomization.yaml
@@ -26,5 +26,6 @@ patches:
     kind: Certificate
     name: git-operator-git-webserver
 images:
-  - name: bitnamilegacy/kubectl
+  - name: bitnami/kubectl
+    newName: bitnamilegacy/kubectl
     newTag: 1.32.3

--- a/services/grafana-loki/0.79.5/grafana-loki-pre-install-jobs/pre-install.yaml
+++ b/services/grafana-loki/0.79.5/grafana-loki-pre-install-jobs/pre-install.yaml
@@ -46,7 +46,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: pre-install
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}"
+          image: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}"
           command:
             - sh
             - -c

--- a/services/harbor/1.17.0/defaults/harbor.yaml
+++ b/services/harbor/1.17.0/defaults/harbor.yaml
@@ -117,7 +117,7 @@ data:
       enabled: false
       transformations:
         priorityClassName: dkp-high-priority
-        kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}
+        kubectlImage: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}
         harbor:
           enabled: true
           cmName: harbor-cosi-overrides
@@ -131,4 +131,4 @@ data:
       targetSecretName: "harbor-s3-credentials"
       reloader: true
 
-      kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}
+      kubectlImage: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}

--- a/services/harbor/1.17.0/defaults/valkey.yaml
+++ b/services/harbor/1.17.0/defaults/valkey.yaml
@@ -7,8 +7,19 @@ metadata:
 data:
   values.yaml: |
     ---
+    global:
+      security:
+        allowInsecureImages: true
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/valkey
+      tag: 8.1.0-debian-12-r2
     sentinel:
       enabled: true
+      image:
+        registry: docker.io
+        repository: bitnamilegacy/valkey-sentinel
+        tag: 8.1.0-debian-12-r0
       primarySet: harbor
     auth:
       enabled: true
@@ -32,6 +43,10 @@ data:
 
     metrics:
       enabled: true
+      image:
+        registry: docker.io
+        repository: bitnamilegacy/redis-exporter
+        tag: 1.69.0-debian-12-r4
       service:
         enabled: true
         extraPorts:

--- a/services/harbor/1.17.0/pre-install/pre-install-jobs.yaml
+++ b/services/harbor/1.17.0/pre-install/pre-install-jobs.yaml
@@ -69,7 +69,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: generate-harbor-admin-password
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}"
+          image: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}"
           command:
             - bash
             - -c
@@ -96,7 +96,7 @@ spec:
                 --from-literal=HARBOR_ADMIN_PASSWORD=$(tr -dc 'A-Za-z0-9!?%=' < /dev/urandom | head -c 20) | \
                 kubectl apply --server-side -f -
         - name: generate-valkey-password
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}"
+          image: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}"
           command:
             - bash
             - -c

--- a/services/istio/1.23.3/defaults/cm.yaml
+++ b/services/istio/1.23.3/defaults/cm.yaml
@@ -29,7 +29,7 @@ data:
         labels:
           prometheus.kommander.d2iq.io/select: "true"
     global:
-      image: ${kubetoolsImageRepository:=bitnami/kubectl}
+      image: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}
       tag: ${kubetoolsImageTag:=1.32.3}
       priorityClassName: "dkp-critical-priority"
     operator:

--- a/services/knative/1.17.0/defaults/cm.yaml
+++ b/services/knative/1.17.0/defaults/cm.yaml
@@ -7,7 +7,7 @@ data:
   values.yaml: |
     global:
       priorityClassName: "dkp-high-priority"
-      image: ${kubetoolsImageRepository:=bitnami/kubectl}
+      image: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}
       tag: ${kubetoolsImageTag:=1.32.3}
     eventing:
       enabled: false

--- a/services/kommander/0.15.2/dynamic-helmreleases/cluster-observer/list-images-values.yaml
+++ b/services/kommander/0.15.2/dynamic-helmreleases/cluster-observer/list-images-values.yaml
@@ -1,2 +1,2 @@
 hooks:
-  kubectlImage: "bitnami/kubectl:1.32.3"
+  kubectlImage: "bitnamilegacy/kubectl:1.32.3"

--- a/services/kube-prometheus-stack/70.4.3/defaults/cm.yaml
+++ b/services/kube-prometheus-stack/70.4.3/defaults/cm.yaml
@@ -30,7 +30,7 @@ data:
     mesosphereResources:
       create: true
       hooks:
-        kubectlImage: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}"
+        kubectlImage: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}"
       rules:
         # addon alert rules are defaulted to false to prevent potential misfires if addons
         # are disabled.

--- a/services/kubecost/2.7.0/defaults/cm.yaml
+++ b/services/kubecost/2.7.0/defaults/cm.yaml
@@ -286,7 +286,7 @@ data:
           credentialsSecretName: federated-store
       transformations:
         priorityClassName: dkp-high-priority
-        kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}
+        kubectlImage: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}
         kubecost:
           enabled: true
   # Overrides for kubecost to run in primary mode for multi cluster setup with object storage.

--- a/services/kubecost/2.7.0/pre-install/pre-install-jobs.yaml
+++ b/services/kubecost/2.7.0/pre-install/pre-install-jobs.yaml
@@ -65,7 +65,7 @@ spec:
       priorityClassName: dkp-high-priority
       containers:
         - name: create-kubecost-cluster-info-configmap
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}"
+          image: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}"
           command:
             - bash
             - -c

--- a/services/kubefed/0.11.1/defaults/cm.yaml
+++ b/services/kubefed/0.11.1/defaults/cm.yaml
@@ -36,7 +36,7 @@ data:
         labels:
           servicemonitor.kommander.mesosphere.io/path: metrics
       postInstallJob:
-        repository: bitnami
+        repository: bitnamilegacy
         image: kubectl
         tag: ${kubetoolsImageTag:=1.32.3}
       webhook:

--- a/services/kubetunnel/0.0.39/defaults/cm.yaml
+++ b/services/kubetunnel/0.0.39/defaults/cm.yaml
@@ -16,7 +16,7 @@ data:
       selfSigned: true
     hooks:
       kubectlImage:
-        repository: "${kubetoolsImageRepository:=bitnami/kubectl}"
+        repository: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}"
         tag: "${kubetoolsImageTag:=1.32.3}"
     controller:
       manager:

--- a/services/nkp-insights-management/1.4.4/defaults/cm.yaml
+++ b/services/nkp-insights-management/1.4.4/defaults/cm.yaml
@@ -34,7 +34,7 @@ data:
     insightsCRIngress:
       globalRateLimitAverageQPS: 100
       globalRateLimitBurst: 100
-    kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}
+    kubectlImage: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}
     managementCM:
       backendTokenTTL: 1h
       insightsTTL: 72h

--- a/services/nkp-insights/1.4.4/defaults/cm.yaml
+++ b/services/nkp-insights/1.4.4/defaults/cm.yaml
@@ -302,7 +302,7 @@ data:
             cpu: 100m
             memory: 512Mi
       schedule: '@every 35m'
-    kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}
+    kubectlImage: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}
     nova:
       baseEvaluationTimeout: 1m
       enabled: true
@@ -420,12 +420,12 @@ data:
           servicePort: 5432
       image:
         registry: docker.io
-        repository: bitnami/postgresql
+        repository: bitnamilegacy/postgresql
         tag: 15.9.0-debian-12-r0
       metrics:
         image:
           registry: docker.io
-          repository: bitnami/postgres-exporter
+          repository: bitnamilegacy/postgres-exporter
           tag: 0.16.0-debian-12-r3
       primary:
         containerSecurityContext:

--- a/services/project-grafana-loki/0.79.5/defaults/cm.yaml
+++ b/services/project-grafana-loki/0.79.5/defaults/cm.yaml
@@ -27,7 +27,7 @@ data:
     ####################################################################
 
     # this is used in object-bucket-claims overrides
-    kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}
+    kubectlImage: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}
 
     loki:
       ingesterFullname: loki-ingester

--- a/services/rook-ceph-cluster/1.16.2/defaults/cm.yaml
+++ b/services/rook-ceph-cluster/1.16.2/defaults/cm.yaml
@@ -244,7 +244,7 @@ data:
           memory: "100Mi"
 
     # this is used in object-bucket-claims overrides
-    kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}
+    kubectlImage: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}
 
     #################################################################
     ## BEGIN NKP specific config overrides                         ##
@@ -283,7 +283,7 @@ data:
     cosiBucketKit:
       enabled: true
       transformations:
-        kubectlImage: ${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}
+        kubectlImage: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}
       bucketClasses: # Cluster scoped resource
         - name: cosi-ceph-nkp
           driverName: rook-ceph.ceph.objectstorage.k8s.io

--- a/services/rook-ceph-cluster/1.16.2/pre-install/ceph-crd-check.yaml
+++ b/services/rook-ceph-cluster/1.16.2/pre-install/ceph-crd-check.yaml
@@ -47,7 +47,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: pre-install
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}"
+          image: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}"
           command:
             - sh
             - -c
@@ -57,7 +57,7 @@ spec:
                 sleep 30
               done
         - name: pre-upgrade
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}"
+          image: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}"
           command:
             - sh
             - -c

--- a/services/thanos/15.7.24/defaults/cm.yaml
+++ b/services/thanos/15.7.24/defaults/cm.yaml
@@ -8,7 +8,7 @@ data:
     ---
     image:
       registry: docker.io
-      repository: bitnami/thanos
+      repository: bitnamilegacy/thanos
       tag: 0.37.1-debian-12-r0
     storegateway:
       enabled: false

--- a/services/thanos/15.7.24/jobs/jobs.yaml
+++ b/services/thanos/15.7.24/jobs/jobs.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: dkp-critical-priority
       containers:
         - name: kubectl
-          image: "${kubetoolsImageRepository:=bitnami/kubectl}:${kubetoolsImageTag:=1.32.3}"
+          image: "${kubetoolsImageRepository:=bitnamilegacy/kubectl}:${kubetoolsImageTag:=1.32.3}"
           command:
             - sh
             - "-c"

--- a/services/velero/8.3.0/defaults/cm.yaml
+++ b/services/velero/8.3.0/defaults/cm.yaml
@@ -55,7 +55,7 @@ data:
             name: plugins
     kubectl:
       image:
-        repository: docker.io/bitnami/kubectl
+        repository: docker.io/bitnamilegacy/kubectl
         # If we don't override the version here, upstream chart will pull an image dynamically based on k8s cluster version.
         # which makes it harder to build airgapped tar bundles. So to make bundle collection predictable, we override the tag here.
         tag: "${kubetoolsImageTag:=1.32.3}"

--- a/services/velero/8.3.0/velero-pre-install.yaml
+++ b/services/velero/8.3.0/velero-pre-install.yaml
@@ -18,5 +18,5 @@ spec:
   postBuild:
     substitute:
       releaseNamespace: ${releaseNamespace}
-      kubetoolsImageRepository: ${kubetoolsImageRepository:=bitnami/kubectl}
+      kubetoolsImageRepository: ${kubetoolsImageRepository:=bitnamilegacy/kubectl}
       kubetoolsImageTag: ${kubetoolsImageTag:=1.32.3}


### PR DESCRIPTION
**What problem does this PR solve?**:
Adding bitnami -> bitnamilegacy back into k-apps branches

**Which issue(s) does this PR fix?**:
This was caught here:
https://github.com/mesosphere/dkp-release-specs/actions/runs/18174251308/job/51736252327?pr=485

Bitnami changes were not added back to the release branch

**Special notes for your reviewer**:
I cherry picked from the release tag:
https://github.com/mesosphere/kommander-applications/compare/release-2.15...v2.15.1

**Does this PR introduce a user-facing change?**:
nothing that isn't already in 2.15.1

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
