### PR TITLE
Template flux2 helm chart to file

### DIFF
--- a/job-logs.txt
+++ b/job-logs.txt
@@ -1,0 +1,2478 @@
+﻿2025-10-07T09:42:21.8612759Z Current runner version: '2.328.0'
+2025-10-07T09:42:21.8618343Z Runner name: 'org-wide-medium-2q28g-q7lk9'
+2025-10-07T09:42:21.8619254Z Runner group name: 'default'
+2025-10-07T09:42:21.8620179Z Machine name: 'org-wide-medium-2q28g-q7lk9'
+2025-10-07T09:42:21.8623270Z ##[group]GITHUB_TOKEN Permissions
+2025-10-07T09:42:21.8625315Z Contents: read
+2025-10-07T09:42:21.8625964Z Metadata: read
+2025-10-07T09:42:21.8626551Z ##[endgroup]
+2025-10-07T09:42:21.8629125Z Secret source: Actions
+2025-10-07T09:42:21.8629881Z Prepare workflow directory
+2025-10-07T09:42:21.8983291Z Prepare all required actions
+2025-10-07T09:42:21.9017558Z Getting action download info
+2025-10-07T09:42:22.4745066Z Download action repository 'actions/create-github-app-token@v1' (SHA:d72941d797fd3113feb6b93fd0dec494b13a2547)
+2025-10-07T09:42:22.9285592Z Download action repository 'actions/cache@v4' (SHA:0057852bfaa89a56745cba8c7296529d2fc39830)
+2025-10-07T09:42:23.3671450Z Download action repository 'actions/checkout@v4' (SHA:08eba0b27e820071cde6df949e0beb9ba4906955)
+2025-10-07T09:42:23.7665956Z Download action repository 'mesosphere/workflow-db@main' (SHA:f9115b2daf08d787e95943fd8718bc6313999fa2)
+2025-10-07T09:42:24.2473206Z Download action repository 'cachix/install-nix-action@v31' (SHA:9280e7aca88deada44c930f1e2c78e21c3ae3edd)
+2025-10-07T09:42:24.5906117Z Download action repository 'jetify-com/devbox-install-action@v0.14.0' (SHA:a0d2d53632934ae004f878c840055956d9f741b0)
+2025-10-07T09:42:24.9756179Z Getting action download info
+2025-10-07T09:42:25.2001366Z Download action repository 'docker/login-action@v2' (SHA:465a07811f14bebb1938fbed4728c6a1ff8901fc)
+2025-10-07T09:42:25.5950450Z Getting action download info
+2025-10-07T09:42:25.8420813Z Download action repository 'DeterminateSystems/nix-installer-action@90bb610b90bf290cad97484ba341453bd1cbefea' (SHA:90bb610b90bf290cad97484ba341453bd1cbefea)
+2025-10-07T09:42:26.2357036Z Complete job name: Kuttl tests
+2025-10-07T09:42:26.2658924Z A job started hook has been configured by the self-hosted runner administrator
+2025-10-07T09:42:26.2771343Z ##[group]Run '/etc/arc/hooks/job-started.sh'
+2025-10-07T09:42:26.2787305Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2025-10-07T09:42:26.2788010Z ##[endgroup]
+2025-10-07T09:42:26.2926345Z [0;37m2025-10-07 09:42:26.290  DEBUG --- Running ARC Job Started Hooks[0m
+2025-10-07T09:42:26.2930107Z [0;37m2025-10-07 09:42:26.292  DEBUG --- Running hook: /etc/arc/hooks/job-started.d/update-status[0m
+2025-10-07T09:42:26.3229880Z ##[group]Run actions/create-github-app-token@v1
+2025-10-07T09:42:26.3230304Z with:
+2025-10-07T09:42:26.3230782Z   app-id: ***
+2025-10-07T09:42:26.3237644Z   private-key: ***
+2025-10-07T09:42:26.3237979Z   owner: nutanix-cloud-native
+2025-10-07T09:42:26.3238337Z   github-api-url: https://api.github.com
+2025-10-07T09:42:26.3238706Z env:
+2025-10-07T09:42:26.3239064Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:42:26.3239496Z   KOCACHE: ~/ko
+2025-10-07T09:42:26.3239786Z ##[endgroup]
+2025-10-07T09:42:26.4189800Z repositories not set, creating token for all repositories for given owner "nutanix-cloud-native"
+2025-10-07T09:42:26.8183650Z ##[group]Run actions/create-github-app-token@v1
+2025-10-07T09:42:26.8184112Z with:
+2025-10-07T09:42:26.8184511Z   app-id: ***
+2025-10-07T09:42:26.8190958Z   private-key: ***
+2025-10-07T09:42:26.8191275Z   owner: mesosphere
+2025-10-07T09:42:26.8191611Z   github-api-url: https://api.github.com
+2025-10-07T09:42:26.8192195Z env:
+2025-10-07T09:42:26.8192621Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:42:26.8193073Z   KOCACHE: ~/ko
+2025-10-07T09:42:26.8193390Z ##[endgroup]
+2025-10-07T09:42:26.9115953Z repositories not set, creating token for all repositories for given owner "mesosphere"
+2025-10-07T09:42:27.2591259Z ##[group]Run git config --global url."***github.com/nutanix-cloud-native/".insteadOf "https://github.com/nutanix-cloud-native/"
+2025-10-07T09:42:27.2592769Z [36;1mgit config --global url."***github.com/nutanix-cloud-native/".insteadOf "https://github.com/nutanix-cloud-native/"[0m
+2025-10-07T09:42:27.2607491Z shell: /usr/bin/bash -e {0}
+2025-10-07T09:42:27.2607852Z env:
+2025-10-07T09:42:27.2608242Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:42:27.2608711Z   KOCACHE: ~/ko
+2025-10-07T09:42:27.2609040Z ##[endgroup]
+2025-10-07T09:42:27.2744205Z ##[group]Run git config --global url."***github.com/mesosphere/".insteadOf "https://github.com/mesosphere/"
+2025-10-07T09:42:27.2745256Z [36;1mgit config --global url."***github.com/mesosphere/".insteadOf "https://github.com/mesosphere/"[0m
+2025-10-07T09:42:27.2758077Z shell: /usr/bin/bash -e {0}
+2025-10-07T09:42:27.2758422Z env:
+2025-10-07T09:42:27.2758821Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:42:27.2759274Z   KOCACHE: ~/ko
+2025-10-07T09:42:27.2759587Z ##[endgroup]
+2025-10-07T09:42:27.2844791Z ##[group]Run echo "GH_TOKEN=***" >> $GITHUB_ENV
+2025-10-07T09:42:27.2845404Z [36;1mecho "GH_TOKEN=***" >> $GITHUB_ENV[0m
+2025-10-07T09:42:27.2858279Z shell: /usr/bin/bash -e {0}
+2025-10-07T09:42:27.2858637Z env:
+2025-10-07T09:42:27.2859043Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:42:27.2859501Z   KOCACHE: ~/ko
+2025-10-07T09:42:27.2859803Z ##[endgroup]
+2025-10-07T09:42:27.3432895Z ##[group]Run actions/cache@v4
+2025-10-07T09:42:27.3433277Z with:
+2025-10-07T09:42:27.3433605Z   path: ~/go/pkg/mod
+~/.cache/go-build
+~/ko
+
+2025-10-07T09:42:27.3433987Z   key: Linux-go-
+2025-10-07T09:42:27.3434291Z   restore-keys: Linux-go-
+
+2025-10-07T09:42:27.3434621Z   enableCrossOsArchive: false
+2025-10-07T09:42:27.3434942Z   fail-on-cache-miss: false
+2025-10-07T09:42:27.3435264Z   lookup-only: false
+2025-10-07T09:42:27.3435568Z   save-always: false
+2025-10-07T09:42:27.3435860Z env:
+2025-10-07T09:42:27.3436240Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:42:27.3436683Z   KOCACHE: ~/ko
+2025-10-07T09:42:27.3437304Z   GH_TOKEN: ***
+2025-10-07T09:42:27.3437606Z ##[endgroup]
+2025-10-07T09:42:27.7861307Z Cache hit for: Linux-go-
+2025-10-07T09:42:29.1785861Z Received 0 of 910680742 (0.0%), 0.0 MBs/sec
+2025-10-07T09:42:30.1788531Z Received 54525952 of 910680742 (6.0%), 26.0 MBs/sec
+2025-10-07T09:42:31.1790765Z Received 125829120 of 910680742 (13.8%), 40.0 MBs/sec
+2025-10-07T09:42:32.1792498Z Received 167772160 of 910680742 (18.4%), 40.0 MBs/sec
+2025-10-07T09:42:33.1797361Z Received 218103808 of 910680742 (23.9%), 41.6 MBs/sec
+2025-10-07T09:42:34.1799817Z Received 268435456 of 910680742 (29.5%), 42.7 MBs/sec
+2025-10-07T09:42:35.1809011Z Received 327155712 of 910680742 (35.9%), 44.6 MBs/sec
+2025-10-07T09:42:36.1826741Z Received 394264576 of 910680742 (43.3%), 47.0 MBs/sec
+2025-10-07T09:42:37.1833048Z Received 427819008 of 910680742 (47.0%), 45.3 MBs/sec
+2025-10-07T09:42:38.1836815Z Received 490733568 of 910680742 (53.9%), 46.8 MBs/sec
+2025-10-07T09:42:39.1841044Z Received 536870912 of 910680742 (59.0%), 46.5 MBs/sec
+2025-10-07T09:42:40.1842716Z Received 591396864 of 910680742 (64.9%), 47.0 MBs/sec
+2025-10-07T09:42:41.1846285Z Received 654311424 of 910680742 (71.8%), 48.0 MBs/sec
+2025-10-07T09:42:42.1854714Z Received 704643072 of 910680742 (77.4%), 48.0 MBs/sec
+2025-10-07T09:42:43.1864996Z Received 759169024 of 910680742 (83.4%), 48.2 MBs/sec
+2025-10-07T09:42:44.1873947Z Received 805306368 of 910680742 (88.4%), 48.0 MBs/sec
+2025-10-07T09:42:45.1883485Z Received 864026624 of 910680742 (94.9%), 48.4 MBs/sec
+2025-10-07T09:42:45.8678968Z Received 910680742 of 910680742 (100.0%), 49.1 MBs/sec
+2025-10-07T09:42:45.8681967Z Cache Size: ~868 MB (910680742 B)
+2025-10-07T09:42:45.8717947Z [command]/usr/bin/tar -xf /runner/_work/_temp/412b2405-2901-4663-bf28-fd0433af32bf/cache.tzst -P -C /runner/_work/kommander/kommander --use-compress-program unzstd
+2025-10-07T09:43:11.6816679Z Cache restored successfully
+2025-10-07T09:43:11.8889608Z Cache restored from key: Linux-go-
+2025-10-07T09:43:11.9537500Z ##[group]Run actions/checkout@v4
+2025-10-07T09:43:11.9537886Z with:
+2025-10-07T09:43:11.9538211Z   repository: mesosphere/kommander
+2025-10-07T09:43:11.9538927Z   token: ***
+2025-10-07T09:43:11.9539242Z   ssh-strict: true
+2025-10-07T09:43:11.9539557Z   ssh-user: git
+2025-10-07T09:43:11.9539880Z   persist-credentials: true
+2025-10-07T09:43:11.9540265Z   clean: true
+2025-10-07T09:43:11.9540623Z   sparse-checkout-cone-mode: true
+2025-10-07T09:43:11.9540983Z   fetch-depth: 1
+2025-10-07T09:43:11.9541453Z   fetch-tags: false
+2025-10-07T09:43:11.9541781Z   show-progress: true
+2025-10-07T09:43:11.9542308Z   lfs: false
+2025-10-07T09:43:11.9542641Z   submodules: false
+2025-10-07T09:43:11.9542959Z   set-safe-directory: true
+2025-10-07T09:43:11.9543386Z env:
+2025-10-07T09:43:11.9543823Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:43:11.9544280Z   KOCACHE: ~/ko
+2025-10-07T09:43:11.9544669Z   GH_TOKEN: ***
+2025-10-07T09:43:11.9544973Z ##[endgroup]
+2025-10-07T09:43:12.0528470Z Syncing repository: mesosphere/kommander
+2025-10-07T09:43:12.0529917Z ##[group]Getting Git version info
+2025-10-07T09:43:12.0530440Z Working directory is '/runner/_work/kommander/kommander'
+2025-10-07T09:43:12.0531118Z [command]/usr/bin/git version
+2025-10-07T09:43:12.0531476Z git version 2.43.2
+2025-10-07T09:43:12.0548874Z ##[endgroup]
+2025-10-07T09:43:12.0564003Z Copying '/home/runner/.gitconfig' to '/runner/_work/_temp/379275dc-bdae-4b43-aa26-9cb2ff9ff79c/.gitconfig'
+2025-10-07T09:43:12.0573043Z Temporarily overriding HOME='/runner/_work/_temp/379275dc-bdae-4b43-aa26-9cb2ff9ff79c' before making global git config changes
+2025-10-07T09:43:12.0574241Z Adding repository directory to the temporary git global config as a safe directory
+2025-10-07T09:43:12.0577520Z [command]/usr/bin/git config --global --add safe.directory /runner/_work/kommander/kommander
+2025-10-07T09:43:12.0610787Z Deleting the contents of '/runner/_work/kommander/kommander'
+2025-10-07T09:43:12.0615230Z ##[group]Initializing the repository
+2025-10-07T09:43:12.0618519Z [command]/usr/bin/git init /runner/_work/kommander/kommander
+2025-10-07T09:43:12.0649100Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-10-07T09:43:12.0649920Z hint: is subject to change. To configure the initial branch name to use in all
+2025-10-07T09:43:12.0650632Z hint: of your new repositories, which will suppress this warning, call:
+2025-10-07T09:43:12.0651196Z hint: 
+2025-10-07T09:43:12.0651629Z hint: 	git config --global init.defaultBranch <name>
+2025-10-07T09:43:12.0652355Z hint: 
+2025-10-07T09:43:12.0652852Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-10-07T09:43:12.0653438Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-10-07T09:43:12.0662526Z hint: 
+2025-10-07T09:43:12.0662896Z hint: 	git branch -m <name>
+2025-10-07T09:43:12.0663479Z Initialized empty Git repository in /runner/_work/kommander/kommander/.git/
+2025-10-07T09:43:12.0671799Z [command]/usr/bin/git remote add origin https://github.com/mesosphere/kommander
+2025-10-07T09:43:12.0708413Z ##[endgroup]
+2025-10-07T09:43:12.0708996Z ##[group]Disabling automatic garbage collection
+2025-10-07T09:43:12.0711539Z [command]/usr/bin/git config --local gc.auto 0
+2025-10-07T09:43:12.0738534Z ##[endgroup]
+2025-10-07T09:43:12.0739226Z ##[group]Setting up auth
+2025-10-07T09:43:12.0744778Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-10-07T09:43:12.0772694Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-10-07T09:43:12.1026694Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-10-07T09:43:12.1056634Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-10-07T09:43:12.1314807Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2025-10-07T09:43:12.1350903Z ##[endgroup]
+2025-10-07T09:43:12.1351474Z ##[group]Fetching the repository
+2025-10-07T09:43:12.1366998Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +788c086bfcb46d2faaa2c38d7d633d9d85048518:refs/remotes/pull/6451/merge
+2025-10-07T09:43:13.1035668Z From https://github.com/mesosphere/kommander
+2025-10-07T09:43:13.1036426Z  * [new ref]         788c086bfcb46d2faaa2c38d7d633d9d85048518 -> pull/6451/merge
+2025-10-07T09:43:13.1058818Z ##[endgroup]
+2025-10-07T09:43:13.1059478Z ##[group]Determining the checkout info
+2025-10-07T09:43:13.1060458Z ##[endgroup]
+2025-10-07T09:43:13.1065403Z [command]/usr/bin/git sparse-checkout disable
+2025-10-07T09:43:13.1101511Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2025-10-07T09:43:13.1128980Z ##[group]Checking out the ref
+2025-10-07T09:43:13.1133575Z [command]/usr/bin/git checkout --progress --force refs/remotes/pull/6451/merge
+2025-10-07T09:43:13.2596974Z Note: switching to 'refs/remotes/pull/6451/merge'.
+2025-10-07T09:43:13.2597587Z 
+2025-10-07T09:43:13.2597908Z You are in 'detached HEAD' state. You can look around, make experimental
+2025-10-07T09:43:13.2598610Z changes and commit them, and you can discard any commits you make in this
+2025-10-07T09:43:13.2599286Z state without impacting any branches by switching back to a branch.
+2025-10-07T09:43:13.2599662Z 
+2025-10-07T09:43:13.2599955Z If you want to create a new branch to retain commits you create, you may
+2025-10-07T09:43:13.2600577Z do so (now or later) by using -c with the switch command. Example:
+2025-10-07T09:43:13.2600930Z 
+2025-10-07T09:43:13.2601132Z   git switch -c <new-branch-name>
+2025-10-07T09:43:13.2601403Z 
+2025-10-07T09:43:13.2601596Z Or undo this operation with:
+2025-10-07T09:43:13.2601839Z 
+2025-10-07T09:43:13.2602341Z   git switch -
+2025-10-07T09:43:13.2602596Z 
+2025-10-07T09:43:13.2602918Z Turn off this advice by setting config variable advice.detachedHead to false
+2025-10-07T09:43:13.2603348Z 
+2025-10-07T09:43:13.2603726Z HEAD is now at 788c086 Merge 61dcb457eb4ab5df3fb71e4fbd82704c580d5939 into 45122130a0f727efd77c11d33d30d40aab9cda8e
+2025-10-07T09:43:13.2609033Z ##[endgroup]
+2025-10-07T09:43:13.2647210Z [command]/usr/bin/git log -1 --format=%H
+2025-10-07T09:43:13.2670085Z 788c086bfcb46d2faaa2c38d7d633d9d85048518
+2025-10-07T09:43:13.2822736Z ##[group]Run mesosphere/workflow-db/actions/docker/login@main
+2025-10-07T09:43:13.2823199Z with:
+2025-10-07T09:43:13.2823575Z   username: ***
+2025-10-07T09:43:13.2823935Z   password: ***
+2025-10-07T09:43:13.2824376Z   nexus-address: https://docker-proxy.devprod-production.d2iq.cloud
+2025-10-07T09:43:13.2824843Z env:
+2025-10-07T09:43:13.2825235Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:43:13.2825677Z   KOCACHE: ~/ko
+2025-10-07T09:43:13.2826047Z   GH_TOKEN: ***
+2025-10-07T09:43:13.2826326Z ##[endgroup]
+2025-10-07T09:43:13.2906714Z ##[group]Run docker/login-action@v2
+2025-10-07T09:43:13.2907091Z with:
+2025-10-07T09:43:13.2907418Z   username: ***
+2025-10-07T09:43:13.2907754Z   password: ***
+2025-10-07T09:43:13.2908105Z   ecr: auto
+2025-10-07T09:43:13.2908550Z   logout: true
+2025-10-07T09:43:13.2908851Z env:
+2025-10-07T09:43:13.2909232Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:43:13.2909722Z   KOCACHE: ~/ko
+2025-10-07T09:43:13.2910113Z   GH_TOKEN: ***
+2025-10-07T09:43:13.2910413Z ##[endgroup]
+2025-10-07T09:43:13.3818878Z Logging into Docker Hub...
+2025-10-07T09:43:14.0902655Z Login Succeeded!
+2025-10-07T09:43:14.1021101Z ##[group]Run docker/login-action@v2
+2025-10-07T09:43:14.1021571Z with:
+2025-10-07T09:43:14.1021975Z   registry: https://docker-proxy.devprod-production.d2iq.cloud
+2025-10-07T09:43:14.1023004Z   username: ***
+2025-10-07T09:43:14.1023373Z   password: ***
+2025-10-07T09:43:14.1023678Z   ecr: auto
+2025-10-07T09:43:14.1023972Z   logout: true
+2025-10-07T09:43:14.1024269Z env:
+2025-10-07T09:43:14.1024656Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:43:14.1025383Z   KOCACHE: ~/ko
+2025-10-07T09:43:14.1025791Z   GH_TOKEN: ***
+2025-10-07T09:43:14.1026092Z ##[endgroup]
+2025-10-07T09:43:14.1946422Z Logging into https://docker-proxy.devprod-production.d2iq.cloud...
+2025-10-07T09:43:14.2814602Z Login Succeeded!
+2025-10-07T09:43:14.2923300Z ##[group]Run cachix/install-nix-action@v31
+2025-10-07T09:43:14.2923710Z with:
+2025-10-07T09:43:14.2924195Z   github_access_token: ***
+2025-10-07T09:43:14.2924552Z   enable_kvm: true
+2025-10-07T09:43:14.2924865Z   set_as_trusted_user: true
+2025-10-07T09:43:14.2925191Z env:
+2025-10-07T09:43:14.2925580Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:43:14.2926038Z   KOCACHE: ~/ko
+2025-10-07T09:43:14.2926415Z   GH_TOKEN: ***
+2025-10-07T09:43:14.2926719Z ##[endgroup]
+2025-10-07T09:43:14.2944858Z ##[group]Run ${GITHUB_ACTION_PATH}/install-nix.sh
+2025-10-07T09:43:14.2945344Z [36;1m${GITHUB_ACTION_PATH}/install-nix.sh[0m
+2025-10-07T09:43:14.2959252Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2025-10-07T09:43:14.2959702Z env:
+2025-10-07T09:43:14.2960082Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:43:14.2960545Z   KOCACHE: ~/ko
+2025-10-07T09:43:14.2960985Z   GH_TOKEN: ***
+2025-10-07T09:43:14.2961334Z   INPUT_EXTRA_NIX_CONFIG: 
+2025-10-07T09:43:14.2961785Z   INPUT_GITHUB_ACCESS_TOKEN: ***
+2025-10-07T09:43:14.2962348Z   INPUT_INSTALL_OPTIONS: 
+2025-10-07T09:43:14.2962684Z   INPUT_INSTALL_URL: 
+2025-10-07T09:43:14.2963004Z   INPUT_NIX_PATH: 
+2025-10-07T09:43:14.2963308Z   INPUT_ENABLE_KVM: true
+2025-10-07T09:43:14.2963637Z   INPUT_SET_AS_TRUSTED_USER: true
+2025-10-07T09:43:14.2964075Z   GITHUB_TOKEN: ***
+2025-10-07T09:43:14.2964381Z ##[endgroup]
+2025-10-07T09:43:14.3020070Z ##[group]Enabling KVM support
+2025-10-07T09:43:14.3079045Z tee: /etc/udev/rules.d/99-install-nix-action-kvm.rules: No such file or directory
+2025-10-07T09:43:14.3080022Z KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"
+2025-10-07T09:43:14.3120215Z sudo: udevadm: command not found
+2025-10-07T09:43:14.3123486Z KVM is not available
+2025-10-07T09:43:14.3124068Z ##[endgroup]
+2025-10-07T09:43:14.3124688Z ##[group]Installing Nix
+2025-10-07T09:43:14.3311936Z installer options: --no-channel-add --nix-extra-conf-file /tmp/tmp.0ThpfaO5kH/nix.conf
+2025-10-07T09:43:14.3777359Z *   Trying 146.75.42.217:443...
+2025-10-07T09:43:14.3778143Z * TCP_NODELAY set
+2025-10-07T09:43:14.3861370Z * Connected to releases.nixos.org (146.75.42.217) port 443 (#0)
+2025-10-07T09:43:14.3863514Z * ALPN, offering h2
+2025-10-07T09:43:14.3863979Z * ALPN, offering http/1.1
+2025-10-07T09:43:14.3905960Z * successfully set certificate verify locations:
+2025-10-07T09:43:14.3906574Z *   CAfile: /etc/ssl/certs/ca-certificates.crt
+2025-10-07T09:43:14.3907244Z   CApath: /etc/ssl/certs
+2025-10-07T09:43:14.3907725Z } [5 bytes data]
+2025-10-07T09:43:14.3908155Z * TLSv1.3 (OUT), TLS handshake, Client hello (1):
+2025-10-07T09:43:14.3920105Z } [512 bytes data]
+2025-10-07T09:43:14.4002670Z * TLSv1.3 (IN), TLS handshake, Server hello (2):
+2025-10-07T09:43:14.4003202Z { [104 bytes data]
+2025-10-07T09:43:14.4003612Z * TLSv1.2 (IN), TLS handshake, Certificate (11):
+2025-10-07T09:43:14.4004070Z { [2827 bytes data]
+2025-10-07T09:43:14.4004860Z * TLSv1.2 (IN), TLS handshake, Server key exchange (12):
+2025-10-07T09:43:14.4005416Z { [300 bytes data]
+2025-10-07T09:43:14.4005749Z * TLSv1.2 (IN), TLS handshake, Server finished (14):
+2025-10-07T09:43:14.4006137Z { [4 bytes data]
+2025-10-07T09:43:14.4006683Z * TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
+2025-10-07T09:43:14.4007175Z } [37 bytes data]
+2025-10-07T09:43:14.4007634Z * TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
+2025-10-07T09:43:14.4008077Z } [1 bytes data]
+2025-10-07T09:43:14.4008410Z * TLSv1.2 (OUT), TLS handshake, Finished (20):
+2025-10-07T09:43:14.4008786Z } [16 bytes data]
+2025-10-07T09:43:14.4093206Z * TLSv1.2 (IN), TLS handshake, Finished (20):
+2025-10-07T09:43:14.4093963Z { [16 bytes data]
+2025-10-07T09:43:14.4095011Z * SSL connection using TLSv1.2 / ECDHE-RSA-CHACHA20-POLY1305
+2025-10-07T09:43:14.4095791Z * ALPN, server accepted to use h2
+2025-10-07T09:43:14.4096224Z * Server certificate:
+2025-10-07T09:43:14.4096760Z *  subject: CN=releases.nixos.org
+2025-10-07T09:43:14.4097489Z *  start date: Aug 14 21:00:27 2025 GMT
+2025-10-07T09:43:14.4097962Z *  expire date: Sep 15 21:00:26 2026 GMT
+2025-10-07T09:43:14.4098578Z *  subjectAltName: host "releases.nixos.org" matched cert's "releases.nixos.org"
+2025-10-07T09:43:14.4099301Z *  issuer: C=BE; O=GlobalSign nv-sa; CN=GlobalSign Atlas R3 DV TLS CA 2025 Q3
+2025-10-07T09:43:14.4099877Z *  SSL certificate verify ok.
+2025-10-07T09:43:14.4100328Z * Using HTTP2, server supports multi-use
+2025-10-07T09:43:14.4100827Z * Connection state changed (HTTP/2 confirmed)
+2025-10-07T09:43:14.4101563Z * Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
+2025-10-07T09:43:14.4102467Z } [5 bytes data]
+2025-10-07T09:43:14.4102899Z * Using Stream ID: 1 (easy handle 0x615cf8b10650)
+2025-10-07T09:43:14.4103372Z } [5 bytes data]
+2025-10-07T09:43:14.4103766Z > GET /nix/nix-2.31.2/install HTTP/2
+2025-10-07T09:43:14.4104205Z > Host: releases.nixos.org
+2025-10-07T09:43:14.4104586Z > user-agent: curl/7.68.0
+2025-10-07T09:43:14.4104903Z > accept: */*
+2025-10-07T09:43:14.4105190Z > 
+2025-10-07T09:43:14.4178662Z { [5 bytes data]
+2025-10-07T09:43:14.4179509Z * Connection state changed (MAX_CONCURRENT_STREAMS == 100)!
+2025-10-07T09:43:14.4180283Z } [5 bytes data]
+2025-10-07T09:43:14.4208650Z < HTTP/2 200 
+2025-10-07T09:43:14.4209248Z < last-modified: Thu, 18 Sep 2025 11:37:32 GMT
+2025-10-07T09:43:14.4209770Z < etag: "12f89d1673c48991f81bf17d64720351"
+2025-10-07T09:43:14.4210399Z < x-amz-server-side-encryption: AES256
+2025-10-07T09:43:14.4210906Z < content-type: text/plain
+2025-10-07T09:43:14.4211409Z < server: AmazonS3
+2025-10-07T09:43:14.4211772Z < via: 1.1 varnish, 1.1 varnish
+2025-10-07T09:43:14.4212493Z < access-control-allow-origin: *
+2025-10-07T09:43:14.4212942Z < accept-ranges: bytes
+2025-10-07T09:43:14.4213333Z < date: Tue, 07 Oct 2025 09:43:14 GMT
+2025-10-07T09:43:14.4213752Z < age: 111103
+2025-10-07T09:43:14.4214211Z < x-served-by: cache-dub4324-DUB, cache-bfi-kbfi7400080-BFI
+2025-10-07T09:43:14.4214630Z < x-cache: HIT, HIT
+2025-10-07T09:43:14.4214944Z < x-cache-hits: 7, 1
+2025-10-07T09:43:14.4215252Z < content-length: 4267
+2025-10-07T09:43:14.4215556Z < 
+2025-10-07T09:43:14.4215838Z { [5 bytes data]
+2025-10-07T09:43:14.4216218Z * Connection #0 to host releases.nixos.org left intact
+2025-10-07T09:43:14.4273728Z downloading Nix 2.31.2 binary tarball for x86_64-linux from 'https://releases.nixos.org/nix/nix-2.31.2/nix-2.31.2-x86_64-linux.tar.xz' to '/tmp/nix-binary-tarball-unpack.Jf1VfjmJP8'...
+2025-10-07T09:43:14.4337440Z   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+2025-10-07T09:43:14.4338123Z                                  Dload  Upload   Total   Spent    Left  Speed
+2025-10-07T09:43:14.4338401Z 
+2025-10-07T09:43:14.5909876Z   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+2025-10-07T09:43:14.5910428Z 100 24.6M  100 24.6M    0     0   157M      0 --:--:-- --:--:-- --:--:--  157M
+2025-10-07T09:43:16.1699874Z Note: a multi-user installation is possible. See https://nix.dev/manual/nix/stable/installation/installing-binary.html#multi-user-installation
+2025-10-07T09:43:16.1719504Z performing a single-user installation of Nix...
+2025-10-07T09:43:16.1720158Z directory /nix does not exist; creating it by running 'mkdir -m 0755 /nix && chown runner /nix' using sudo
+2025-10-07T09:43:16.1810454Z 
+2025-10-07T09:43:16.7180266Z copying Nix to /nix/store...
+2025-10-07T09:43:16.7922928Z installing 'nix-2.31.2'
+2025-10-07T09:43:17.0220164Z building '/nix/store/g30g3gcmq5fly1p3qga608wisvhkczjs-user-environment.drv'...
+2025-10-07T09:43:17.0387370Z modifying /home/runner/.profile...
+2025-10-07T09:43:17.0410657Z 
+2025-10-07T09:43:17.0411051Z Installation finished!  To ensure that the necessary environment
+2025-10-07T09:43:17.0412360Z variables are set, either log in again, or type
+2025-10-07T09:43:17.0412859Z 
+2025-10-07T09:43:17.0413105Z   . /home/runner/.nix-profile/etc/profile.d/nix.sh
+2025-10-07T09:43:17.0413438Z 
+2025-10-07T09:43:17.0413615Z in your shell.
+2025-10-07T09:43:17.1304575Z ##[endgroup]
+2025-10-07T09:43:17.1440036Z ##[group]Run jetify-com/devbox-install-action@v0.14.0
+2025-10-07T09:43:17.1440485Z with:
+2025-10-07T09:43:17.1440777Z   enable-cache: false
+2025-10-07T09:43:17.1441093Z   refresh-cli: true
+2025-10-07T09:43:17.1441417Z   skip-nix-installation: true
+2025-10-07T09:43:17.1441776Z   project-path: ./bootstrapper
+2025-10-07T09:43:17.1442382Z   disable-nix-access-token: false
+2025-10-07T09:43:17.1442737Z env:
+2025-10-07T09:43:17.1443140Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:43:17.1443582Z   KOCACHE: ~/ko
+2025-10-07T09:43:17.1444056Z   GH_TOKEN: ***
+2025-10-07T09:43:17.1444384Z   TMPDIR: /runner/_work/_temp
+2025-10-07T09:43:17.1444853Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+2025-10-07T09:43:17.1445388Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+2025-10-07T09:43:17.1445787Z ##[endgroup]
+2025-10-07T09:43:17.1486210Z ##[group]Run if [[ -n $DEVBOX_USE_VERSION ]]; then
+2025-10-07T09:43:17.1486667Z [36;1mif [[ -n $DEVBOX_USE_VERSION ]]; then[0m
+2025-10-07T09:43:17.1487101Z [36;1m  echo "latest_version=$DEVBOX_USE_VERSION" >> $GITHUB_ENV[0m
+2025-10-07T09:43:17.1487517Z [36;1melse[0m
+2025-10-07T09:43:17.1487816Z [36;1m  tmp_file=$(mktemp)[0m
+2025-10-07T09:43:17.1488247Z [36;1m  latest_url="https://releases.jetify.com/devbox/stable/version"[0m
+2025-10-07T09:43:17.1488811Z [36;1m  curl --fail --silent --location --output "${tmp_file}" "${latest_url}"[0m
+2025-10-07T09:43:17.1489297Z [36;1m  latest_version=$(cat "${tmp_file}")[0m
+2025-10-07T09:43:17.1489685Z [36;1m  if [[ -n ${latest_version} ]]; then[0m
+2025-10-07T09:43:17.1490103Z [36;1m    echo "Found devbox latest version ${latest_version}."[0m
+2025-10-07T09:43:17.1490591Z [36;1m    echo "latest_version=$latest_version" >> $GITHUB_ENV[0m
+2025-10-07T09:43:17.1490982Z [36;1m  else[0m
+2025-10-07T09:43:17.1491346Z [36;1m    echo "ERROR: unable to find the latest devbox version."[0m
+2025-10-07T09:43:17.1491748Z [36;1m    exit 1[0m
+2025-10-07T09:43:17.1492235Z [36;1m  fi[0m
+2025-10-07T09:43:17.1492539Z [36;1mfi[0m
+2025-10-07T09:43:17.1510787Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2025-10-07T09:43:17.1511210Z env:
+2025-10-07T09:43:17.1511580Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:43:17.1512291Z   KOCACHE: ~/ko
+2025-10-07T09:43:17.1512747Z   GH_TOKEN: ***
+2025-10-07T09:43:17.1513065Z   TMPDIR: /runner/_work/_temp
+2025-10-07T09:43:17.1513530Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+2025-10-07T09:43:17.1514024Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+2025-10-07T09:43:17.1514416Z   DEVBOX_USE_VERSION: 
+2025-10-07T09:43:17.1514722Z ##[endgroup]
+2025-10-07T09:43:17.3251575Z Found devbox latest version 0.16.0.
+2025-10-07T09:43:17.3298788Z ##[group]Run export DEVBOX_USE_VERSION="0.16.0"
+2025-10-07T09:43:17.3299251Z [36;1mexport DEVBOX_USE_VERSION="0.16.0"[0m
+2025-10-07T09:43:17.3299750Z [36;1mcurl -fsSL https://get.jetify.com/devbox | FORCE=1 bash[0m
+2025-10-07T09:43:17.3300189Z [36;1m[0m
+2025-10-07T09:43:17.3300493Z [36;1mversion=$(devbox version)[0m
+2025-10-07T09:43:17.3300916Z [36;1mif [[ ! "$version" = "$DEVBOX_USE_VERSION" ]]; then[0m
+2025-10-07T09:43:17.3301590Z [36;1m  echo "ERROR: mismatch devbox version downloaded. Expected $DEVBOX_USE_VERSION, got $version."[0m
+2025-10-07T09:43:17.3302398Z [36;1m  exit 1[0m
+2025-10-07T09:43:17.3302726Z [36;1mfi[0m
+2025-10-07T09:43:17.3303131Z [36;1mDEVBOX_BINARY="$(find "${HOME}/.cache/devbox/bin" -name devbox)"[0m
+2025-10-07T09:43:17.3303592Z [36;1mif [ -n "$DEVBOX_SHA256" ]; then[0m
+2025-10-07T09:43:17.3304003Z [36;1m  if command -v "sha256sum" 1>/dev/null 2>&1; then[0m
+2025-10-07T09:43:17.3304448Z [36;1m    # Linux distributions will likely have this.[0m
+2025-10-07T09:43:17.3305148Z [36;1m    DEVBOX_CHECKSUM="$(sha256sum "$DEVBOX_BINARY" | cut -f1 -d' ')"[0m
+2025-10-07T09:43:17.3305658Z [36;1m  elif command -v "shasum" 1>/dev/null 2>&1; then[0m
+2025-10-07T09:43:17.3306239Z [36;1m    # MacOS comes with this.[0m
+2025-10-07T09:43:17.3306738Z [36;1m    DEVBOX_CHECKSUM="$(shasum -a 256 "$DEVBOX_BINARY" | cut -f1 -d' ')"[0m
+2025-10-07T09:43:17.3307189Z [36;1m  fi[0m
+2025-10-07T09:43:17.3307480Z [36;1m[0m
+2025-10-07T09:43:17.3307787Z [36;1m  if [ -z "$DEVBOX_CHECKSUM" ]; then[0m
+2025-10-07T09:43:17.3308342Z [36;1m    echo "ERROR: unable to get devbox checksum. Please ensure sha256sum or shasum is installed."[0m
+2025-10-07T09:43:17.3308870Z [36;1m    exit 2[0m
+2025-10-07T09:43:17.3309184Z [36;1m  fi[0m
+2025-10-07T09:43:17.3323156Z [36;1m[0m
+2025-10-07T09:43:17.3323555Z [36;1m  if [[ ! "$DEVBOX_CHECKSUM" = "$DEVBOX_SHA256" ]]; then[0m
+2025-10-07T09:43:17.3324138Z [36;1m    echo "ERROR: checksums do not match. Expected $DEVBOX_SHA256, got $DEVBOX_CHECKSUM."[0m
+2025-10-07T09:43:17.3324651Z [36;1m    exit 3[0m
+2025-10-07T09:43:17.3324946Z [36;1m  fi[0m
+2025-10-07T09:43:17.3325222Z [36;1mfi[0m
+2025-10-07T09:43:17.3325534Z [36;1mmkdir -p ~/.local/bin[0m
+2025-10-07T09:43:17.3325918Z [36;1mmv "$DEVBOX_BINARY" ~/.local/bin/devbox[0m
+2025-10-07T09:43:17.3341369Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2025-10-07T09:43:17.3341794Z env:
+2025-10-07T09:43:17.3342471Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:43:17.3342944Z   KOCACHE: ~/ko
+2025-10-07T09:43:17.3343383Z   GH_TOKEN: ***
+2025-10-07T09:43:17.3343697Z   TMPDIR: /runner/_work/_temp
+2025-10-07T09:43:17.3344145Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+2025-10-07T09:43:17.3344671Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+2025-10-07T09:43:17.3345073Z   latest_version: 0.16.0
+2025-10-07T09:43:17.3345396Z   DEVBOX_SHA256: 
+2025-10-07T09:43:17.3345707Z ##[endgroup]
+2025-10-07T09:43:17.9052803Z Devbox 📦 by Jetify
+2025-10-07T09:43:17.9053414Z   Instant, easy and predictable development environments.
+2025-10-07T09:43:17.9053797Z 
+2025-10-07T09:43:17.9054097Z   This script downloads and installs the latest devbox binary.
+2025-10-07T09:43:17.9054461Z 
+2025-10-07T09:43:17.9054647Z Confirm Installation Details
+2025-10-07T09:43:17.9055087Z   Location:     /usr/local/bin/devbox
+2025-10-07T09:43:17.9055623Z   Download URL: https://releases.jetify.com/devbox
+2025-10-07T09:43:17.9055955Z 
+2025-10-07T09:43:17.9055959Z 
+2025-10-07T09:43:17.9056137Z Downloading and Installing
+2025-10-07T09:43:17.9056634Z → Downloading devbox binary...
+2025-10-07T09:43:18.3777815Z [1F[0K✓ Downloading devbox binary... [DONE]
+2025-10-07T09:43:18.3778543Z → Installing in /usr/local/bin/devbox (requires sudo)...
+2025-10-07T09:43:18.7700979Z [1F[0K✓ Installing in /usr/local/bin/devbox... [DONE]
+2025-10-07T09:43:19.0714763Z ✓ Successfully installed devbox 🚀
+2025-10-07T09:43:19.3728584Z 
+2025-10-07T09:43:19.3729465Z Next Steps
+2025-10-07T09:43:19.3729970Z   1. Learn how to use devbox
+2025-10-07T09:43:19.3730598Z      Run devbox help or read the docs at https://github.com/jetify-com/devbox
+2025-10-07T09:43:19.3731210Z   2. Get help and give feedback
+2025-10-07T09:43:19.3731732Z      Join our community at https://discord.gg/jetify
+2025-10-07T09:43:19.4355374Z → Downloading version 0.16.0...
+2025-10-07T09:43:19.9719671Z [1F[0K✓ Downloading version 0.16.0... [DONE]
+2025-10-07T09:43:19.9740837Z → Verifying checksum...
+2025-10-07T09:43:20.3151809Z [1F[0K✓ Verifying checksum... [DONE]
+2025-10-07T09:43:20.3152564Z → Unpacking binary...
+2025-10-07T09:43:20.5156788Z [1F[0K✓ Unpacking binary... [DONE]
+2025-10-07T09:43:20.5186623Z 
+2025-10-07T09:43:20.5789478Z ##[group]Run echo "$HOME/.local/bin" >> $GITHUB_PATH
+2025-10-07T09:43:20.5789958Z [36;1mecho "$HOME/.local/bin" >> $GITHUB_PATH[0m
+2025-10-07T09:43:20.5811692Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2025-10-07T09:43:20.5812864Z env:
+2025-10-07T09:43:20.5813495Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:43:20.5814249Z   KOCACHE: ~/ko
+2025-10-07T09:43:20.5814952Z   GH_TOKEN: ***
+2025-10-07T09:43:20.5815460Z   TMPDIR: /runner/_work/_temp
+2025-10-07T09:43:20.5816448Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+2025-10-07T09:43:20.5817292Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+2025-10-07T09:43:20.5817965Z   latest_version: 0.16.0
+2025-10-07T09:43:20.5818488Z ##[endgroup]
+2025-10-07T09:43:20.5909417Z ##[group]Run mkdir -p ~/.config/nix
+2025-10-07T09:43:20.5909888Z [36;1mmkdir -p ~/.config/nix[0m
+2025-10-07T09:43:20.5910604Z [36;1mecho "access-tokens = github.com=***" >> ~/.config/nix/nix.conf[0m
+2025-10-07T09:43:20.5926351Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2025-10-07T09:43:20.5926796Z env:
+2025-10-07T09:43:20.5927179Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:43:20.5927666Z   KOCACHE: ~/ko
+2025-10-07T09:43:20.5928082Z   GH_TOKEN: ***
+2025-10-07T09:43:20.5928404Z   TMPDIR: /runner/_work/_temp
+2025-10-07T09:43:20.5928846Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+2025-10-07T09:43:20.5929385Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+2025-10-07T09:43:20.5929818Z   latest_version: 0.16.0
+2025-10-07T09:43:20.5930139Z ##[endgroup]
+2025-10-07T09:43:20.6007700Z ##[group]Run NIX_VERSION_OUTPUT=$(nix --version)
+2025-10-07T09:43:20.6008146Z [36;1mNIX_VERSION_OUTPUT=$(nix --version)[0m
+2025-10-07T09:43:20.6008619Z [36;1mNIX_VERSION=$(echo "${NIX_VERSION_OUTPUT}" | awk '{print $NF}')[0m
+2025-10-07T09:43:20.6009115Z [36;1mecho "nix_version=$NIX_VERSION" >> $GITHUB_ENV[0m
+2025-10-07T09:43:20.6024876Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2025-10-07T09:43:20.6025314Z env:
+2025-10-07T09:43:20.6025721Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:43:20.6026187Z   KOCACHE: ~/ko
+2025-10-07T09:43:20.6026628Z   GH_TOKEN: ***
+2025-10-07T09:43:20.6026957Z   TMPDIR: /runner/_work/_temp
+2025-10-07T09:43:20.6027418Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+2025-10-07T09:43:20.6027959Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+2025-10-07T09:43:20.6028374Z   latest_version: 0.16.0
+2025-10-07T09:43:20.6028695Z ##[endgroup]
+2025-10-07T09:43:20.6389363Z ##[group]Run devbox run --config=./bootstrapper -- echo "Packages installed!"
+2025-10-07T09:43:20.6389979Z [36;1mdevbox run --config=./bootstrapper -- echo "Packages installed!"[0m
+2025-10-07T09:43:20.6405410Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2025-10-07T09:43:20.6405843Z env:
+2025-10-07T09:43:20.6406241Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:43:20.6406697Z   KOCACHE: ~/ko
+2025-10-07T09:43:20.6407129Z   GH_TOKEN: ***
+2025-10-07T09:43:20.6407442Z   TMPDIR: /runner/_work/_temp
+2025-10-07T09:43:20.6407898Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+2025-10-07T09:43:20.6408429Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+2025-10-07T09:43:20.6408833Z   latest_version: 0.16.0
+2025-10-07T09:43:20.6409163Z   nix_version: 2.31.2
+2025-10-07T09:43:20.6409478Z ##[endgroup]
+2025-10-07T09:43:20.6783336Z Info: Running script "echo" on /runner/_work/kommander/kommander/bootstrapper
+2025-10-07T09:43:20.6812176Z Info: Ensuring packages are installed.
+2025-10-07T09:43:38.8797530Z Info: Installing the following packages to the nix store: cmctl@latest, envsubst@latest, fluxcd@latest, goimports@latest, kind@latest, kustomize@latest, kuttl@latest, gh@latest, ko@latest, gnused@latest, kubectl@latest, wget@latest, go@latest, jq@latest, just@latest
+2025-10-07T09:43:39.3018237Z these 63 paths will be fetched (292.96 MiB download, 1406.48 MiB unpacked):
+2025-10-07T09:43:39.3018982Z   /nix/store/1xjldbdb814annhpmcwz7h6z6y3lay15-acl-2.3.1
+2025-10-07T09:43:39.3019623Z   /nix/store/9igigiz42g7w2i605dd5k1spxy9nkf48-attr-2.5.1
+2025-10-07T09:43:39.3020578Z   /nix/store/4nmqxajzaf60yjribkgvj5j54x9yvr1r-bash-5.1-p12
+2025-10-07T09:43:39.3021176Z   /nix/store/izpf49b74i15pcr9708s3xdwyqs4jxwl-bash-5.2p32
+2025-10-07T09:43:39.3021899Z   /nix/store/jzfqlxwln31ck2gx168yd12gizwsd0pr-cmctl-1.14.5
+2025-10-07T09:43:39.3023029Z   /nix/store/dj89pwrdlycn8iyn08v8znmynjz1zsi9-coreutils-9.0
+2025-10-07T09:43:39.3023586Z   /nix/store/8jfd15711zjz6d7lib09j40arfn24z7z-envsubst-1.4.2
+2025-10-07T09:43:39.3024062Z   /nix/store/0kzywrdb93bs60whav8cdwi3q5k1ybvi-fluxcd-2.3.0
+2025-10-07T09:43:39.3024603Z   /nix/store/xvzz97yk73hw03v5dhhz3j47ggwf1yq1-gcc-13.2.0-lib
+2025-10-07T09:43:39.3025210Z   /nix/store/0rxb3ixzk4zaqivc9s795m0a3679wbw2-gcc-13.2.0-libgcc
+2025-10-07T09:43:39.3025705Z   /nix/store/flq1szdy6pvm50f348ik03x8058kf0b6-gh-2.50.0
+2025-10-07T09:43:39.3026181Z   /nix/store/4s21k8k7p1mfik0b33r2spq5hq7774k1-glibc-2.33-108
+2025-10-07T09:43:39.3026668Z   /nix/store/0wydilnf1c9vznywsvxqnaing4wraaxp-glibc-2.39-52
+2025-10-07T09:43:39.3027206Z   /nix/store/3dyw8dzj9ab4m8hv5dpyx7zii8d0w6fi-glibc-2.39-52
+2025-10-07T09:43:39.3027741Z   /nix/store/k7zgvzp2r31zkg9xqgjim7mbknryv6bs-glibc-2.39-52
+2025-10-07T09:43:39.3028300Z   /nix/store/m71p7f0nymb19yn1dascklyya2i96jfw-glibc-2.39-52
+2025-10-07T09:43:39.3028779Z   /nix/store/9zsm74npdqq2lgjzavlzaqrz8x44mq9d-gnused-4.9
+2025-10-07T09:43:39.3029245Z   /nix/store/a2m476dmim68g082fcia3wrbrzhhfgmv-go-1.17.7
+2025-10-07T09:43:39.3029955Z   /nix/store/mi0ybwsm6pmxzv9hsm6bcbqaq1pkf8wh-go-1.23.1
+2025-10-07T09:43:39.3030542Z   /nix/store/6fs2waydlsszzamlmf533zxivd28szy2-gotools-unstable-2021-01-13
+2025-10-07T09:43:39.3031513Z   /nix/store/s3lvxqjqlw3fbg29ys7mk36kg0ivx4h2-iana-etc-20211124
+2025-10-07T09:43:39.3032563Z   /nix/store/dzsby2vk02jcn0s43fkna2qqqix6ccy1-iana-etc-20240318
+2025-10-07T09:43:39.3033419Z   /nix/store/zzabmhclvdspa62fz40y08lnfx1n4b2c-iana-etc-20240318
+2025-10-07T09:43:39.3034281Z   /nix/store/33flg1kzjqn426gg4yfz1zkgpj9cmc4j-jq-1.7.1
+2025-10-07T09:43:39.3035086Z   /nix/store/7y2nxi5svi3ya06jyfw7l06rxvfb1zzf-jq-1.7.1-bin
+2025-10-07T09:43:39.3035828Z   /nix/store/5cq70lcqc2aph4q03brijk3alfh5rnmz-jq-1.7.1-doc
+2025-10-07T09:43:39.3036607Z   /nix/store/bjf63mfkn3r6svmb4qlsy1v8bff4dwa9-jq-1.7.1-lib
+2025-10-07T09:43:39.3037434Z   /nix/store/shvd454wy3lnhirj922yrzffzscci28s-jq-1.7.1-man
+2025-10-07T09:43:39.3038235Z   /nix/store/y5ss3x2g7s1mj416dfa069s4svwk4h9f-just-1.28.0
+2025-10-07T09:43:39.3038979Z   /nix/store/skkd1458vk68di6dkdhiq5cakfi3p7am-just-1.28.0-man
+2025-10-07T09:43:39.3039782Z   /nix/store/8if8dwbvyalf0cfk0vkaysvcmkva9syh-kind-0.23.0
+2025-10-07T09:43:39.3040493Z   /nix/store/vi97ix6hlnkwsigic4pg8pmcairlh6my-ko-0.15.4
+2025-10-07T09:43:39.3041142Z   /nix/store/05k95p72niq1gh39gv1g9n0ivsgl4hiy-kubectl-1.30.1
+2025-10-07T09:43:39.3041648Z   /nix/store/5vr6jxqx0al48cv8ryxr003f4f4f1h65-kubectl-1.30.1-man
+2025-10-07T09:43:39.3042382Z   /nix/store/dr124zy69xxahw9iycvbbf1ss8jxh7m7-kustomize-5.4.2
+2025-10-07T09:43:39.3042873Z   /nix/store/lr87j4wljn94dfc41dpdkq32wggaw5hz-kuttl-0.16.0
+2025-10-07T09:43:39.3043364Z   /nix/store/w2id1hwv4vv7hvp4slgsyrydrjbfqdxc-libidn2-2.3.2
+2025-10-07T09:43:39.3043849Z   /nix/store/70x99mlxawd915q5nfj4swxjjnjw1ahy-libidn2-2.3.7
+2025-10-07T09:43:39.3044307Z   /nix/store/8hq38sx1hjgganlj6dn0fvvba0g7gcpi-libidn2-2.3.7
+2025-10-07T09:43:39.3044799Z   /nix/store/ic63ay0py10fyryaw7345k4ps32da33w-libidn2-2.3.7
+2025-10-07T09:43:39.3045262Z   /nix/store/pq755f1pxaas9q7666wzdzxidcvf9frg-libidn2-2.3.7
+2025-10-07T09:43:39.3045760Z   /nix/store/8ckxc8biqqfdwyhr0w70jgrcb4h7a4y5-libunistring-0.9.10
+2025-10-07T09:43:39.3046303Z   /nix/store/vf553z7mi2vqk8ca6kkfd9x5gy3nnz0p-libunistring-1.1
+2025-10-07T09:43:39.3046807Z   /nix/store/yfp7dr8m7zi7kxk49wd714gwvhb105hf-libunistring-1.1
+2025-10-07T09:43:39.3047285Z   /nix/store/560z0zfybsjb8m76n67x6c1k7gpm080w-libunistring-1.2
+2025-10-07T09:43:39.3047780Z   /nix/store/lw2macnzp3av47m41qv6vcnq2daibgl1-libunistring-1.2
+2025-10-07T09:43:39.3048278Z   /nix/store/qd3g8rk5hx5zkb70idjh6fa12sh6bipg-mailcap-2.1.53
+2025-10-07T09:43:39.3048776Z   /nix/store/zk9ybjjixdwyv3jmpg2i7s8p7iqi5vhh-mailcap-2.1.53
+2025-10-07T09:43:39.3049528Z   /nix/store/3zrkasqf3sqr9ff6sv5fddhlbf072a36-mailcap-2.1.54
+2025-10-07T09:43:39.3050055Z   /nix/store/l7mj5f6n6x69yixv7j7wazjq15y1mvki-oniguruma-6.9.9-lib
+2025-10-07T09:43:39.3050706Z   /nix/store/jv2p6cmx23ihj5y4r98wnn2nmv4qhfh5-openssl-3.0.14
+2025-10-07T09:43:39.3051181Z   /nix/store/pn90mx43spz33pb2l2s8yz19j4hqi648-pcre-8.45
+2025-10-07T09:43:39.3051648Z   /nix/store/4i0gfyhwf63ycz5j489mgkh2nlinnvfi-perl-5.34.0
+2025-10-07T09:43:39.3052343Z   /nix/store/hym0wsdlccbvf30gp5ww7cg1pwfljy38-tzdata-2021e
+2025-10-07T09:43:39.3052821Z   /nix/store/897xqnq52vw76991r5m80h9j91370vj9-tzdata-2024a
+2025-10-07T09:43:39.3053269Z   /nix/store/y6hmqbmbwq0rmx1fzix5c5jszla2pzmp-tzdata-2024a
+2025-10-07T09:43:39.3053813Z   /nix/store/g5dj80arfsy8lvkda22dgkcqmyqa126w-util-linux-minimal-2.39.4-lib
+2025-10-07T09:43:39.3054367Z   /nix/store/8zz13nkg17nx2z4z08vwrihp7ni5kgzn-wget-1.24.5
+2025-10-07T09:43:39.3054857Z   /nix/store/1q9vc0lq7qjlfjz47mfmlzdf86c543jy-xgcc-13.2.0-libgcc
+2025-10-07T09:43:39.3055373Z   /nix/store/bihw7p4zdqwyxmnc8h67c06lnjkvdan8-xgcc-13.3.0-libgcc
+2025-10-07T09:43:39.3055867Z   /nix/store/dffyikn59cy7fff2qd60gs9jl63szqnh-xgcc-13.3.0-libgcc
+2025-10-07T09:43:39.3056392Z   /nix/store/x45xiwvk2v97bw1yp1vb6rnmvhagpgyz-xgcc-13.3.0-libgcc
+2025-10-07T09:43:39.3056869Z   /nix/store/rc18a8k50zmrif61250sfidkqvlg41ln-zlib-1.3.1
+2025-10-07T09:43:39.3066896Z copying path '/nix/store/shvd454wy3lnhirj922yrzffzscci28s-jq-1.7.1-man' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3068306Z copying path '/nix/store/skkd1458vk68di6dkdhiq5cakfi3p7am-just-1.28.0-man' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3069765Z copying path '/nix/store/5vr6jxqx0al48cv8ryxr003f4f4f1h65-kubectl-1.30.1-man' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3079335Z copying path '/nix/store/dzsby2vk02jcn0s43fkna2qqqix6ccy1-iana-etc-20240318' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3080827Z copying path '/nix/store/zzabmhclvdspa62fz40y08lnfx1n4b2c-iana-etc-20240318' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3082774Z copying path '/nix/store/33flg1kzjqn426gg4yfz1zkgpj9cmc4j-jq-1.7.1' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3083631Z copying path '/nix/store/5cq70lcqc2aph4q03brijk3alfh5rnmz-jq-1.7.1-doc' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3085399Z copying path '/nix/store/zk9ybjjixdwyv3jmpg2i7s8p7iqi5vhh-mailcap-2.1.53' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3086829Z copying path '/nix/store/3zrkasqf3sqr9ff6sv5fddhlbf072a36-mailcap-2.1.54' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3088181Z copying path '/nix/store/897xqnq52vw76991r5m80h9j91370vj9-tzdata-2024a' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3089583Z copying path '/nix/store/y6hmqbmbwq0rmx1fzix5c5jszla2pzmp-tzdata-2024a' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3091368Z copying path '/nix/store/0rxb3ixzk4zaqivc9s795m0a3679wbw2-gcc-13.2.0-libgcc' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3096126Z copying path '/nix/store/vf553z7mi2vqk8ca6kkfd9x5gy3nnz0p-libunistring-1.1' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3099942Z copying path '/nix/store/1q9vc0lq7qjlfjz47mfmlzdf86c543jy-xgcc-13.2.0-libgcc' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3101463Z copying path '/nix/store/bihw7p4zdqwyxmnc8h67c06lnjkvdan8-xgcc-13.3.0-libgcc' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3102823Z copying path '/nix/store/dffyikn59cy7fff2qd60gs9jl63szqnh-xgcc-13.3.0-libgcc' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3356470Z copying path '/nix/store/8ckxc8biqqfdwyhr0w70jgrcb4h7a4y5-libunistring-0.9.10' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3367453Z copying path '/nix/store/s3lvxqjqlw3fbg29ys7mk36kg0ivx4h2-iana-etc-20211124' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3368912Z copying path '/nix/store/yfp7dr8m7zi7kxk49wd714gwvhb105hf-libunistring-1.1' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3375525Z copying path '/nix/store/560z0zfybsjb8m76n67x6c1k7gpm080w-libunistring-1.2' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3377390Z copying path '/nix/store/lw2macnzp3av47m41qv6vcnq2daibgl1-libunistring-1.2' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3404150Z copying path '/nix/store/qd3g8rk5hx5zkb70idjh6fa12sh6bipg-mailcap-2.1.53' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3406637Z copying path '/nix/store/hym0wsdlccbvf30gp5ww7cg1pwfljy38-tzdata-2021e' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3413524Z copying path '/nix/store/x45xiwvk2v97bw1yp1vb6rnmvhagpgyz-xgcc-13.3.0-libgcc' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3683008Z copying path '/nix/store/pq755f1pxaas9q7666wzdzxidcvf9frg-libidn2-2.3.7' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3719370Z copying path '/nix/store/w2id1hwv4vv7hvp4slgsyrydrjbfqdxc-libidn2-2.3.2' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3776151Z copying path '/nix/store/8hq38sx1hjgganlj6dn0fvvba0g7gcpi-libidn2-2.3.7' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3898227Z copying path '/nix/store/70x99mlxawd915q5nfj4swxjjnjw1ahy-libidn2-2.3.7' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3900151Z copying path '/nix/store/ic63ay0py10fyryaw7345k4ps32da33w-libidn2-2.3.7' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3902796Z copying path '/nix/store/4s21k8k7p1mfik0b33r2spq5hq7774k1-glibc-2.33-108' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.3907463Z copying path '/nix/store/m71p7f0nymb19yn1dascklyya2i96jfw-glibc-2.39-52' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.4011443Z copying path '/nix/store/3dyw8dzj9ab4m8hv5dpyx7zii8d0w6fi-glibc-2.39-52' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.4530217Z copying path '/nix/store/0wydilnf1c9vznywsvxqnaing4wraaxp-glibc-2.39-52' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.4531728Z copying path '/nix/store/k7zgvzp2r31zkg9xqgjim7mbknryv6bs-glibc-2.39-52' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.4763736Z copying path '/nix/store/8jfd15711zjz6d7lib09j40arfn24z7z-envsubst-1.4.2' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.4765288Z copying path '/nix/store/05k95p72niq1gh39gv1g9n0ivsgl4hiy-kubectl-1.30.1' from 'https://cache.nixos.org'...
+2025-10-07T09:43:39.4766702Z copying path '/nix/store/8if8dwbvyalf0cfk0vkaysvcmkva9syh-kind-0.23.0' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.0844795Z copying path '/nix/store/jv2p6cmx23ihj5y4r98wnn2nmv4qhfh5-openssl-3.0.14' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.0847829Z copying path '/nix/store/pn90mx43spz33pb2l2s8yz19j4hqi648-pcre-8.45' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.0849353Z copying path '/nix/store/g5dj80arfsy8lvkda22dgkcqmyqa126w-util-linux-minimal-2.39.4-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.0850854Z copying path '/nix/store/rc18a8k50zmrif61250sfidkqvlg41ln-zlib-1.3.1' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.0860704Z copying path '/nix/store/izpf49b74i15pcr9708s3xdwyqs4jxwl-bash-5.2p32' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.0887885Z copying path '/nix/store/9igigiz42g7w2i605dd5k1spxy9nkf48-attr-2.5.1' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.0889045Z copying path '/nix/store/4nmqxajzaf60yjribkgvj5j54x9yvr1r-bash-5.1-p12' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.1065816Z copying path '/nix/store/1xjldbdb814annhpmcwz7h6z6y3lay15-acl-2.3.1' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.1497811Z copying path '/nix/store/dj89pwrdlycn8iyn08v8znmynjz1zsi9-coreutils-9.0' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.1620103Z copying path '/nix/store/mi0ybwsm6pmxzv9hsm6bcbqaq1pkf8wh-go-1.23.1' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.1691378Z copying path '/nix/store/9zsm74npdqq2lgjzavlzaqrz8x44mq9d-gnused-4.9' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.1709868Z copying path '/nix/store/jzfqlxwln31ck2gx168yd12gizwsd0pr-cmctl-1.14.5' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.1711495Z copying path '/nix/store/xvzz97yk73hw03v5dhhz3j47ggwf1yq1-gcc-13.2.0-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.1714026Z copying path '/nix/store/dr124zy69xxahw9iycvbbf1ss8jxh7m7-kustomize-5.4.2' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.1715713Z copying path '/nix/store/0kzywrdb93bs60whav8cdwi3q5k1ybvi-fluxcd-2.3.0' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.1717180Z copying path '/nix/store/lr87j4wljn94dfc41dpdkq32wggaw5hz-kuttl-0.16.0' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.1718672Z copying path '/nix/store/l7mj5f6n6x69yixv7j7wazjq15y1mvki-oniguruma-6.9.9-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.1746247Z copying path '/nix/store/flq1szdy6pvm50f348ik03x8058kf0b6-gh-2.50.0' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.1748989Z copying path '/nix/store/vi97ix6hlnkwsigic4pg8pmcairlh6my-ko-0.15.4' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.2028065Z copying path '/nix/store/4i0gfyhwf63ycz5j489mgkh2nlinnvfi-perl-5.34.0' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.2635200Z copying path '/nix/store/8zz13nkg17nx2z4z08vwrihp7ni5kgzn-wget-1.24.5' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.2746498Z copying path '/nix/store/bjf63mfkn3r6svmb4qlsy1v8bff4dwa9-jq-1.7.1-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.4644985Z copying path '/nix/store/7y2nxi5svi3ya06jyfw7l06rxvfb1zzf-jq-1.7.1-bin' from 'https://cache.nixos.org'...
+2025-10-07T09:43:40.4931405Z copying path '/nix/store/y5ss3x2g7s1mj416dfa069s4svwk4h9f-just-1.28.0' from 'https://cache.nixos.org'...
+2025-10-07T09:43:41.5191685Z copying path '/nix/store/a2m476dmim68g082fcia3wrbrzhhfgmv-go-1.17.7' from 'https://cache.nixos.org'...
+2025-10-07T09:43:41.8128182Z warning: download buffer is full; consider increasing the 'download-buffer-size' setting
+2025-10-07T09:43:46.3059777Z copying path '/nix/store/6fs2waydlsszzamlmf533zxivd28szy2-gotools-unstable-2021-01-13' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.1769374Z Packages installed!
+2025-10-07T09:44:21.1893835Z ##[group]Run devbox run gh auth setup-git
+2025-10-07T09:44:21.1894572Z [36;1mdevbox run gh auth setup-git[0m
+2025-10-07T09:44:21.1912405Z shell: /usr/bin/bash -e {0}
+2025-10-07T09:44:21.1912772Z env:
+2025-10-07T09:44:21.1913188Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:44:21.1913649Z   KOCACHE: ~/ko
+2025-10-07T09:44:21.1914098Z   GH_TOKEN: ***
+2025-10-07T09:44:21.1914430Z   TMPDIR: /runner/_work/_temp
+2025-10-07T09:44:21.1914892Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+2025-10-07T09:44:21.1915406Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+2025-10-07T09:44:21.1915812Z   latest_version: 0.16.0
+2025-10-07T09:44:21.1916137Z   nix_version: 2.31.2
+2025-10-07T09:44:21.1916448Z ##[endgroup]
+2025-10-07T09:44:21.2299739Z Info: Running script "gh" on /runner/_work/kommander/kommander
+2025-10-07T09:44:21.2316770Z Info: Ensuring packages are installed.
+2025-10-07T09:44:21.3541251Z Info: Installing the following packages to the nix store: fluxcd@latest, gitlint@latest, kubectl@latest, kubernetes-helm@latest, yamllint@latest, yq@latest, git@latest, github-cli@latest, go@1.24, goreleaser@latest, pre-commit@latest, python312Packages.pre-commit-hooks@latest, yamale@latest
+2025-10-07T09:44:21.5794461Z these 216 paths will be fetched (377.71 MiB download, 1504.50 MiB unpacked):
+2025-10-07T09:44:21.5795455Z   /nix/store/z2h58nbh0xpz0h16lkmpiq8lgx464h0d-acl-2.3.2
+2025-10-07T09:44:21.5796251Z   /nix/store/hyn78kcvg9bggc39ldaihynfib06s9kx-attr-2.5.2
+2025-10-07T09:44:21.5797008Z   /nix/store/m101dg80ngyjdb02g6jwy80sr7kzj26g-bash-5.2p26
+2025-10-07T09:44:21.5797784Z   /nix/store/58br4vk3q5akf4g8lx0pqzfhn47k3j8d-bash-5.2p37
+2025-10-07T09:44:21.5798526Z   /nix/store/ki4if6b0w5bqv8dc5lrjp8xm7wjy9dlf-bash-5.2p37
+2025-10-07T09:44:21.5799239Z   /nix/store/xg75pc4yyfd5n2fimhb98ps910q5lm5n-bash-5.2p37
+2025-10-07T09:44:21.5799982Z   /nix/store/xy4jjgw87sbgwylm5kn047d9gkbhsr9x-bash-5.2p37
+2025-10-07T09:44:21.5800791Z   /nix/store/db139dpnchza6i3mw1nhscwh6vap9n1j-brotli-1.1.0-lib
+2025-10-07T09:44:21.5801588Z   /nix/store/fkrsaskxaa3jlxih84w5c7kward5gdkl-bzip2-1.0.8
+2025-10-07T09:44:21.5802906Z   /nix/store/mq1680dppidpggmaqaklwapvgm6iw3a6-bzip2-1.0.8
+2025-10-07T09:44:21.5803680Z   /nix/store/ms1f510rp2z7afhq7jr81691x6456py9-bzip2-1.0.8
+2025-10-07T09:44:21.5804460Z   /nix/store/r2cw2amwdjwdfcdrvfbq1cj4ryi6yfs5-bzip2-1.0.8
+2025-10-07T09:44:21.5805288Z   /nix/store/dhv5gh89him9a7ddr56cqg87zfkmjihp-coreutils-9.5
+2025-10-07T09:44:21.5806111Z   /nix/store/nbnlwb2crbbg9kwchflrwap6w7icf3ah-curl-8.8.0
+2025-10-07T09:44:21.5806900Z   /nix/store/fl463h2qx89fsqbldjglz9f487xygj48-expat-2.6.2
+2025-10-07T09:44:21.5807689Z   /nix/store/a3nihpi9j1s1yf9ina2qiajwdn70gr75-expat-2.6.4
+2025-10-07T09:44:21.5808493Z   /nix/store/spb4xrswkigavjyhri271xqfzhazxgar-expat-2.6.4
+2025-10-07T09:44:21.5809247Z   /nix/store/5ym85sliy2jc5by8c4rrvr402448kmxv-expat-2.7.1
+2025-10-07T09:44:21.5809896Z   /nix/store/yk2xip9sajrrvymmacmmxw38m6p4kl25-fluxcd-2.4.0
+2025-10-07T09:44:21.5810669Z   /nix/store/c6r62m84hywf4i6qq1h28f13zv38yqyp-gcc-13.3.0-lib
+2025-10-07T09:44:21.5811197Z   /nix/store/7gzzk927as120sja4mwqcn28jv08q6s6-gcc-13.3.0-libgcc
+2025-10-07T09:44:21.5811732Z   /nix/store/6kbrc4ca98srlfpgyaayl2q9zpg1gys6-gcc-14-20241116-lib
+2025-10-07T09:44:21.5812588Z   /nix/store/ik84lbv5jvjm1xxvdl8mhg52ry3xycvm-gcc-14-20241116-lib
+2025-10-07T09:44:21.5813141Z   /nix/store/2kgif7n5hi16qhkrnjnv5swnq9aq3qhj-gcc-14-20241116-libgcc
+2025-10-07T09:44:21.5813684Z   /nix/store/id29wx2vp10d5xi6wzsykd4rb9ssaikx-gcc-14-20241116-libgcc
+2025-10-07T09:44:21.5814243Z   /nix/store/gv7z0km39q3fgzavpic8vrl7smh5n2w6-gcc-14.2.1.20250322-lib
+2025-10-07T09:44:21.5815186Z   /nix/store/0x600292yi5qzg389nan9j4dvzlh8785-gcc-14.2.1.20250322-libgcc
+2025-10-07T09:44:21.5816055Z   /nix/store/jlpymxmsa3yw0p9sin0jym7ldv09h7hs-gdbm-1.23
+2025-10-07T09:44:21.5816818Z   /nix/store/323746wbdf2yzp4nhfb7n3dzwkn25sm0-gdbm-1.24-lib
+2025-10-07T09:44:21.5817358Z   /nix/store/3l0ghb5nqlvrf83wsf2cxwn1my9xnwxv-gdbm-1.24-lib
+2025-10-07T09:44:21.5818144Z   /nix/store/gqb27wwd1lnb85hhs3sz5pli29bmkvwc-gdbm-1.25-lib
+2025-10-07T09:44:21.5818917Z   /nix/store/kpicyzzxir2hr4j4ng94wywlsraz4k8p-gettext-0.21.1
+2025-10-07T09:44:21.5819463Z   /nix/store/asx7ishza3n6lffbzs4m7101ggsmd205-gh-2.23.0
+2025-10-07T09:44:21.5819946Z   /nix/store/ln3rnyn8yklr8j21a9i6s0s501lhdii6-git-2.45.2
+2025-10-07T09:44:21.5820734Z   /nix/store/iw4nz88jqklmjz5wr8dzxwdlswhr2rgi-git-2.45.2-doc
+2025-10-07T09:44:21.5821416Z   /nix/store/4m5lmdz2h0a1w9npkrv43fkngihnqc2b-gitlint-0.19.1
+2025-10-07T09:44:21.5821924Z   /nix/store/lqz6hmd86viw83f9qll2ip87jhb7p1ah-glibc-2.35-224
+2025-10-07T09:44:21.5822623Z   /nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36
+2025-10-07T09:44:21.5823379Z   /nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66
+2025-10-07T09:44:21.5824034Z   /nix/store/cmpyglinc9xl9pr4ymx8akl286ygl64x-glibc-2.40-66
+2025-10-07T09:44:21.5824578Z   /nix/store/g3s0z9r7m1lsfxdk8bj88nw8k8q3dmmg-glibc-2.40-66
+2025-10-07T09:44:21.5825107Z   /nix/store/rmy663w9p7xb202rcln4jjzmvivznmz8-glibc-2.40-66
+2025-10-07T09:44:21.5825623Z   /nix/store/knxxpiihqyi01k1dayl988wymihdp0fn-gmp-with-cxx-6.3.0
+2025-10-07T09:44:21.5826171Z   /nix/store/mdiqq9b2rvv7fajlmg3f7d6r6g78l547-gnugrep-3.11
+2025-10-07T09:44:21.5826700Z   /nix/store/cdhx572ij0pvn9ayd33lk8118137j6m8-gnused-4.9
+2025-10-07T09:44:21.5827152Z   /nix/store/5xvi25nqmbrg58aixp4zgczilfnp7pwg-go-1.24.3
+2025-10-07T09:44:21.5827710Z   /nix/store/iibmw8lki8rf2kanzpg6c6n9llfq1737-goreleaser-2.9.0
+2025-10-07T09:44:21.5828383Z   /nix/store/aw1kk0gvw7j4vmjxhha2fj2jfsvgrd1p-gzip-1.13
+2025-10-07T09:44:21.5828882Z   /nix/store/nl44nfqyyc7d5bw58v8g5ac2wcvmfp98-iana-etc-20221107
+2025-10-07T09:44:21.5829400Z   /nix/store/nnc2zba1j8ij62csbdkz7w3q04qfh1pj-iana-etc-20240318
+2025-10-07T09:44:21.5830087Z   /nix/store/j4gc8fk7wazgn2hqnh0m8b12xx6m1n75-iana-etc-20250108
+2025-10-07T09:44:21.5830706Z   /nix/store/z2prz17656knc97bxfsp1aq961lshvla-iana-etc-20250108
+2025-10-07T09:44:21.5831468Z   /nix/store/d7mhlprb84m83vm0z1xw18jpxz3x5hzy-jq-1.7.1
+2025-10-07T09:44:21.5832270Z   /nix/store/2yi7k5ay6xj73rbfqf170gms922rjm2d-jq-1.7.1-bin
+2025-10-07T09:44:21.5833074Z   /nix/store/xpdllxp63rgicy6mmi8gl9fsw3m0p1kq-keyutils-1.6.3-lib
+2025-10-07T09:44:21.5833653Z   /nix/store/9rn354l23mr9kh840kn94c3p9bns4wd4-kubectl-1.33.0
+2025-10-07T09:44:21.5834475Z   /nix/store/sakg9rw3pdg0d0pbpjizvy8vcyydqxrc-kubectl-1.33.0-man
+2025-10-07T09:44:21.5835235Z   /nix/store/q55vhgsdzdp5spag22g7i0cn00knb4ki-kubernetes-helm-3.17.3
+2025-10-07T09:44:21.5835958Z   /nix/store/ixvjg40bxg59mmzjjgs6f2nf2hbal1y4-libffi-3.4.6
+2025-10-07T09:44:21.5836658Z   /nix/store/k9hqqrqws9jsvl1ip8890nrsgavn3kyb-libffi-3.4.6
+2025-10-07T09:44:21.5837138Z   /nix/store/q085zx93v7krdw8c92mbwvfhwypck9g9-libffi-3.4.6
+2025-10-07T09:44:21.5837820Z   /nix/store/paqdsvmj4fwhc2w6rr884c3kymxl69k0-libffi-3.4.8
+2025-10-07T09:44:21.5838543Z   /nix/store/na1irnycfp8z5mab0g5jvrnhnscsaqsb-libidn2-2.3.2
+2025-10-07T09:44:21.5839329Z   /nix/store/9hscch9v5bx4nd4p4z8ik45g05kajql8-libidn2-2.3.7
+2025-10-07T09:44:21.5839853Z   /nix/store/ii1fdbyzymw9vj2ywxrmz34wbnlg4fb6-libidn2-2.3.7
+2025-10-07T09:44:21.5840529Z   /nix/store/y2xxdhhjy2l5mgpm3d0rw2wxmpd61my4-libidn2-2.3.7
+2025-10-07T09:44:21.5841299Z   /nix/store/6nkqdqzpa75514lhglgnjs5k4dklw4sb-libidn2-2.3.8
+2025-10-07T09:44:21.5841963Z   /nix/store/y0ii7yfaxi2k2vnfyknb64rcczsdyjkf-libidn2-2.3.8
+2025-10-07T09:44:21.5842907Z   /nix/store/qwirfr2adh1173hyw34vjygnma4w8azd-libkrb5-1.21.2
+2025-10-07T09:44:21.5843574Z   /nix/store/0n2d54ql7fw485p1181sz6v6j287p4fq-libpsl-0.21.5
+2025-10-07T09:44:21.5844312Z   /nix/store/qpxn8irb7gdlnmm846q27mwva9h99lci-libssh2-1.11.0
+2025-10-07T09:44:21.5845151Z   /nix/store/jdjpni8kq3i95dj1d49nlf9m10wl0kqq-libunistring-1.0
+2025-10-07T09:44:21.5846007Z   /nix/store/34ypj5kl3jgbdj22fc5299zk3kw51hzi-libunistring-1.3
+2025-10-07T09:44:21.5846839Z   /nix/store/nj19yxkqf0iqjqn4x6dbglsvqk5bgsbs-libunistring-1.3
+2025-10-07T09:44:21.5847573Z   /nix/store/vzdd455zm255kx85hg1cvci3bbn8adwj-libunistring-1.3
+2025-10-07T09:44:21.5848323Z   /nix/store/w522qnwdxzy6hhg723yzlds8xgiw4qqp-libunistring-1.3
+2025-10-07T09:44:21.5848853Z   /nix/store/yypqcvqhnv8y4zpicgxdigp3giq81gzb-libunistring-1.3
+2025-10-07T09:44:21.5849396Z   /nix/store/533ikgdlff50xfypjnafb750kql0wsyn-libxcrypt-4.4.36
+2025-10-07T09:44:21.5849908Z   /nix/store/8q0sgpqv4km05yfxw00silpvbizjbqdj-libxcrypt-4.4.38
+2025-10-07T09:44:21.5850416Z   /nix/store/h8wi6kwl1cywxr3f22836vgrrb11fvlb-libxcrypt-4.4.38
+2025-10-07T09:44:21.5850914Z   /nix/store/ll9dm3r87v4r46a0km0zck4968m60vys-libxcrypt-4.4.38
+2025-10-07T09:44:21.5851420Z   /nix/store/8paaarxd0v13p4007xzp275c1yd1h5xs-libyaml-0.2.5
+2025-10-07T09:44:21.5851929Z   /nix/store/a28v2wclwmaymykakvbzfgzsxrqp4jij-libyaml-0.2.5
+2025-10-07T09:44:21.5852915Z   /nix/store/ijfqv8wkbpn1k056p522ii0cxrrkrgfl-libyaml-0.2.5
+2025-10-07T09:44:21.5853415Z   /nix/store/hkysrcal4q61a9hd905pc8nw72zb3m6g-mailcap-2.1.53
+2025-10-07T09:44:21.5853910Z   /nix/store/ih35ndii8g86q4hlr2f1ma0z14ga4d0r-mailcap-2.1.53
+2025-10-07T09:44:21.5854394Z   /nix/store/1jj2lq1kzys105rqq5n1a2r4v59arz43-mailcap-2.1.54
+2025-10-07T09:44:21.5854894Z   /nix/store/3cd6mykxz9s07v786aq7nxp1aipmnz67-mailcap-2.1.54
+2025-10-07T09:44:21.5855399Z   /nix/store/4bi57kqfj94ln0fa5gqdkhs7a66rxgza-mailcap-2.1.54
+2025-10-07T09:44:21.5855896Z   /nix/store/ci6lysmni722fq1gjhhddyy4pynfqwc1-mailcap-2.1.54
+2025-10-07T09:44:21.5856390Z   /nix/store/qrbqwxws5c0l889asky9m5rwqs5rb1zy-mailcap-2.1.54
+2025-10-07T09:44:21.5856885Z   /nix/store/2af51irxs1ilijingdad4hjhaigyh83c-mpdecimal-4.0.0
+2025-10-07T09:44:21.5857409Z   /nix/store/amllxsxa2mqj373qm6r6dcrfqlasmh4q-mpdecimal-4.0.0
+2025-10-07T09:44:21.5857923Z   /nix/store/p4s6y3knq29v71l1gv9mni8wdc3qp3a8-mpdecimal-4.0.0
+2025-10-07T09:44:21.5858417Z   /nix/store/v2qf70paiw2r2v3hm09xmsjx4a8as54d-mpdecimal-4.0.0
+2025-10-07T09:44:21.5858938Z   /nix/store/a1370wggay4293caa9z82dc5dazmyg5a-ncurses-6.4.20221231
+2025-10-07T09:44:21.5859452Z   /nix/store/80l1sb3vcmrkcdd7ihlizkcnv19rq9fj-ncurses-6.5
+2025-10-07T09:44:21.5859924Z   /nix/store/jfnx02k29ca8cyk32fqv3q6842h0v93j-ncurses-6.5
+2025-10-07T09:44:21.5860390Z   /nix/store/lw6xycmxbi4d1qgjb5bbys1fi3b8fsrq-ncurses-6.5
+2025-10-07T09:44:21.5860895Z   /nix/store/ljcl4myy1yb9c8a5gsflpid473c2vdqy-nghttp2-1.61.0-lib
+2025-10-07T09:44:21.5861730Z   /nix/store/bhk5aa1c5nvir74vwlxrqci6g5iznw76-oniguruma-6.9.10-lib
+2025-10-07T09:44:21.5862467Z   /nix/store/954l60hahqvr0hbs7ww6lmgkxvk8akdf-openssl-3.4.1
+2025-10-07T09:44:21.5862959Z   /nix/store/99cizfcv53x3mjb15cx7kmdxsglp17hc-openssl-3.4.1
+2025-10-07T09:44:21.5863439Z   /nix/store/xy8x4g472i5n1bh24c5ixhbnk6qlm9vz-openssl-3.4.1
+2025-10-07T09:44:21.5863912Z   /nix/store/nm8yrdm0g59yff79qsm1xmk20xl0vg7w-pcre2-10.44
+2025-10-07T09:44:21.5864377Z   /nix/store/jdyb7l90301ri8zcipdapc0dhsfq0qli-perl-5.38.2
+2025-10-07T09:44:21.5864914Z   /nix/store/yshryy5iwkc951z8l85fs3p3zifwwfpl-perl5.38.2-Authen-SASL-2.1700
+2025-10-07T09:44:21.5865502Z   /nix/store/y60as6ni1la05d22nq6im7wsrvmfzycn-perl5.38.2-CGI-4.59
+2025-10-07T09:44:21.5866067Z   /nix/store/62m7hjr7jhjs636s2sfl39jfwf52pm6d-perl5.38.2-CGI-Fast-2.16
+2025-10-07T09:44:21.5866635Z   /nix/store/rn56npzqnnhrwx1vkc3h0gjmsr68g28s-perl5.38.2-Clone-0.46
+2025-10-07T09:44:21.5867242Z   /nix/store/xwa7ic0nzpcj4l0qbi20z1srg9wml9yp-perl5.38.2-Digest-HMAC-1.04
+2025-10-07T09:44:21.5867854Z   /nix/store/l19pji8ing3x9ibcgps4flfrkkm9da11-perl5.38.2-Encode-Locale-1.05
+2025-10-07T09:44:21.5868431Z   /nix/store/zkby0wqm5rzqbqgqlrhgcrx1avi0y2g6-perl5.38.2-FCGI-0.82
+2025-10-07T09:44:21.5869033Z   /nix/store/nsskybgcskd7a0x75qw886cnhgp4c8qi-perl5.38.2-FCGI-ProcManager-0.28
+2025-10-07T09:44:21.5869671Z   /nix/store/cn7kyqqnbcd6qqccqv8zxhqlbb18q0b6-perl5.38.2-File-Listing-6.16
+2025-10-07T09:44:21.5870289Z   /nix/store/zzpkik96anzgbk91lyivnf0vgiziiq5g-perl5.38.2-HTML-Parser-3.81
+2025-10-07T09:44:21.5870902Z   /nix/store/chxp8cv63dh861fbcsvl2xrmglss4wgj-perl5.38.2-HTML-TagCloud-0.38
+2025-10-07T09:44:21.5871501Z   /nix/store/r8z84w8mijgwn8qqjyn18xlsch2n9mhp-perl5.38.2-HTML-Tagset-3.20
+2025-10-07T09:44:21.5872318Z   /nix/store/s7c39p2lf1kmff5y56b5r8mgs2qx2bqn-perl5.38.2-HTTP-CookieJar-0.014
+2025-10-07T09:44:21.5873080Z   /nix/store/6hmz0h9hdwafw01nb4w5d30gl7qk462j-perl5.38.2-HTTP-Cookies-6.10
+2025-10-07T09:44:21.5873693Z   /nix/store/yfx2hxpwqmq2x7fvhi08xbh79fqv8abi-perl5.38.2-HTTP-Daemon-6.16
+2025-10-07T09:44:21.5874276Z   /nix/store/4cdvai8kv7wq0hsiz977g3h4s4zzmmwk-perl5.38.2-HTTP-Date-6.06
+2025-10-07T09:44:21.5874868Z   /nix/store/z988xsl15sl83wvbk3qbx5dg96cjfhxx-perl5.38.2-HTTP-Message-6.45
+2025-10-07T09:44:21.5875465Z   /nix/store/m71wpahp170arh31a29jpvrl6511s35m-perl5.38.2-HTTP-Negotiate-6.01
+2025-10-07T09:44:21.5876050Z   /nix/store/35kp7s183kvb6wfh15j95fhisdwi52nc-perl5.38.2-IO-HTML-1.004
+2025-10-07T09:44:21.5876645Z   /nix/store/skl91jm6gs63xvdr8apjz63kk9yw991p-perl5.38.2-IO-Socket-SSL-2.083
+2025-10-07T09:44:21.5877260Z   /nix/store/bmfb3nkmgsbf7bk8fqz2bga6bfm6hvvf-perl5.38.2-LWP-MediaTypes-6.04
+2025-10-07T09:44:21.5877868Z   /nix/store/fmmq9y0sq0vnk60q0k1gpz9j4da1jvhv-perl5.38.2-Mozilla-CA-20230821
+2025-10-07T09:44:21.5878484Z   /nix/store/l7kka54pclrb3ql0fvx49l9q2r3q88i4-perl5.38.2-Net-HTTP-6.23
+2025-10-07T09:44:21.5879063Z   /nix/store/bpmj9ywwln3m5wh7fmxv1hnrvlp16aw8-perl5.38.2-Net-SMTP-SSL-1.04
+2025-10-07T09:44:21.5879671Z   /nix/store/j7fsiamgakl9470d21p3vdcva1kzqg12-perl5.38.2-Net-SSLeay-1.92
+2025-10-07T09:44:21.5880268Z   /nix/store/cacjjy3li61rcv9gzqgwf7fdqlla2jm7-perl5.38.2-TermReadKey-2.38
+2025-10-07T09:44:21.5880851Z   /nix/store/5qfah54wzpc1h8kfyr9pvqgs8ndhrva3-perl5.38.2-Test-Fatal-0.017
+2025-10-07T09:44:21.5881447Z   /nix/store/hy5m8f0kj3ck1wf3h6rjd7hxfjyvn46b-perl5.38.2-Test-Needs-0.002010
+2025-10-07T09:44:21.5882303Z   /nix/store/hqcbhpiiwyxplj7gjmwzxa212wqrmpvv-perl5.38.2-Test-RequiresInternet-0.05
+2025-10-07T09:44:21.5891445Z   /nix/store/zv926j10wpy8szy7swqy1a777l8byxf8-perl5.38.2-TimeDate-2.33
+2025-10-07T09:44:21.5892582Z   /nix/store/n5rawk6qscxa1xhnbskriz0bn11s4zvx-perl5.38.2-Try-Tiny-0.31
+2025-10-07T09:44:21.5893226Z   /nix/store/8rkd7jnxmvhfzzwmizxxcw85jq0ycmkr-perl5.38.2-URI-5.21
+2025-10-07T09:44:21.5893835Z   /nix/store/h1iii7x06j6aqrr47kkw6zwji9m132xd-perl5.38.2-WWW-RobotRules-6.02
+2025-10-07T09:44:21.5894441Z   /nix/store/r8v4j0czcah66xw9sc62aiczybdb0x3a-perl5.38.2-libnet-3.15
+2025-10-07T09:44:21.5895213Z   /nix/store/vlypcas06558rlk67m505j6ki1dq84z8-perl5.38.2-libwww-perl-6.72
+2025-10-07T09:44:21.5895763Z   /nix/store/ym281lpaz32pfn6b2iyh579gkrnp9blh-pre-commit-4.0.1
+2025-10-07T09:44:21.5896413Z   /nix/store/a9cabl8m1ikqf7js02x1rdp31mwfwgbl-publicsuffix-list-0-unstable-2024-01-07
+2025-10-07T09:44:21.5897042Z   /nix/store/15y9cgcb9yi8hl0vzrm6gvf6pkk79snf-pytest-check-hook
+2025-10-07T09:44:21.5897567Z   /nix/store/kjvgj2n3yn70hmjifg6y0bk9m4rf7jba-python3-3.12.10
+2025-10-07T09:44:21.5898077Z   /nix/store/z7xxy35k7620hs6fn6la5fg2lgklv72l-python3-3.12.4
+2025-10-07T09:44:21.5898560Z   /nix/store/f2krmq3iv5nibcvn4rw7nrnrciqprdkh-python3-3.12.9
+2025-10-07T09:44:21.5899049Z   /nix/store/wz0j2zi02rvnjiz37nn28h3gfdq61svz-python3-3.12.9
+2025-10-07T09:44:21.5899595Z   /nix/store/k5bqdfpv3iy2i0gv7dh8i98y6fvc3r7l-python3.12-argcomplete-3.5.3
+2025-10-07T09:44:21.5900181Z   /nix/store/x5wf6l37cjk508x55wdy6siqnim36w7b-python3.12-arrow-1.3.0
+2025-10-07T09:44:21.5900727Z   /nix/store/kcnmlg0qy7k3cfmx1nvbf491r8gfz9ym-python3.12-cffi-1.17.1
+2025-10-07T09:44:21.5901363Z   /nix/store/3spza6zrxiqn5qv7k57syzp99zc48z11-python3.12-cfgv-3.4.0
+2025-10-07T09:44:21.5901913Z   /nix/store/5sv8vflbfs3q0ybspcn0wjy55mzv1app-python3.12-click-8.1.8
+2025-10-07T09:44:21.5902780Z   /nix/store/n33cld2v7s1kq8v4d147z0j5j71wd4l4-python3.12-distlib-0.3.9
+2025-10-07T09:44:21.5903372Z   /nix/store/d5qff3rlh2yg71jmv6vnz1iz84zrvgnd-python3.12-editdistance-s-1.0.0
+2025-10-07T09:44:21.5903996Z   /nix/store/8gdmm3pap7h94l1fbcyxjhynihlw0vwa-python3.12-filelock-3.17.0
+2025-10-07T09:44:21.5904603Z   /nix/store/l7qvgwfkrv251bjj2kixqqzvk5xm779d-python3.12-identify-2.6.9
+2025-10-07T09:44:21.5905200Z   /nix/store/5jzjyrgfzfnk1s4b8idhyxl7hc6nmg15-python3.12-iniconfig-2.0.0
+2025-10-07T09:44:21.5905939Z   /nix/store/3gnji4ajqjyx5s5h103kvc5s0wy31n42-python3.12-nodeenv-1.9.1
+2025-10-07T09:44:21.5906803Z   /nix/store/lg94m18r8lvhmvjjqp3g8ljcqpmniilr-python3.12-packaging-24.2
+2025-10-07T09:44:21.5907410Z   /nix/store/daj2pj0q06b7l2vz0zws8f5lh66br40f-python3.12-pathspec-0.12.1
+2025-10-07T09:44:21.5908006Z   /nix/store/vi3hb8n9xh5088r6csxmwa324hbbxrdf-python3.12-platformdirs-4.3.6
+2025-10-07T09:44:21.5908602Z   /nix/store/7v1n263qhz0mjrbygygd9a21dy3aah73-python3.12-pluggy-1.5.0
+2025-10-07T09:44:21.5909220Z   /nix/store/iflfg66rp1gpp2mimmyfjlr65hxn88xp-python3.12-pre-commit-hooks-5.0.0
+2025-10-07T09:44:21.5909840Z   /nix/store/zx6265n7bl90xfr3c17dzlfc92nfv7li-python3.12-pycparser-2.22
+2025-10-07T09:44:21.5910403Z   /nix/store/aldsnf9wag98sdh21girchlcxw4nj4ip-python3.12-pytest-8.3.5
+2025-10-07T09:44:21.5911046Z   /nix/store/skfyzrjkhlqr7pzz0id6chf7nqnm140i-python3.12-python-dateutil-2.9.0.post0
+2025-10-07T09:44:21.5911675Z   /nix/store/mdldk60mwk0xyck3ipiwjkd9rv4hz4lc-python3.12-pyyaml-6.0.2
+2025-10-07T09:44:21.5912446Z   /nix/store/rjscl1ashhjs346dwmv0i8wfm0lmf360-python3.12-pyyaml-6.0.2
+2025-10-07T09:44:21.5912993Z   /nix/store/smm6sag2w822b34mxs15ff3bp5x9fqqj-python3.12-pyyaml-6.0.2
+2025-10-07T09:44:21.5913561Z   /nix/store/zchpgwiqq5yijckk5pm0k3qrw18zy8xb-python3.12-ruamel-base-1.0.0
+2025-10-07T09:44:21.5914182Z   /nix/store/bfaryaq95y2dpcxv6h2rzxywr3pbb29n-python3.12-ruamel-yaml-0.18.10
+2025-10-07T09:44:21.5914803Z   /nix/store/g36l1f2vvvhdrf0w2fh85ps9dp7fxci3-python3.12-ruamel-yaml-clib-0.2.7
+2025-10-07T09:44:21.5915380Z   /nix/store/cn5339q35gkkj66nn5g5lqqsdkpg2s9p-python3.12-sh-2.2.1
+2025-10-07T09:44:21.5915933Z   /nix/store/4myqaxi85b5rmifk0x2bslzxqj642krd-python3.12-six-1.17.0
+2025-10-07T09:44:21.5916488Z   /nix/store/15dhhbhmq9ci2v0981yrv27czw4jwqzx-python3.12-toml-0.10.2
+2025-10-07T09:44:21.5917056Z   /nix/store/034p5f5m5m6r83sl8pgzs2zlyz3v8rxc-python3.12-tomlkit-0.13.2
+2025-10-07T09:44:21.5917720Z   /nix/store/b64x2d1xr4aiqmsbf8afsdl6118lswhq-python3.12-types-python-dateutil-2.9.0.20241206
+2025-10-07T09:44:21.5918386Z   /nix/store/w0sf0c82jbqjbvi4a384jbl37bzwq8aw-python3.12-ukkonen-1.0.1
+2025-10-07T09:44:21.5918974Z   /nix/store/6v99imr7bd97d2kfl3r8kw3w49247vry-python3.12-virtualenv-20.29.2
+2025-10-07T09:44:21.5919581Z   /nix/store/5z87xszhx5pzn2dkvn6wqh3s0l7l5q8l-python3.12-xmltodict-0.14.2
+2025-10-07T09:44:21.5920290Z   /nix/store/sqdik2zfa3b2ah83pcyqy9iz8wycmg6c-python3.12-yamale-6.0.0
+2025-10-07T09:44:21.5920854Z   /nix/store/gv594vjq46584iacivk8n58vni310bf1-python3.12-yamllint-1.37.0
+2025-10-07T09:44:21.5921408Z   /nix/store/6hi0d9yr13s08s8wgbmv15rf8acm18dy-python3.12-yq-3.4.3
+2025-10-07T09:44:21.5921936Z   /nix/store/zbrzpn46fkhk61c84w7kd65idrj3pxqp-readline-8.2p10
+2025-10-07T09:44:21.5922639Z   /nix/store/7i8g8v65sycv3kqv64i9z5wg89dsafk0-readline-8.2p13
+2025-10-07T09:44:21.5923122Z   /nix/store/j20wsmj4s2yzvrw51r0rfh5gvssw2vhc-readline-8.2p13
+2025-10-07T09:44:21.5923611Z   /nix/store/j8rf4yi0w2w2n4mp01cz7b6xmykcqm30-readline-8.2p13
+2025-10-07T09:44:21.5924102Z   /nix/store/73s9ldg013iipng6pkq3ly4s5b1ys3g8-sqlite-3.45.3
+2025-10-07T09:44:21.5924580Z   /nix/store/dklcsy2jx4g6irxc5pnka0b3g2niq6k2-sqlite-3.48.0
+2025-10-07T09:44:21.5925070Z   /nix/store/kz7q992dqpfcbzi1ic9qdss1k7bcihnj-sqlite-3.48.0
+2025-10-07T09:44:21.5925550Z   /nix/store/nff52xidq9f2qf93x5r5sr8zc8iwwa5j-sqlite-3.48.0
+2025-10-07T09:44:21.5926027Z   /nix/store/66fr4mlfnwym5dw4bx61xs7nb81q58cb-tzdata-2022g
+2025-10-07T09:44:21.5926511Z   /nix/store/k6vxnriwl3ywpmlmvif3zr418j7dwm1n-tzdata-2024a
+2025-10-07T09:44:21.5926986Z   /nix/store/i1lligvkms3cgz8wcb05px5xzlnnpzxb-tzdata-2024b
+2025-10-07T09:44:21.5927455Z   /nix/store/ss40xh9b67bnk6p7q4cqvmdbvb993d8h-tzdata-2025a
+2025-10-07T09:44:21.5928024Z   /nix/store/swcnsg3jzac44md8r2mm73ljgdxycjw9-tzdata-2025a
+2025-10-07T09:44:21.5928507Z   /nix/store/qyihkwbhd70ynz380whj3bsxk1d2lyc4-tzdata-2025b
+2025-10-07T09:44:21.5928979Z   /nix/store/x5w27khq3ypmfr2jf8jmamh2rbmxd2jf-tzdata-2025b
+2025-10-07T09:44:21.5929516Z   /nix/store/3d60537nh7nf44qvlkgy1m3qddb4q8zx-util-linux-minimal-2.40.4-lib
+2025-10-07T09:44:21.5930113Z   /nix/store/bd12z7swxj5kzqw9m1gf99d6v570h0b3-util-linux-minimal-2.40.4-lib
+2025-10-07T09:44:21.5930863Z   /nix/store/g5rqiqfi401f3qww9ybq1svjsap29ki7-util-linux-minimal-2.41-lib
+2025-10-07T09:44:21.5931415Z   /nix/store/5gacdf63qdvhj419snm0kjl2c70iks66-which-2.23
+2025-10-07T09:44:21.5931937Z   /nix/store/4vm6fj41qg4b4m99zlklvcxwfg6jvrja-xgcc-14-20241116-libgcc
+2025-10-07T09:44:21.5932717Z   /nix/store/jnjv6jf8k0qpnqk4bqqziaf89f4l0v0r-xgcc-14-20241116-libgcc
+2025-10-07T09:44:21.5933263Z   /nix/store/m2047a1xwgblgkrnbxz0yilkaqfrbf2b-xgcc-14-20241116-libgcc
+2025-10-07T09:44:21.5933827Z   /nix/store/fdsndp18qa1fk375vcd4vrn00c0p4zpr-xgcc-14.2.1.20250322-libgcc
+2025-10-07T09:44:21.5934403Z   /nix/store/za53jjhjl1xajv3y1zpjvr9mh4w0c1ay-xgcc-14.2.1.20250322-libgcc
+2025-10-07T09:44:21.5934926Z   /nix/store/s5yfqhxzlcpw0ps2vb3gizicvharnd2n-xz-5.6.2
+2025-10-07T09:44:21.5935375Z   /nix/store/5f9d9sh15sk3xw80cbx8m5aiiqn0g3nw-xz-5.6.4
+2025-10-07T09:44:21.5935820Z   /nix/store/qkmlj9xwg316pxsprhq1jldjc3xqvim1-xz-5.6.4
+2025-10-07T09:44:21.5936247Z   /nix/store/hzfjla4v6x1851jh0wakajlqif0jxrgy-xz-5.8.1
+2025-10-07T09:44:21.5936698Z   /nix/store/8dr41ckl7sbv2v5aim3csxzql03z68hk-zlib-1.3.1
+2025-10-07T09:44:21.5937170Z   /nix/store/mn3p4hf44iwkijkwjpbsjs82bwg1xfap-zlib-1.3.1
+2025-10-07T09:44:21.5937646Z   /nix/store/xijpnhg8mg0g4lahwrxdwylpcq7249gc-zlib-1.3.1
+2025-10-07T09:44:21.5938090Z   /nix/store/c8wv624pj273mx39q1qb7ciqvrfm64d0-zstd-1.5.6
+2025-10-07T09:44:21.5938750Z copying path '/nix/store/sakg9rw3pdg0d0pbpjizvy8vcyydqxrc-kubectl-1.33.0-man' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.5950664Z copying path '/nix/store/iw4nz88jqklmjz5wr8dzxwdlswhr2rgi-git-2.45.2-doc' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.5955869Z copying path '/nix/store/nl44nfqyyc7d5bw58v8g5ac2wcvmfp98-iana-etc-20221107' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.5957703Z copying path '/nix/store/nnc2zba1j8ij62csbdkz7w3q04qfh1pj-iana-etc-20240318' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.5959587Z copying path '/nix/store/j4gc8fk7wazgn2hqnh0m8b12xx6m1n75-iana-etc-20250108' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.5961462Z copying path '/nix/store/z2prz17656knc97bxfsp1aq961lshvla-iana-etc-20250108' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.5975949Z copying path '/nix/store/ih35ndii8g86q4hlr2f1ma0z14ga4d0r-mailcap-2.1.53' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.5977411Z copying path '/nix/store/1jj2lq1kzys105rqq5n1a2r4v59arz43-mailcap-2.1.54' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.5978822Z copying path '/nix/store/3cd6mykxz9s07v786aq7nxp1aipmnz67-mailcap-2.1.54' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.5980227Z copying path '/nix/store/4bi57kqfj94ln0fa5gqdkhs7a66rxgza-mailcap-2.1.54' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.5993956Z copying path '/nix/store/xwa7ic0nzpcj4l0qbi20z1srg9wml9yp-perl5.38.2-Digest-HMAC-1.04' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.5995659Z copying path '/nix/store/nsskybgcskd7a0x75qw886cnhgp4c8qi-perl5.38.2-FCGI-ProcManager-0.28' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.5997741Z copying path '/nix/store/chxp8cv63dh861fbcsvl2xrmglss4wgj-perl5.38.2-HTML-TagCloud-0.38' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6014184Z copying path '/nix/store/8rkd7jnxmvhfzzwmizxxcw85jq0ycmkr-perl5.38.2-URI-5.21' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6015730Z copying path '/nix/store/r8v4j0czcah66xw9sc62aiczybdb0x3a-perl5.38.2-libnet-3.15' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6025521Z copying path '/nix/store/66fr4mlfnwym5dw4bx61xs7nb81q58cb-tzdata-2022g' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6242652Z copying path '/nix/store/hyn78kcvg9bggc39ldaihynfib06s9kx-attr-2.5.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6246810Z copying path '/nix/store/m101dg80ngyjdb02g6jwy80sr7kzj26g-bash-5.2p26' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6252198Z copying path '/nix/store/db139dpnchza6i3mw1nhscwh6vap9n1j-brotli-1.1.0-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6266227Z copying path '/nix/store/ms1f510rp2z7afhq7jr81691x6456py9-bzip2-1.0.8' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6275157Z copying path '/nix/store/fl463h2qx89fsqbldjglz9f487xygj48-expat-2.6.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6290766Z copying path '/nix/store/7gzzk927as120sja4mwqcn28jv08q6s6-gcc-13.3.0-libgcc' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6296738Z copying path '/nix/store/2kgif7n5hi16qhkrnjnv5swnq9aq3qhj-gcc-14-20241116-libgcc' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6298410Z copying path '/nix/store/id29wx2vp10d5xi6wzsykd4rb9ssaikx-gcc-14-20241116-libgcc' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6314684Z copying path '/nix/store/jlpymxmsa3yw0p9sin0jym7ldv09h7hs-gdbm-1.23' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6318245Z copying path '/nix/store/0x600292yi5qzg389nan9j4dvzlh8785-gcc-14.2.1.20250322-libgcc' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6320794Z copying path '/nix/store/cdhx572ij0pvn9ayd33lk8118137j6m8-gnused-4.9' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6339795Z copying path '/nix/store/xpdllxp63rgicy6mmi8gl9fsw3m0p1kq-keyutils-1.6.3-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6343883Z copying path '/nix/store/q085zx93v7krdw8c92mbwvfhwypck9g9-libffi-3.4.6' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6371052Z copying path '/nix/store/qpxn8irb7gdlnmm846q27mwva9h99lci-libssh2-1.11.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6471556Z copying path '/nix/store/jdjpni8kq3i95dj1d49nlf9m10wl0kqq-libunistring-1.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6479873Z copying path '/nix/store/34ypj5kl3jgbdj22fc5299zk3kw51hzi-libunistring-1.3' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6501333Z copying path '/nix/store/c6r62m84hywf4i6qq1h28f13zv38yqyp-gcc-13.3.0-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6503418Z copying path '/nix/store/nj19yxkqf0iqjqn4x6dbglsvqk5bgsbs-libunistring-1.3' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6547808Z copying path '/nix/store/vzdd455zm255kx85hg1cvci3bbn8adwj-libunistring-1.3' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6561180Z copying path '/nix/store/w522qnwdxzy6hhg723yzlds8xgiw4qqp-libunistring-1.3' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6572410Z copying path '/nix/store/yypqcvqhnv8y4zpicgxdigp3giq81gzb-libunistring-1.3' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6578123Z copying path '/nix/store/533ikgdlff50xfypjnafb750kql0wsyn-libxcrypt-4.4.36' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6640468Z copying path '/nix/store/hkysrcal4q61a9hd905pc8nw72zb3m6g-mailcap-2.1.53' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6811763Z copying path '/nix/store/ci6lysmni722fq1gjhhddyy4pynfqwc1-mailcap-2.1.54' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6883412Z copying path '/nix/store/qrbqwxws5c0l889asky9m5rwqs5rb1zy-mailcap-2.1.54' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6884950Z copying path '/nix/store/v2qf70paiw2r2v3hm09xmsjx4a8as54d-mpdecimal-4.0.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6920760Z copying path '/nix/store/a1370wggay4293caa9z82dc5dazmyg5a-ncurses-6.4.20221231' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.6922874Z copying path '/nix/store/ljcl4myy1yb9c8a5gsflpid473c2vdqy-nghttp2-1.61.0-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7016216Z copying path '/nix/store/nm8yrdm0g59yff79qsm1xmk20xl0vg7w-pcre2-10.44' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7033824Z copying path '/nix/store/yshryy5iwkc951z8l85fs3p3zifwwfpl-perl5.38.2-Authen-SASL-2.1700' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7037841Z copying path '/nix/store/rn56npzqnnhrwx1vkc3h0gjmsr68g28s-perl5.38.2-Clone-0.46' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7489355Z copying path '/nix/store/aw1kk0gvw7j4vmjxhha2fj2jfsvgrd1p-gzip-1.13' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7491642Z copying path '/nix/store/qwirfr2adh1173hyw34vjygnma4w8azd-libkrb5-1.21.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7507613Z copying path '/nix/store/na1irnycfp8z5mab0g5jvrnhnscsaqsb-libidn2-2.3.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7513562Z copying path '/nix/store/z2h58nbh0xpz0h16lkmpiq8lgx464h0d-acl-2.3.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7518601Z copying path '/nix/store/ii1fdbyzymw9vj2ywxrmz34wbnlg4fb6-libidn2-2.3.7' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7561709Z copying path '/nix/store/y2xxdhhjy2l5mgpm3d0rw2wxmpd61my4-libidn2-2.3.7' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7573853Z copying path '/nix/store/l19pji8ing3x9ibcgps4flfrkkm9da11-perl5.38.2-Encode-Locale-1.05' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7606383Z copying path '/nix/store/y0ii7yfaxi2k2vnfyknb64rcczsdyjkf-libidn2-2.3.8' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7746434Z copying path '/nix/store/zkby0wqm5rzqbqgqlrhgcrx1avi0y2g6-perl5.38.2-FCGI-0.82' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7800230Z copying path '/nix/store/6nkqdqzpa75514lhglgnjs5k4dklw4sb-libidn2-2.3.8' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7837336Z copying path '/nix/store/35kp7s183kvb6wfh15j95fhisdwi52nc-perl5.38.2-IO-HTML-1.004' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7870516Z copying path '/nix/store/9hscch9v5bx4nd4p4z8ik45g05kajql8-libidn2-2.3.7' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7876132Z copying path '/nix/store/bmfb3nkmgsbf7bk8fqz2bga6bfm6hvvf-perl5.38.2-LWP-MediaTypes-6.04' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7886395Z copying path '/nix/store/r8z84w8mijgwn8qqjyn18xlsch2n9mhp-perl5.38.2-HTML-Tagset-3.20' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7937317Z copying path '/nix/store/fmmq9y0sq0vnk60q0k1gpz9j4da1jvhv-perl5.38.2-Mozilla-CA-20230821' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7965655Z copying path '/nix/store/l7kka54pclrb3ql0fvx49l9q2r3q88i4-perl5.38.2-Net-HTTP-6.23' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7967221Z copying path '/nix/store/lqz6hmd86viw83f9qll2ip87jhb7p1ah-glibc-2.35-224' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.7973210Z copying path '/nix/store/mdiqq9b2rvv7fajlmg3f7d6r6g78l547-gnugrep-3.11' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8016548Z copying path '/nix/store/cacjjy3li61rcv9gzqgwf7fdqlla2jm7-perl5.38.2-TermReadKey-2.38' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8023499Z copying path '/nix/store/j7fsiamgakl9470d21p3vdcva1kzqg12-perl5.38.2-Net-SSLeay-1.92' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8457452Z copying path '/nix/store/hy5m8f0kj3ck1wf3h6rjd7hxfjyvn46b-perl5.38.2-Test-Needs-0.002010' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8487869Z copying path '/nix/store/zv926j10wpy8szy7swqy1a777l8byxf8-perl5.38.2-TimeDate-2.33' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8507778Z copying path '/nix/store/hqcbhpiiwyxplj7gjmwzxa212wqrmpvv-perl5.38.2-Test-RequiresInternet-0.05' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8509862Z copying path '/nix/store/n5rawk6qscxa1xhnbskriz0bn11s4zvx-perl5.38.2-Try-Tiny-0.31' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8513030Z copying path '/nix/store/h1iii7x06j6aqrr47kkw6zwji9m132xd-perl5.38.2-WWW-RobotRules-6.02' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8514786Z copying path '/nix/store/a9cabl8m1ikqf7js02x1rdp31mwfwgbl-publicsuffix-list-0-unstable-2024-01-07' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8617275Z copying path '/nix/store/73s9ldg013iipng6pkq3ly4s5b1ys3g8-sqlite-3.45.3' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8618687Z copying path '/nix/store/k6vxnriwl3ywpmlmvif3zr418j7dwm1n-tzdata-2024a' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8658324Z copying path '/nix/store/i1lligvkms3cgz8wcb05px5xzlnnpzxb-tzdata-2024b' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8833369Z copying path '/nix/store/swcnsg3jzac44md8r2mm73ljgdxycjw9-tzdata-2025a' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8835186Z copying path '/nix/store/ss40xh9b67bnk6p7q4cqvmdbvb993d8h-tzdata-2025a' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8854268Z copying path '/nix/store/qyihkwbhd70ynz380whj3bsxk1d2lyc4-tzdata-2025b' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8893419Z copying path '/nix/store/x5w27khq3ypmfr2jf8jmamh2rbmxd2jf-tzdata-2025b' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8947697Z copying path '/nix/store/4vm6fj41qg4b4m99zlklvcxwfg6jvrja-xgcc-14-20241116-libgcc' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8957693Z copying path '/nix/store/5qfah54wzpc1h8kfyr9pvqgs8ndhrva3-perl5.38.2-Test-Fatal-0.017' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8973803Z copying path '/nix/store/jnjv6jf8k0qpnqk4bqqziaf89f4l0v0r-xgcc-14-20241116-libgcc' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.8998403Z copying path '/nix/store/skl91jm6gs63xvdr8apjz63kk9yw991p-perl5.38.2-IO-Socket-SSL-2.083' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.9038453Z copying path '/nix/store/0n2d54ql7fw485p1181sz6v6j287p4fq-libpsl-0.21.5' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.9457432Z copying path '/nix/store/4cdvai8kv7wq0hsiz977g3h4s4zzmmwk-perl5.38.2-HTTP-Date-6.06' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.9503410Z copying path '/nix/store/cmpyglinc9xl9pr4ymx8akl286ygl64x-glibc-2.40-66' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.9504926Z copying path '/nix/store/m2047a1xwgblgkrnbxz0yilkaqfrbf2b-xgcc-14-20241116-libgcc' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.9566357Z copying path '/nix/store/fdsndp18qa1fk375vcd4vrn00c0p4zpr-xgcc-14.2.1.20250322-libgcc' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.9591496Z copying path '/nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.9925199Z copying path '/nix/store/cn7kyqqnbcd6qqccqv8zxhqlbb18q0b6-perl5.38.2-File-Listing-6.16' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.9973278Z copying path '/nix/store/kpicyzzxir2hr4j4ng94wywlsraz4k8p-gettext-0.21.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.9981733Z copying path '/nix/store/rmy663w9p7xb202rcln4jjzmvivznmz8-glibc-2.40-66' from 'https://cache.nixos.org'...
+2025-10-07T09:44:21.9984202Z copying path '/nix/store/g3s0z9r7m1lsfxdk8bj88nw8k8q3dmmg-glibc-2.40-66' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.0052906Z copying path '/nix/store/knxxpiihqyi01k1dayl988wymihdp0fn-gmp-with-cxx-6.3.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.0993163Z copying path '/nix/store/s7c39p2lf1kmff5y56b5r8mgs2qx2bqn-perl5.38.2-HTTP-CookieJar-0.014' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.1517970Z copying path '/nix/store/z988xsl15sl83wvbk3qbx5dg96cjfhxx-perl5.38.2-HTTP-Message-6.45' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.1567176Z copying path '/nix/store/bpmj9ywwln3m5wh7fmxv1hnrvlp16aw8-perl5.38.2-Net-SMTP-SSL-1.04' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.1617288Z copying path '/nix/store/za53jjhjl1xajv3y1zpjvr9mh4w0c1ay-xgcc-14.2.1.20250322-libgcc' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.1944955Z copying path '/nix/store/s5yfqhxzlcpw0ps2vb3gizicvharnd2n-xz-5.6.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.1997365Z copying path '/nix/store/c8wv624pj273mx39q1qb7ciqvrfm64d0-zstd-1.5.6' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.2474181Z copying path '/nix/store/dhv5gh89him9a7ddr56cqg87zfkmjihp-coreutils-9.5' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.2919590Z copying path '/nix/store/zzpkik96anzgbk91lyivnf0vgiziiq5g-perl5.38.2-HTML-Parser-3.81' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.2924218Z copying path '/nix/store/6hmz0h9hdwafw01nb4w5d30gl7qk462j-perl5.38.2-HTTP-Cookies-6.10' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.2927973Z copying path '/nix/store/yfx2hxpwqmq2x7fvhi08xbh79fqv8abi-perl5.38.2-HTTP-Daemon-6.16' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.2965253Z copying path '/nix/store/zbrzpn46fkhk61c84w7kd65idrj3pxqp-readline-8.2p10' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.3043797Z copying path '/nix/store/m71wpahp170arh31a29jpvrl6511s35m-perl5.38.2-HTTP-Negotiate-6.01' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.3448654Z copying path '/nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.3899954Z copying path '/nix/store/y60as6ni1la05d22nq6im7wsrvmfzycn-perl5.38.2-CGI-4.59' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.3995533Z copying path '/nix/store/nbnlwb2crbbg9kwchflrwap6w7icf3ah-curl-8.8.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.3997039Z copying path '/nix/store/jdyb7l90301ri8zcipdapc0dhsfq0qli-perl-5.38.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.4038331Z copying path '/nix/store/z7xxy35k7620hs6fn6la5fg2lgklv72l-python3-3.12.4' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.4458903Z copying path '/nix/store/9rn354l23mr9kh840kn94c3p9bns4wd4-kubectl-1.33.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:22.4549979Z copying path '/nix/store/62m7hjr7jhjs636s2sfl39jfwf52pm6d-perl5.38.2-CGI-Fast-2.16' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0063452Z copying path '/nix/store/asx7ishza3n6lffbzs4m7101ggsmd205-gh-2.23.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0134572Z copying path '/nix/store/6kbrc4ca98srlfpgyaayl2q9zpg1gys6-gcc-14-20241116-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0136471Z copying path '/nix/store/fkrsaskxaa3jlxih84w5c7kward5gdkl-bzip2-1.0.8' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0138143Z copying path '/nix/store/ixvjg40bxg59mmzjjgs6f2nf2hbal1y4-libffi-3.4.6' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0140328Z copying path '/nix/store/h8wi6kwl1cywxr3f22836vgrrb11fvlb-libxcrypt-4.4.38' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0146053Z copying path '/nix/store/a3nihpi9j1s1yf9ina2qiajwdn70gr75-expat-2.6.4' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0151470Z copying path '/nix/store/323746wbdf2yzp4nhfb7n3dzwkn25sm0-gdbm-1.24-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0160648Z copying path '/nix/store/ijfqv8wkbpn1k056p522ii0cxrrkrgfl-libyaml-0.2.5' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0452340Z copying path '/nix/store/ki4if6b0w5bqv8dc5lrjp8xm7wjy9dlf-bash-5.2p37' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0524853Z copying path '/nix/store/amllxsxa2mqj373qm6r6dcrfqlasmh4q-mpdecimal-4.0.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0550445Z copying path '/nix/store/xg75pc4yyfd5n2fimhb98ps910q5lm5n-bash-5.2p37' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0591881Z copying path '/nix/store/lw6xycmxbi4d1qgjb5bbys1fi3b8fsrq-ncurses-6.5' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0786422Z copying path '/nix/store/mq1680dppidpggmaqaklwapvgm6iw3a6-bzip2-1.0.8' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0787900Z copying path '/nix/store/5ym85sliy2jc5by8c4rrvr402448kmxv-expat-2.7.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0952306Z copying path '/nix/store/yk2xip9sajrrvymmacmmxw38m6p4kl25-fluxcd-2.4.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.0954004Z copying path '/nix/store/gv7z0km39q3fgzavpic8vrl7smh5n2w6-gcc-14.2.1.20250322-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.1042231Z copying path '/nix/store/gqb27wwd1lnb85hhs3sz5pli29bmkvwc-gdbm-1.25-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.1081246Z copying path '/nix/store/iibmw8lki8rf2kanzpg6c6n9llfq1737-goreleaser-2.9.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.1471602Z copying path '/nix/store/q55vhgsdzdp5spag22g7i0cn00knb4ki-kubernetes-helm-3.17.3' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.1747462Z copying path '/nix/store/paqdsvmj4fwhc2w6rr884c3kymxl69k0-libffi-3.4.8' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.2955026Z copying path '/nix/store/8paaarxd0v13p4007xzp275c1yd1h5xs-libyaml-0.2.5' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.2993951Z copying path '/nix/store/8q0sgpqv4km05yfxw00silpvbizjbqdj-libxcrypt-4.4.38' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.2997563Z copying path '/nix/store/p4s6y3knq29v71l1gv9mni8wdc3qp3a8-mpdecimal-4.0.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.2999052Z copying path '/nix/store/58br4vk3q5akf4g8lx0pqzfhn47k3j8d-bash-5.2p37' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.3057055Z copying path '/nix/store/r2cw2amwdjwdfcdrvfbq1cj4ryi6yfs5-bzip2-1.0.8' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.4846842Z copying path '/nix/store/spb4xrswkigavjyhri271xqfzhazxgar-expat-2.6.4' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.5267163Z copying path '/nix/store/ik84lbv5jvjm1xxvdl8mhg52ry3xycvm-gcc-14-20241116-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.5316550Z copying path '/nix/store/k9hqqrqws9jsvl1ip8890nrsgavn3kyb-libffi-3.4.6' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.5320217Z copying path '/nix/store/3l0ghb5nqlvrf83wsf2cxwn1my9xnwxv-gdbm-1.24-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.5321747Z copying path '/nix/store/ll9dm3r87v4r46a0km0zck4968m60vys-libxcrypt-4.4.38' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.6169191Z copying path '/nix/store/a28v2wclwmaymykakvbzfgzsxrqp4jij-libyaml-0.2.5' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.6286965Z copying path '/nix/store/80l1sb3vcmrkcdd7ihlizkcnv19rq9fj-ncurses-6.5' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.6298732Z copying path '/nix/store/2af51irxs1ilijingdad4hjhaigyh83c-mpdecimal-4.0.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.6301119Z copying path '/nix/store/jfnx02k29ca8cyk32fqv3q6842h0v93j-ncurses-6.5' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.6352762Z copying path '/nix/store/954l60hahqvr0hbs7ww6lmgkxvk8akdf-openssl-3.4.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.6363899Z copying path '/nix/store/bhk5aa1c5nvir74vwlxrqci6g5iznw76-oniguruma-6.9.10-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.6513700Z copying path '/nix/store/99cizfcv53x3mjb15cx7kmdxsglp17hc-openssl-3.4.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.6823075Z copying path '/nix/store/xy8x4g472i5n1bh24c5ixhbnk6qlm9vz-openssl-3.4.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.7099318Z copying path '/nix/store/5gacdf63qdvhj419snm0kjl2c70iks66-which-2.23' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.7790123Z copying path '/nix/store/xy4jjgw87sbgwylm5kn047d9gkbhsr9x-bash-5.2p37' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.7814708Z copying path '/nix/store/d7mhlprb84m83vm0z1xw18jpxz3x5hzy-jq-1.7.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.8755391Z copying path '/nix/store/5f9d9sh15sk3xw80cbx8m5aiiqn0g3nw-xz-5.6.4' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.9474896Z copying path '/nix/store/2yi7k5ay6xj73rbfqf170gms922rjm2d-jq-1.7.1-bin' from 'https://cache.nixos.org'...
+2025-10-07T09:44:23.9751810Z copying path '/nix/store/5xvi25nqmbrg58aixp4zgczilfnp7pwg-go-1.24.3' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.0754491Z copying path '/nix/store/hzfjla4v6x1851jh0wakajlqif0jxrgy-xz-5.8.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.0758308Z copying path '/nix/store/8dr41ckl7sbv2v5aim3csxzql03z68hk-zlib-1.3.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.0760093Z copying path '/nix/store/qkmlj9xwg316pxsprhq1jldjc3xqvim1-xz-5.6.4' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.1077622Z copying path '/nix/store/7i8g8v65sycv3kqv64i9z5wg89dsafk0-readline-8.2p13' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.1499093Z copying path '/nix/store/nff52xidq9f2qf93x5r5sr8zc8iwwa5j-sqlite-3.48.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.1809051Z copying path '/nix/store/mn3p4hf44iwkijkwjpbsjs82bwg1xfap-zlib-1.3.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.1810524Z copying path '/nix/store/xijpnhg8mg0g4lahwrxdwylpcq7249gc-zlib-1.3.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.2455081Z copying path '/nix/store/kz7q992dqpfcbzi1ic9qdss1k7bcihnj-sqlite-3.48.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.2785063Z copying path '/nix/store/dklcsy2jx4g6irxc5pnka0b3g2niq6k2-sqlite-3.48.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.3858083Z copying path '/nix/store/g5rqiqfi401f3qww9ybq1svjsap29ki7-util-linux-minimal-2.41-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.4964856Z copying path '/nix/store/j8rf4yi0w2w2n4mp01cz7b6xmykcqm30-readline-8.2p13' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.5945091Z copying path '/nix/store/j20wsmj4s2yzvrw51r0rfh5gvssw2vhc-readline-8.2p13' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.5954302Z copying path '/nix/store/bd12z7swxj5kzqw9m1gf99d6v570h0b3-util-linux-minimal-2.40.4-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.6851905Z copying path '/nix/store/3d60537nh7nf44qvlkgy1m3qddb4q8zx-util-linux-minimal-2.40.4-lib' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.7623894Z copying path '/nix/store/kjvgj2n3yn70hmjifg6y0bk9m4rf7jba-python3-3.12.10' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.7928125Z copying path '/nix/store/wz0j2zi02rvnjiz37nn28h3gfdq61svz-python3-3.12.9' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.7996391Z copying path '/nix/store/f2krmq3iv5nibcvn4rw7nrnrciqprdkh-python3-3.12.9' from 'https://cache.nixos.org'...
+2025-10-07T09:44:24.8787418Z copying path '/nix/store/vlypcas06558rlk67m505j6ki1dq84z8-perl5.38.2-libwww-perl-6.72' from 'https://cache.nixos.org'...
+2025-10-07T09:44:26.2976423Z copying path '/nix/store/ln3rnyn8yklr8j21a9i6s0s501lhdii6-git-2.45.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.6991520Z copying path '/nix/store/3spza6zrxiqn5qv7k57syzp99zc48z11-python3.12-cfgv-3.4.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.6993384Z copying path '/nix/store/5sv8vflbfs3q0ybspcn0wjy55mzv1app-python3.12-click-8.1.8' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.6994906Z copying path '/nix/store/n33cld2v7s1kq8v4d147z0j5j71wd4l4-python3.12-distlib-0.3.9' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.6996413Z copying path '/nix/store/8gdmm3pap7h94l1fbcyxjhynihlw0vwa-python3.12-filelock-3.17.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.6998007Z copying path '/nix/store/5jzjyrgfzfnk1s4b8idhyxl7hc6nmg15-python3.12-iniconfig-2.0.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.6999941Z copying path '/nix/store/3gnji4ajqjyx5s5h103kvc5s0wy31n42-python3.12-nodeenv-1.9.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.7001465Z copying path '/nix/store/lg94m18r8lvhmvjjqp3g8ljcqpmniilr-python3.12-packaging-24.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.7003294Z copying path '/nix/store/daj2pj0q06b7l2vz0zws8f5lh66br40f-python3.12-pathspec-0.12.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.7004478Z copying path '/nix/store/vi3hb8n9xh5088r6csxmwa324hbbxrdf-python3.12-platformdirs-4.3.6' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.7005582Z copying path '/nix/store/zx6265n7bl90xfr3c17dzlfc92nfv7li-python3.12-pycparser-2.22' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.7006559Z copying path '/nix/store/smm6sag2w822b34mxs15ff3bp5x9fqqj-python3.12-pyyaml-6.0.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.7007547Z copying path '/nix/store/7v1n263qhz0mjrbygygd9a21dy3aah73-python3.12-pluggy-1.5.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.7129589Z copying path '/nix/store/cn5339q35gkkj66nn5g5lqqsdkpg2s9p-python3.12-sh-2.2.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.7140053Z copying path '/nix/store/4myqaxi85b5rmifk0x2bslzxqj642krd-python3.12-six-1.17.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.7151583Z copying path '/nix/store/15dhhbhmq9ci2v0981yrv27czw4jwqzx-python3.12-toml-0.10.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.7171064Z copying path '/nix/store/b64x2d1xr4aiqmsbf8afsdl6118lswhq-python3.12-types-python-dateutil-2.9.0.20241206' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.7189485Z copying path '/nix/store/w0sf0c82jbqjbvi4a384jbl37bzwq8aw-python3.12-ukkonen-1.0.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.7339106Z copying path '/nix/store/skfyzrjkhlqr7pzz0id6chf7nqnm140i-python3.12-python-dateutil-2.9.0.post0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.7381882Z copying path '/nix/store/aldsnf9wag98sdh21girchlcxw4nj4ip-python3.12-pytest-8.3.5' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.7715310Z copying path '/nix/store/gv594vjq46584iacivk8n58vni310bf1-python3.12-yamllint-1.37.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.7824224Z copying path '/nix/store/6v99imr7bd97d2kfl3r8kw3w49247vry-python3.12-virtualenv-20.29.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.8125958Z copying path '/nix/store/kcnmlg0qy7k3cfmx1nvbf491r8gfz9ym-python3.12-cffi-1.17.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.8168834Z copying path '/nix/store/x5wf6l37cjk508x55wdy6siqnim36w7b-python3.12-arrow-1.3.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.9188918Z copying path '/nix/store/4m5lmdz2h0a1w9npkrv43fkngihnqc2b-gitlint-0.19.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:27.9631849Z copying path '/nix/store/d5qff3rlh2yg71jmv6vnz1iz84zrvgnd-python3.12-editdistance-s-1.0.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:28.0408835Z copying path '/nix/store/mdldk60mwk0xyck3ipiwjkd9rv4hz4lc-python3.12-pyyaml-6.0.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:28.0410389Z copying path '/nix/store/zchpgwiqq5yijckk5pm0k3qrw18zy8xb-python3.12-ruamel-base-1.0.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:28.0411372Z copying path '/nix/store/g36l1f2vvvhdrf0w2fh85ps9dp7fxci3-python3.12-ruamel-yaml-clib-0.2.7' from 'https://cache.nixos.org'...
+2025-10-07T09:44:28.1176039Z copying path '/nix/store/15y9cgcb9yi8hl0vzrm6gvf6pkk79snf-pytest-check-hook' from 'https://cache.nixos.org'...
+2025-10-07T09:44:28.1177674Z copying path '/nix/store/bfaryaq95y2dpcxv6h2rzxywr3pbb29n-python3.12-ruamel-yaml-0.18.10' from 'https://cache.nixos.org'...
+2025-10-07T09:44:28.1273227Z copying path '/nix/store/sqdik2zfa3b2ah83pcyqy9iz8wycmg6c-python3.12-yamale-6.0.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:28.1280970Z copying path '/nix/store/l7qvgwfkrv251bjj2kixqqzvk5xm779d-python3.12-identify-2.6.9' from 'https://cache.nixos.org'...
+2025-10-07T09:44:28.2139327Z copying path '/nix/store/ym281lpaz32pfn6b2iyh579gkrnp9blh-pre-commit-4.0.1' from 'https://cache.nixos.org'...
+2025-10-07T09:44:28.2486874Z copying path '/nix/store/iflfg66rp1gpp2mimmyfjlr65hxn88xp-python3.12-pre-commit-hooks-5.0.0' from 'https://cache.nixos.org'...
+2025-10-07T09:44:28.8935156Z copying path '/nix/store/k5bqdfpv3iy2i0gv7dh8i98y6fvc3r7l-python3.12-argcomplete-3.5.3' from 'https://cache.nixos.org'...
+2025-10-07T09:44:28.8936360Z copying path '/nix/store/rjscl1ashhjs346dwmv0i8wfm0lmf360-python3.12-pyyaml-6.0.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:28.8937551Z copying path '/nix/store/034p5f5m5m6r83sl8pgzs2zlyz3v8rxc-python3.12-tomlkit-0.13.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:28.8938714Z copying path '/nix/store/5z87xszhx5pzn2dkvn6wqh3s0l7l5q8l-python3.12-xmltodict-0.14.2' from 'https://cache.nixos.org'...
+2025-10-07T09:44:28.9739749Z copying path '/nix/store/6hi0d9yr13s08s8wgbmv15rf8acm18dy-python3.12-yq-3.4.3' from 'https://cache.nixos.org'...
+2025-10-07T09:45:00.9868906Z ##[group]Run devbox run just bootstrap-dev-start-kind
+2025-10-07T09:45:00.9869409Z [36;1mdevbox run just bootstrap-dev-start-kind[0m
+2025-10-07T09:45:00.9887160Z shell: /usr/bin/bash -e {0}
+2025-10-07T09:45:00.9887509Z env:
+2025-10-07T09:45:00.9887910Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:45:00.9888618Z   KOCACHE: ~/ko
+2025-10-07T09:45:00.9889297Z   GH_TOKEN: ***
+2025-10-07T09:45:00.9889747Z   TMPDIR: /runner/_work/_temp
+2025-10-07T09:45:00.9890234Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+2025-10-07T09:45:00.9890757Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+2025-10-07T09:45:00.9891173Z   latest_version: 0.16.0
+2025-10-07T09:45:00.9891500Z   nix_version: 2.31.2
+2025-10-07T09:45:00.9891847Z   DOCKER_USERNAME: ***
+2025-10-07T09:45:00.9892495Z   DOCKER_PASSWORD: ***
+2025-10-07T09:45:00.9892818Z ##[endgroup]
+2025-10-07T09:45:01.0289351Z Info: Running script "just" on /runner/_work/kommander/kommander/bootstrapper
+2025-10-07T09:45:01.1322934Z kind delete cluster --name bootstrap-dev
+2025-10-07T09:45:01.1491853Z Deleting cluster "bootstrap-dev" ...
+2025-10-07T09:45:01.5283453Z Creating cluster "bootstrap-dev" ...
+2025-10-07T09:45:01.5284392Z  • Ensuring node image (kindest/node:v1.30.0) 🖼  ...
+2025-10-07T09:45:18.0756269Z  ✓ Ensuring node image (kindest/node:v1.30.0) 🖼
+2025-10-07T09:45:18.0756817Z  • Preparing nodes 📦   ...
+2025-10-07T09:45:26.6719042Z  ✓ Preparing nodes 📦 
+2025-10-07T09:45:26.6992678Z  • Writing configuration 📜  ...
+2025-10-07T09:45:27.1514839Z  ✓ Writing configuration 📜
+2025-10-07T09:45:27.1515348Z  • Starting control-plane 🕹️  ...
+2025-10-07T09:45:37.7650921Z  ✓ Starting control-plane 🕹️
+2025-10-07T09:45:37.7651671Z  • Installing CNI 🔌  ...
+2025-10-07T09:45:38.0417173Z  ✓ Installing CNI 🔌
+2025-10-07T09:45:38.0417647Z  • Installing StorageClass 💾  ...
+2025-10-07T09:45:38.3466947Z  ✓ Installing StorageClass 💾
+2025-10-07T09:45:38.5185520Z Set kubectl context to "kind-bootstrap-dev"
+2025-10-07T09:45:38.5186209Z You can now use your cluster with:
+2025-10-07T09:45:38.5186451Z 
+2025-10-07T09:45:38.5186795Z kubectl cluster-info --context kind-bootstrap-dev
+2025-10-07T09:45:38.5187166Z 
+2025-10-07T09:45:38.5187553Z Have a nice day! 👋
+2025-10-07T09:45:38.6145736Z Warning: resource configmaps/coredns is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T09:45:38.6749677Z configmap/coredns configured
+2025-10-07T09:45:38.7331253Z deployment.apps/coredns restarted
+2025-10-07T09:45:38.7886331Z Waiting for deployment spec update to be observed...
+2025-10-07T09:45:51.2298629Z Waiting for deployment spec update to be observed...
+2025-10-07T09:45:51.2378854Z Waiting for deployment "coredns" rollout to finish: 0 out of 2 new replicas have been updated...
+2025-10-07T09:45:51.5930972Z Waiting for deployment "coredns" rollout to finish: 0 of 2 updated replicas are available...
+2025-10-07T09:45:56.8042732Z Waiting for deployment "coredns" rollout to finish: 1 of 2 updated replicas are available...
+2025-10-07T09:45:56.8104634Z deployment "coredns" successfully rolled out
+2025-10-07T09:45:56.8142873Z kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.5/cert-manager.yaml
+2025-10-07T09:45:57.5116873Z namespace/cert-manager created
+2025-10-07T09:45:57.5209960Z customresourcedefinition.apiextensions.k8s.io/certificaterequests.cert-manager.io created
+2025-10-07T09:45:57.5330853Z customresourcedefinition.apiextensions.k8s.io/certificates.cert-manager.io created
+2025-10-07T09:45:57.5700183Z customresourcedefinition.apiextensions.k8s.io/challenges.acme.cert-manager.io created
+2025-10-07T09:45:57.6094105Z customresourcedefinition.apiextensions.k8s.io/clusterissuers.cert-manager.io created
+2025-10-07T09:45:57.6456271Z customresourcedefinition.apiextensions.k8s.io/issuers.cert-manager.io created
+2025-10-07T09:45:57.6584516Z customresourcedefinition.apiextensions.k8s.io/orders.acme.cert-manager.io created
+2025-10-07T09:45:57.6706163Z serviceaccount/cert-manager-cainjector created
+2025-10-07T09:45:57.6794244Z serviceaccount/cert-manager created
+2025-10-07T09:45:57.6972848Z serviceaccount/cert-manager-webhook created
+2025-10-07T09:45:57.7020106Z clusterrole.rbac.authorization.k8s.io/cert-manager-cainjector created
+2025-10-07T09:45:57.7078412Z clusterrole.rbac.authorization.k8s.io/cert-manager-controller-issuers created
+2025-10-07T09:45:57.7119046Z clusterrole.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers created
+2025-10-07T09:45:57.7217842Z clusterrole.rbac.authorization.k8s.io/cert-manager-controller-certificates created
+2025-10-07T09:45:57.7259957Z clusterrole.rbac.authorization.k8s.io/cert-manager-controller-orders created
+2025-10-07T09:45:57.7319359Z clusterrole.rbac.authorization.k8s.io/cert-manager-controller-challenges created
+2025-10-07T09:45:57.7388138Z clusterrole.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim created
+2025-10-07T09:45:57.7424715Z clusterrole.rbac.authorization.k8s.io/cert-manager-cluster-view created
+2025-10-07T09:45:57.7483960Z clusterrole.rbac.authorization.k8s.io/cert-manager-view created
+2025-10-07T09:45:57.7523059Z clusterrole.rbac.authorization.k8s.io/cert-manager-edit created
+2025-10-07T09:45:57.7667669Z clusterrole.rbac.authorization.k8s.io/cert-manager-controller-approve:cert-manager-io created
+2025-10-07T09:45:57.7728351Z clusterrole.rbac.authorization.k8s.io/cert-manager-controller-certificatesigningrequests created
+2025-10-07T09:45:57.7764805Z clusterrole.rbac.authorization.k8s.io/cert-manager-webhook:subjectaccessreviews created
+2025-10-07T09:45:57.7821365Z clusterrolebinding.rbac.authorization.k8s.io/cert-manager-cainjector created
+2025-10-07T09:45:57.7858176Z clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-issuers created
+2025-10-07T09:45:57.7914686Z clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers created
+2025-10-07T09:45:57.7954207Z clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-certificates created
+2025-10-07T09:45:57.7991937Z clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-orders created
+2025-10-07T09:45:57.8048403Z clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-challenges created
+2025-10-07T09:45:57.8086930Z clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim created
+2025-10-07T09:45:57.8146421Z clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-approve:cert-manager-io created
+2025-10-07T09:45:57.8183839Z clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-certificatesigningrequests created
+2025-10-07T09:45:57.8240141Z clusterrolebinding.rbac.authorization.k8s.io/cert-manager-webhook:subjectaccessreviews created
+2025-10-07T09:45:57.8288320Z role.rbac.authorization.k8s.io/cert-manager-cainjector:leaderelection created
+2025-10-07T09:45:57.8335168Z role.rbac.authorization.k8s.io/cert-manager:leaderelection created
+2025-10-07T09:45:57.8401884Z role.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving created
+2025-10-07T09:45:57.8446350Z rolebinding.rbac.authorization.k8s.io/cert-manager-cainjector:leaderelection created
+2025-10-07T09:45:57.8515176Z rolebinding.rbac.authorization.k8s.io/cert-manager:leaderelection created
+2025-10-07T09:45:57.8564586Z rolebinding.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving created
+2025-10-07T09:45:57.8658162Z service/cert-manager created
+2025-10-07T09:45:57.8795863Z service/cert-manager-webhook created
+2025-10-07T09:45:57.8912961Z deployment.apps/cert-manager-cainjector created
+2025-10-07T09:45:57.9026916Z deployment.apps/cert-manager created
+2025-10-07T09:45:57.9183263Z deployment.apps/cert-manager-webhook created
+2025-10-07T09:45:57.9338636Z mutatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
+2025-10-07T09:45:57.9454758Z validatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
+2025-10-07T09:45:57.9496264Z cmctl check api --wait=2m -v=5 -n cert-manager
+2025-10-07T09:46:00.0112495Z I1007 09:46:00.010919    4835 api.go:116] "Not ready" logger="cert-manager.checkAPI" err="the cert-manager webhook deployment is not ready yet" underlyingError="Internal error occurred: failed calling webhook \"webhook.cert-manager.io\": failed to call webhook: Post \"https://cert-manager-webhook.cert-manager.svc:443/validate?timeout=30s\": dial tcp 10.96.215.74:443: connect: connection refused"
+2025-10-07T09:46:02.9949774Z I1007 09:46:02.994592    4835 api.go:116] "Not ready" logger="cert-manager.checkAPI" err="the cert-manager webhook deployment is not ready yet" underlyingError="Internal error occurred: failed calling webhook \"webhook.cert-manager.io\": failed to call webhook: Post \"https://cert-manager-webhook.cert-manager.svc:443/validate?timeout=30s\": dial tcp 10.96.215.74:443: connect: connection refused"
+2025-10-07T09:46:07.9947961Z I1007 09:46:07.994525    4835 api.go:116] "Not ready" logger="cert-manager.checkAPI" err="the cert-manager webhook deployment is not ready yet" underlyingError="Internal error occurred: failed calling webhook \"webhook.cert-manager.io\": failed to call webhook: Post \"https://cert-manager-webhook.cert-manager.svc:443/validate?timeout=30s\": dial tcp 10.96.215.74:443: connect: connection refused"
+2025-10-07T09:46:13.0034392Z The cert-manager API is ready
+2025-10-07T09:46:13.0242690Z ##[group]Run devbox run just bootstrap-test
+2025-10-07T09:46:13.0243189Z [36;1mdevbox run just bootstrap-test[0m
+2025-10-07T09:46:13.0261452Z shell: /usr/bin/bash -e {0}
+2025-10-07T09:46:13.0262165Z env:
+2025-10-07T09:46:13.0262801Z   GOPRIVATE: github.com/mesosphere,github.com/nutanix-cloud-native
+2025-10-07T09:46:13.0263543Z   KOCACHE: ~/ko
+2025-10-07T09:46:13.0264177Z   GH_TOKEN: ***
+2025-10-07T09:46:13.0264625Z   TMPDIR: /runner/_work/_temp
+2025-10-07T09:46:13.0265253Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+2025-10-07T09:46:13.0265795Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+2025-10-07T09:46:13.0266201Z   latest_version: 0.16.0
+2025-10-07T09:46:13.0266510Z   nix_version: 2.31.2
+2025-10-07T09:46:13.0266832Z ##[endgroup]
+2025-10-07T09:46:13.0689988Z Info: Running script "just" on /runner/_work/kommander/kommander/bootstrapper
+2025-10-07T09:46:13.0992719Z ++ mktemp
+2025-10-07T09:46:13.1005307Z + export KUBECONFIG=/runner/_work/_temp/tmp.A3DPhpFqQ2
+2025-10-07T09:46:13.1005915Z + KUBECONFIG=/runner/_work/_temp/tmp.A3DPhpFqQ2
+2025-10-07T09:46:13.1006692Z + kind get kubeconfig --name bootstrap-dev
+2025-10-07T09:46:13.2625857Z + kubectl kuttl test -v2 --config=/runner/_work/kommander/kommander/bootstrapper/../tests/kuttl-config/kuttl-test-kommander-bootstrap.yaml
+2025-10-07T09:46:13.3178808Z === RUN   kuttl
+2025-10-07T09:46:13.3179426Z     harness.go:465: starting setup
+2025-10-07T09:46:13.3180136Z     harness.go:255: running tests using configured kubeconfig.
+2025-10-07T09:46:13.3255960Z     harness.go:278: Successful connection to cluster at: https://127.0.0.1:38707
+2025-10-07T09:46:13.3263465Z     harness.go:363: running tests
+2025-10-07T09:46:13.3264254Z     harness.go:75: going to run test suite with timeout of 600 seconds for each step
+2025-10-07T09:46:13.3265225Z     harness.go:375: testsuite: ../tests/kuttl-kommander-bootstrap/ has 5 tests
+2025-10-07T09:46:13.3266013Z === RUN   kuttl/harness
+2025-10-07T09:46:13.3266573Z === RUN   kuttl/harness/airgapped
+2025-10-07T09:46:13.3267155Z === PAUSE kuttl/harness/airgapped
+2025-10-07T09:46:13.3267738Z === RUN   kuttl/harness/flux-manifests
+2025-10-07T09:46:13.3268378Z === PAUSE kuttl/harness/flux-manifests
+2025-10-07T09:46:13.3268953Z === RUN   kuttl/harness/ingress
+2025-10-07T09:46:13.3269482Z === PAUSE kuttl/harness/ingress
+2025-10-07T09:46:13.3269997Z === RUN   kuttl/harness/install
+2025-10-07T09:46:13.3270521Z === PAUSE kuttl/harness/install
+2025-10-07T09:46:13.3271056Z === RUN   kuttl/harness/skipcapicluster
+2025-10-07T09:46:13.3271669Z === PAUSE kuttl/harness/skipcapicluster
+2025-10-07T09:46:13.3272389Z === CONT  kuttl/harness/airgapped
+2025-10-07T09:46:13.3286197Z     logger.go:42: 09:46:13 | airgapped | Creating namespace: kuttl-test-exciting-grackle
+2025-10-07T09:46:13.3338018Z     logger.go:42: 09:46:13 | airgapped/0-configure | starting test step 0-configure
+2025-10-07T09:46:13.3401087Z     logger.go:42: 09:46:13 | airgapped/0-configure | ConfigMap:kuttl-test-exciting-grackle/kommander-bootstrap-configuration created
+2025-10-07T09:46:13.3401988Z     logger.go:42: 09:46:13 | airgapped/0-configure | test step completed 0-configure
+2025-10-07T09:46:13.3402891Z     logger.go:42: 09:46:13 | airgapped/1-start | starting test step 1-start
+2025-10-07T09:46:13.3403610Z     logger.go:42: 09:46:13 | airgapped/1-start | running command: [sh -c cd ../../../bootstrapper
+2025-10-07T09:46:13.3404248Z         kubectl create namespace $NAMESPACE-git
+2025-10-07T09:46:13.3404912Z         just bootstrap-deploy $NAMESPACE $NAMESPACE $NAMESPACE $NAMESPACE-git skip-capi-cluster
+2025-10-07T09:46:13.3405451Z         ]
+2025-10-07T09:46:13.3870388Z     logger.go:42: 09:46:13 | airgapped/1-start | namespace/kuttl-test-exciting-grackle-git created
+2025-10-07T09:46:13.4138558Z     logger.go:42: 09:46:13 | airgapped/1-start | flux pull artifact oci://docker.io/mesosphere/git-operator-manifests:v0.13.11 --output /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests
+2025-10-07T09:46:13.4361425Z     logger.go:42: 09:46:13 | airgapped/1-start | ► pulling artifact from docker.io/mesosphere/git-operator-manifests:v0.13.11
+2025-10-07T09:46:14.1108253Z     logger.go:42: 09:46:14 | airgapped/1-start | ✔ source https://github.com/mesosphere/git-operator
+2025-10-07T09:46:14.1109659Z     logger.go:42: 09:46:14 | airgapped/1-start | ✔ revision v0.13.11@sha1:2fe7ec9c9c5c8080452b13388259c0ff949d357a
+2025-10-07T09:46:14.1111449Z     logger.go:42: 09:46:14 | airgapped/1-start | ✔ digest index.docker.io/mesosphere/git-operator-manifests@sha256:d5f2149ec717a4db534d567bd4f774900e9e7d596c652fdc817fb803a2fefd45
+2025-10-07T09:46:14.1113763Z     logger.go:42: 09:46:14 | airgapped/1-start | ✔ artifact content extracted to /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests
+2025-10-07T09:46:14.1138418Z     logger.go:42: 09:46:14 | airgapped/1-start | sed -i -r 's/(image\: docker\.io\/mesosphere\/git-operator\:v[0-9]+\.[0-9]+.[0-9]+)\@sha256\:.*?$/\1/g' /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests/manager/manager.yaml
+2025-10-07T09:46:14.1168187Z     logger.go:42: 09:46:14 | airgapped/1-start | kustomize build manifests/skip-capi-cluster | env KO_DOCKER_REPO=kind.local KIND_CLUSTER_NAME=bootstrap-dev ko resolve -f - | NAMESPACE=kuttl-test-exciting-grackle FLUX_NAMESPACE=kuttl-test-exciting-grackle KOMMANDER_NAMESPACE=kuttl-test-exciting-grackle GIT_OPERATOR_NAMESPACE=kuttl-test-exciting-grackle-git envsubst | kubectl apply -f -
+2025-10-07T09:46:14.5833832Z     logger.go:42: 09:46:14 | airgapped/1-start | 2025/10/07 09:46:14 Using base cgr.dev/chainguard/static:latest@sha256:b2e1c3d3627093e54f6805823e73edd17ab93d6c7202e672988080c863e0412b for github.com/mesosphere/kommander/bootstrapper/cmd
+2025-10-07T09:46:14.8534046Z     logger.go:42: 09:46:14 | airgapped/1-start | 2025/10/07 09:46:14 git doesn't contain any tags. Tag info will not be available
+2025-10-07T09:46:14.8535220Z     logger.go:42: 09:46:14 | airgapped/1-start | git is in a dirty state
+2025-10-07T09:46:14.8536347Z     logger.go:42: 09:46:14 | airgapped/1-start | Please check in your pipeline what can be changing the following files:
+2025-10-07T09:46:14.8537427Z     logger.go:42: 09:46:14 | airgapped/1-start | ?? bootstrapper/internal/fluxmanifests/manifests/mirror/
+2025-10-07T09:46:14.8538495Z     logger.go:42: 09:46:14 | airgapped/1-start | ?? bootstrapper/internal/fluxmanifests/manifests/patch-proxy-env-vars.yaml
+2025-10-07T09:46:14.8539566Z     logger.go:42: 09:46:14 | airgapped/1-start | ?? bootstrapper/internal/fluxmanifests/manifests/templates/
+2025-10-07T09:46:14.8540379Z     logger.go:42: 09:46:14 | airgapped/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/crd/
+2025-10-07T09:46:14.8541251Z     logger.go:42: 09:46:14 | airgapped/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/default/
+2025-10-07T09:46:14.8542313Z     logger.go:42: 09:46:14 | airgapped/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/gitwebserver/
+2025-10-07T09:46:14.8543122Z     logger.go:42: 09:46:14 | airgapped/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/manager/
+2025-10-07T09:46:14.8543905Z     logger.go:42: 09:46:14 | airgapped/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/prometheus/
+2025-10-07T09:46:14.8544669Z     logger.go:42: 09:46:14 | airgapped/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/rbac/
+2025-10-07T09:46:14.8545463Z     logger.go:42: 09:46:14 | airgapped/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/samples/
+2025-10-07T09:46:14.8546265Z     logger.go:42: 09:46:14 | airgapped/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/tls/
+2025-10-07T09:46:14.8547078Z     logger.go:42: 09:46:14 | airgapped/1-start | ?? bootstrapper/kubeconfig
+2025-10-07T09:46:14.8547794Z     logger.go:42: 09:46:14 | airgapped/1-start | ?? bootstrapper/~/
+2025-10-07T09:46:14.8548261Z     logger.go:42: 09:46:14 | airgapped/1-start | 
+2025-10-07T09:46:14.8581830Z     logger.go:42: 09:46:14 | airgapped/1-start | 2025/10/07 09:46:14 Building github.com/mesosphere/kommander/bootstrapper/cmd for linux/amd64
+2025-10-07T09:46:26.3873929Z     logger.go:42: 09:46:26 | airgapped/1-start | 2025/10/07 09:46:26 Loading kind.local/cmd-02a858f764b6c320f56e528e7f1a7f40:1205abb557330a78faec0e7efa8857f1631c06f02d31935473b907325b0123b0
+2025-10-07T09:46:27.3658335Z     logger.go:42: 09:46:27 | airgapped/1-start | 2025/10/07 09:46:27 Loaded kind.local/cmd-02a858f764b6c320f56e528e7f1a7f40:1205abb557330a78faec0e7efa8857f1631c06f02d31935473b907325b0123b0
+2025-10-07T09:46:27.3659402Z     logger.go:42: 09:46:27 | airgapped/1-start | 2025/10/07 09:46:27 Adding tag latest
+2025-10-07T09:46:27.4602326Z     logger.go:42: 09:46:27 | airgapped/1-start | 2025/10/07 09:46:27 Added tag latest
+2025-10-07T09:46:27.5461842Z     logger.go:42: 09:46:27 | airgapped/1-start | serviceaccount/kommander-bootstrap created
+2025-10-07T09:46:27.5510643Z     logger.go:42: 09:46:27 | airgapped/1-start | clusterrole.rbac.authorization.k8s.io/kommander-bootstrap-role created
+2025-10-07T09:46:27.5540686Z     logger.go:42: 09:46:27 | airgapped/1-start | clusterrolebinding.rbac.authorization.k8s.io/kommander-bootstrap-rolebinding created
+2025-10-07T09:46:27.5599550Z     logger.go:42: 09:46:27 | airgapped/1-start | job.batch/kommander-bootstrap created
+2025-10-07T09:46:27.5639303Z     logger.go:42: 09:46:27 | airgapped/1-start | cd /runner/_work/kommander/kommander/bootstrapper/internal/fluxmanifests/manifests; find . -type f ! -name "empty.yaml" -exec rm -- {} +
+2025-10-07T09:46:27.5689374Z     logger.go:42: 09:46:27 | airgapped/1-start | cd /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests; find . -maxdepth 1 ! -name "." ! -name "kustomization.yaml" -exec rm -rf -- {} +
+2025-10-07T10:01:28.4561178Z     logger.go:42: 10:01:28 | airgapped/1-start | test step failed 1-start
+2025-10-07T10:01:28.4563324Z     logger.go:42: 10:01:28 | airgapped/1-start | collecting log output for [type==pod,label: batch.kubernetes.io/job-name=kommander-bootstrap]
+2025-10-07T10:01:28.4564438Z     logger.go:42: 10:01:28 | airgapped/1-start | running command: [kubectl logs --prefix -l batch.kubernetes.io/job-name=kommander-bootstrap -n kuttl-test-exciting-grackle --all-containers --tail=100]
+2025-10-07T10:01:28.5171048Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:53:10Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5173259Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:53:15Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5175251Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:53:20Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5177168Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:53:25Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5179388Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:53:30Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5181237Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:53:35Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5183210Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:53:40Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5185172Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:53:45Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5186504Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:53:50Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5187736Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:53:55Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5188976Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:54:00Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5190203Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:54:05Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5191432Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:54:10Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5192848Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:54:15Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5194231Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:54:20Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5195495Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:54:25Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5196726Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:54:30Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5197938Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:54:35Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5199167Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:54:40Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5200515Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:54:45Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5201746Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:54:50Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5203247Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:54:55Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5204482Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:55:00Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5205716Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:55:05Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5207067Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:55:10Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5208282Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:55:15Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5209500Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:55:20Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5210922Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:55:25Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5213134Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:55:30Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5214468Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:55:35Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5215813Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:55:40Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5217093Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:55:45Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5218680Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:55:50Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5220104Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:55:55Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5221704Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:56:00Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5223911Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:56:05Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5225744Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:56:10Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5227354Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:56:15Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5228947Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:56:20Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5230185Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:56:25Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5231399Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:56:30Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5232924Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:56:35Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5234343Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:56:40Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5235782Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:56:45Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5237426Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:56:50Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5239154Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:56:55Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5240438Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:57:00Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5241676Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:57:05Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5243301Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:57:10Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5245083Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:57:15Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5247006Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:57:20Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5248253Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:57:25Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5249654Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:57:30Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5250902Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:57:35Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5252309Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:57:40Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5253550Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:57:45Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5262966Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:57:50Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5264999Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:57:55Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5266308Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:58:00Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5267736Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:58:05Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5269059Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:58:10Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5270331Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:58:15Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5271575Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:58:20Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5273109Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:58:25Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5274331Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:58:30Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5275937Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:58:35Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5277761Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:58:40Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5279323Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:58:45Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5280669Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:58:50Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5282292Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:58:55Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5283536Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:59:00Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5284761Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:59:05Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5286627Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:59:10Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5288207Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:59:15Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5289915Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:59:20Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5291645Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:59:25Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5293623Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:59:30Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5294862Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:59:35Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5296082Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:59:40Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5297302Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:59:45Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5299059Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:59:50Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5300894Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T09:59:55Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5302398Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:00:00Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5304363Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:00:05Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5305779Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:00:10Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5306995Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:00:15Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5308185Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:00:20Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5309796Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:00:25Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5311032Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:00:30Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5312521Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:00:35Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5313765Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:00:40Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5315285Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:00:45Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5316546Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:00:50Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5318654Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:00:55Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5319955Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:01:00Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5321191Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:01:05Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5322908Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:01:10Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5324149Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:01:15Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5325599Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:01:20Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5327349Z     logger.go:42: 10:01:28 | airgapped/1-start | [pod/kommander-bootstrap-mjcfl/bootstrap] 2025-10-07T10:01:25Z	INFO	waiting for kommander-operator HelmRelease to be ready	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:01:28.5328605Z     case.go:366: failed in step 1-start
+2025-10-07T10:01:28.5329658Z     case.go:368: --- Job:kuttl-test-exciting-grackle/kommander-bootstrap
+2025-10-07T10:01:28.5330422Z         +++ Job:kuttl-test-exciting-grackle/kommander-bootstrap
+2025-10-07T10:01:28.5330858Z         @@ -1,9 +1,19 @@
+2025-10-07T10:01:28.5331321Z          apiVersion: batch/v1
+2025-10-07T10:01:28.5331849Z          kind: Job
+2025-10-07T10:01:28.5332493Z          metadata:
+2025-10-07T10:01:28.5332966Z         +  annotations:
+2025-10-07T10:01:28.5333598Z         +    kubectl.kubernetes.io/last-applied-configuration: |
+2025-10-07T10:01:28.5337602Z         +      {"apiVersion":"batch/v1","kind":"Job","metadata":{"annotations":{},"labels":{"app.kubernetes.io/part-of":"kommander-bootstrap"},"name":"kommander-bootstrap","namespace":"kuttl-test-exciting-grackle"},"spec":{"activeDeadlineSeconds":3628800,"backoffLimit":99999,"template":{"spec":{"containers":[{"args":["-flux-namespace=kuttl-test-exciting-grackle","-kommander-namespace=kuttl-test-exciting-grackle","-git-operator-namespace=kuttl-test-exciting-grackle-git","--skip-capi-cluster"],"image":"kind.local/cmd-02a858f764b6c320f56e528e7f1a7f40:1205abb557330a78faec0e7efa8857f1631c06f02d31935473b907325b0123b0","imagePullPolicy":"IfNotPresent","name":"bootstrap"}],"priorityClassName":"system-cluster-critical","restartPolicy":"OnFailure","serviceAccountName":"kommander-bootstrap"}}}}
+2025-10-07T10:01:28.5340273Z         +  labels:
+2025-10-07T10:01:28.5340636Z         +    app.kubernetes.io/part-of: kommander-bootstrap
+2025-10-07T10:01:28.5341108Z         +  managedFields: '[... elided field over 10 lines long ...]'
+2025-10-07T10:01:28.5341644Z            name: kommander-bootstrap
+2025-10-07T10:01:28.5342246Z            namespace: kuttl-test-exciting-grackle
+2025-10-07T10:01:28.5342670Z         +spec: '[... elided field over 10 lines long ...]'
+2025-10-07T10:01:28.5343193Z          status:
+2025-10-07T10:01:28.5343689Z         -  succeeded: 1
+2025-10-07T10:01:28.5344177Z         +  active: 1
+2025-10-07T10:01:28.5344658Z         +  ready: 1
+2025-10-07T10:01:28.5345161Z         +  startTime: "2025-10-07T09:46:27Z"
+2025-10-07T10:01:28.5345748Z            terminating: 0
+2025-10-07T10:01:28.5346289Z         +  uncountedTerminatedPods: {}
+2025-10-07T10:01:28.5346893Z          
+2025-10-07T10:01:28.5347186Z         
+2025-10-07T10:01:28.5347753Z     case.go:368: resource Job:kuttl-test-exciting-grackle/kommander-bootstrap: .status.succeeded: key is missing from map
+2025-10-07T10:01:28.5349022Z     logger.go:42: 10:01:28 | airgapped | airgapped events from ns kuttl-test-exciting-grackle:
+2025-10-07T10:01:28.5350589Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:27 +0000 UTC	Normal	Pod kommander-bootstrap-mjcfl		Scheduled	Successfully assigned kuttl-test-exciting-grackle/kommander-bootstrap-mjcfl to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:01:28.5352696Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:27 +0000 UTC	Normal	Pod kommander-bootstrap-mjcfl.spec.containers{bootstrap}		Pulled	Container image "kind.local/cmd-02a858f764b6c320f56e528e7f1a7f40:1205abb557330a78faec0e7efa8857f1631c06f02d31935473b907325b0123b0" already present on machine	kubelet	
+2025-10-07T10:01:28.5354192Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:27 +0000 UTC	Normal	Pod kommander-bootstrap-mjcfl.spec.containers{bootstrap}		Created	Created container bootstrap	kubelet	
+2025-10-07T10:01:28.5355246Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:27 +0000 UTC	Normal	Job.batch kommander-bootstrap		SuccessfulCreate	Created pod: kommander-bootstrap-mjcfl	job-controller	
+2025-10-07T10:01:28.5356534Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-jsv8n		Scheduled	Successfully assigned kuttl-test-exciting-grackle/flux-oci-mirror-6cbf6f6759-jsv8n to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:01:28.5357892Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	ReplicaSet.apps flux-oci-mirror-6cbf6f6759		SuccessfulCreate	Created pod: flux-oci-mirror-6cbf6f6759-jsv8n	replicaset-controller	
+2025-10-07T10:01:28.5359282Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Issuing	Issuing certificate as Secret does not exist	cert-manager-certificates-trigger	
+2025-10-07T10:01:28.5360475Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	Deployment.apps flux-oci-mirror		ScalingReplicaSet	Scaled up replica set flux-oci-mirror-6cbf6f6759 to 1	deployment-controller	
+2025-10-07T10:01:28.5362222Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-jnc4g		Scheduled	Successfully assigned kuttl-test-exciting-grackle/helm-controller-59c6d95f56-jnc4g to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:01:28.5363642Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	ReplicaSet.apps helm-controller-59c6d95f56		SuccessfulCreate	Created pod: helm-controller-59c6d95f56-jnc4g	replicaset-controller	
+2025-10-07T10:01:28.5364853Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	Deployment.apps helm-controller		ScalingReplicaSet	Scaled up replica set helm-controller-59c6d95f56 to 1	deployment-controller	
+2025-10-07T10:01:28.5366313Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-zqrdz		Scheduled	Successfully assigned kuttl-test-exciting-grackle/image-automation-controller-686b6755cf-zqrdz to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:01:28.5367882Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	ReplicaSet.apps image-automation-controller-686b6755cf		SuccessfulCreate	Created pod: image-automation-controller-686b6755cf-zqrdz	replicaset-controller	
+2025-10-07T10:01:28.5369250Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	Deployment.apps image-automation-controller		ScalingReplicaSet	Scaled up replica set image-automation-controller-686b6755cf to 1	deployment-controller	
+2025-10-07T10:01:28.5370794Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-wtx6f		Scheduled	Successfully assigned kuttl-test-exciting-grackle/image-reflector-controller-844d8d4f8c-wtx6f to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:01:28.5372705Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	ReplicaSet.apps image-reflector-controller-844d8d4f8c		SuccessfulCreate	Created pod: image-reflector-controller-844d8d4f8c-wtx6f	replicaset-controller	
+2025-10-07T10:01:28.5374105Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	Deployment.apps image-reflector-controller		ScalingReplicaSet	Scaled up replica set image-reflector-controller-844d8d4f8c to 1	deployment-controller	
+2025-10-07T10:01:28.5375327Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	Pod kommander-bootstrap-mjcfl.spec.containers{bootstrap}		Started	Started container bootstrap	kubelet	
+2025-10-07T10:01:28.5376682Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-5gdx6		Scheduled	Successfully assigned kuttl-test-exciting-grackle/kustomize-controller-f957cbb99-5gdx6 to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:01:28.5378146Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	ReplicaSet.apps kustomize-controller-f957cbb99		SuccessfulCreate	Created pod: kustomize-controller-f957cbb99-5gdx6	replicaset-controller	
+2025-10-07T10:01:28.5379411Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	Deployment.apps kustomize-controller		ScalingReplicaSet	Scaled up replica set kustomize-controller-f957cbb99 to 1	deployment-controller	
+2025-10-07T10:01:28.5380880Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	Pod notification-controller-78f9dc766-wq9nv		Scheduled	Successfully assigned kuttl-test-exciting-grackle/notification-controller-78f9dc766-wq9nv to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:01:28.5382742Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	ReplicaSet.apps notification-controller-78f9dc766		SuccessfulCreate	Created pod: notification-controller-78f9dc766-wq9nv	replicaset-controller	
+2025-10-07T10:01:28.5384057Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:28 +0000 UTC	Normal	Deployment.apps notification-controller		ScalingReplicaSet	Scaled up replica set notification-controller-78f9dc766 to 1	deployment-controller	
+2025-10-07T10:01:28.5385373Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Warning	Pod flux-oci-mirror-6cbf6f6759-jsv8n		FailedMount	MountVolume.SetUp failed for volume "proxy-ca" : secret "flux-oci-mirror-ca-secret" not found	kubelet	
+2025-10-07T10:01:28.5386607Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-jsv8n.spec.containers{manager}		Pulling	Pulling image "mesosphere/flux-oci-mirror:v0.2.5"	kubelet	
+2025-10-07T10:01:28.5387972Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-vault	
+2025-10-07T10:01:28.5389499Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-venafi	
+2025-10-07T10:01:28.5391009Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-selfsigned	
+2025-10-07T10:01:28.5392781Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-acme	
+2025-10-07T10:01:28.5394583Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-ca	
+2025-10-07T10:01:28.5396214Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		cert-manager.io	Certificate request has been approved by cert-manager.io	cert-manager-certificaterequests-approver	
+2025-10-07T10:01:28.5397689Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		CertificateIssued	Certificate fetched from issuer successfully	cert-manager-certificaterequests-issuer-selfsigned	
+2025-10-07T10:01:28.5399167Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Generated	Stored new private key in temporary Secret resource "flux-oci-mirror-ca-k2jtq"	cert-manager-certificates-key-manager	
+2025-10-07T10:01:28.5400602Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Requested	Created new CertificateRequest resource "flux-oci-mirror-ca-1"	cert-manager-certificates-request-manager	
+2025-10-07T10:01:28.5401906Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Issuing	The certificate has been successfully issued	cert-manager-certificates-issuing	
+2025-10-07T10:01:28.5403354Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-jnc4g.spec.containers{manager}		Pulling	Pulling image "ghcr.io/fluxcd/helm-controller:v1.3.0"	kubelet	
+2025-10-07T10:01:28.5404840Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-zqrdz.spec.containers{manager}		Pulling	Pulling image "ghcr.io/fluxcd/image-automation-controller:v0.41.2"	kubelet	
+2025-10-07T10:01:28.5406252Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-wtx6f.spec.containers{manager}		Pulling	Pulling image "ghcr.io/fluxcd/image-reflector-controller:v0.35.2"	kubelet	
+2025-10-07T10:01:28.5407971Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-5gdx6.spec.containers{manager}		Pulling	Pulling image "ghcr.io/fluxcd/kustomize-controller:v1.6.1"	kubelet	
+2025-10-07T10:01:28.5409278Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	Pod notification-controller-78f9dc766-wq9nv.spec.containers{manager}		Pulling	Pulling image "ghcr.io/fluxcd/notification-controller:v1.6.0"	kubelet	
+2025-10-07T10:01:28.5410754Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	Pod source-controller-cddb46ccb-qgg7r		Scheduled	Successfully assigned kuttl-test-exciting-grackle/source-controller-cddb46ccb-qgg7r to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:01:28.5412327Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	Pod source-controller-cddb46ccb-qgg7r.spec.containers{manager}		Pulling	Pulling image "ghcr.io/fluxcd/source-controller:v1.6.2"	kubelet	
+2025-10-07T10:01:28.5413565Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	ReplicaSet.apps source-controller-cddb46ccb		SuccessfulCreate	Created pod: source-controller-cddb46ccb-qgg7r	replicaset-controller	
+2025-10-07T10:01:28.5414805Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:29 +0000 UTC	Normal	Deployment.apps source-controller		ScalingReplicaSet	Scaled up replica set source-controller-cddb46ccb to 1	deployment-controller	
+2025-10-07T10:01:28.5416236Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:31 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-jnc4g.spec.containers{manager}		Pulled	Successfully pulled image "ghcr.io/fluxcd/helm-controller:v1.3.0" in 1.954s (1.954s including waiting). Image size: 42587139 bytes.	kubelet	
+2025-10-07T10:01:28.5417719Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:31 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-jnc4g.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:01:28.5418778Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:31 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-jnc4g.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:01:28.5420234Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:33 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-zqrdz.spec.containers{manager}		Pulled	Successfully pulled image "ghcr.io/fluxcd/image-automation-controller:v0.41.2" in 2.137s (4.058s including waiting). Image size: 24602001 bytes.	kubelet	
+2025-10-07T10:01:28.5421793Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:33 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-zqrdz.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:01:28.5423097Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:34 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-zqrdz.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:01:28.5424525Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:36 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-5gdx6.spec.containers{manager}		Pulled	Successfully pulled image "ghcr.io/fluxcd/kustomize-controller:v1.6.1" in 3.204s (7.256s including waiting). Image size: 67373776 bytes.	kubelet	
+2025-10-07T10:01:28.5425925Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:36 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-5gdx6.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:01:28.5427121Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:36 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-5gdx6.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:01:28.5428567Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:39 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-wtx6f.spec.containers{manager}		Pulled	Successfully pulled image "ghcr.io/fluxcd/image-reflector-controller:v0.35.2" in 2.831s (10.087s including waiting). Image size: 40677230 bytes.	kubelet	
+2025-10-07T10:01:28.5430025Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:39 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-wtx6f.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:01:28.5431159Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:39 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-wtx6f.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:01:28.5432769Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:43 +0000 UTC	Normal	Pod notification-controller-78f9dc766-wq9nv.spec.containers{manager}		Pulled	Successfully pulled image "ghcr.io/fluxcd/notification-controller:v1.6.0" in 3.95s (14.032s including waiting). Image size: 49367374 bytes.	kubelet	
+2025-10-07T10:01:28.5434186Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:43 +0000 UTC	Normal	Pod notification-controller-78f9dc766-wq9nv.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:01:28.5435295Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:43 +0000 UTC	Normal	Pod notification-controller-78f9dc766-wq9nv.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:01:28.5436668Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:45 +0000 UTC	Normal	Pod source-controller-cddb46ccb-qgg7r.spec.containers{manager}		Pulled	Successfully pulled image "ghcr.io/fluxcd/source-controller:v1.6.2" in 2.6s (16.413s including waiting). Image size: 63804109 bytes.	kubelet	
+2025-10-07T10:01:28.5438016Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:45 +0000 UTC	Normal	Pod source-controller-cddb46ccb-qgg7r.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:01:28.5439179Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:46 +0000 UTC	Normal	Pod source-controller-cddb46ccb-qgg7r.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:01:28.5440485Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:46 +0000 UTC	Warning	Pod source-controller-cddb46ccb-qgg7r.spec.containers{manager}		Unhealthy	Readiness probe failed: Get "http://10.244.0.14:9090/": dial tcp 10.244.0.14:9090: connect: connection refused	kubelet	
+2025-10-07T10:01:28.5442170Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:47 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-jsv8n.spec.containers{manager}		Pulled	Successfully pulled image "mesosphere/flux-oci-mirror:v0.2.5" in 1.911s (18.025s including waiting). Image size: 5533943 bytes.	kubelet	
+2025-10-07T10:01:28.5443492Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:47 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-jsv8n.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:01:28.5444535Z     logger.go:42: 10:01:28 | airgapped | 2025-10-07 09:46:47 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-jsv8n.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:01:28.5445345Z     logger.go:42: 10:01:28 | airgapped | Deleting namespace: kuttl-test-exciting-grackle
+2025-10-07T10:11:28.5297302Z     case.go:116: context deadline exceeded
+2025-10-07T10:11:28.5298937Z === CONT  kuttl/harness/install
+2025-10-07T10:11:28.5404136Z     logger.go:42: 10:11:28 | install | Creating namespace: kuttl-test-noted-osprey
+2025-10-07T10:11:28.5449453Z     logger.go:42: 10:11:28 | install/0-start | starting test step 0-start
+2025-10-07T10:11:28.5452687Z     logger.go:42: 10:11:28 | install/0-start | running command: [sh -c cd ../../../bootstrapper
+2025-10-07T10:11:28.5453517Z         kubectl create namespace some-git-namespace
+2025-10-07T10:11:28.5454132Z         just bootstrap-deploy $NAMESPACE $NAMESPACE $NAMESPACE some-git-namespace skip-capi-cluster
+2025-10-07T10:11:28.5454715Z         ]
+2025-10-07T10:11:28.5941735Z     logger.go:42: 10:11:28 | install/0-start | namespace/some-git-namespace created
+2025-10-07T10:11:28.6281595Z     logger.go:42: 10:11:28 | install/0-start | flux pull artifact oci://docker.io/mesosphere/git-operator-manifests:v0.13.11 --output /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests
+2025-10-07T10:11:28.9986304Z     logger.go:42: 10:11:28 | install/0-start | ► pulling artifact from docker.io/mesosphere/git-operator-manifests:v0.13.11
+2025-10-07T10:11:29.6905078Z     logger.go:42: 10:11:29 | install/0-start | ✔ source https://github.com/mesosphere/git-operator
+2025-10-07T10:11:29.6906144Z     logger.go:42: 10:11:29 | install/0-start | ✔ revision v0.13.11@sha1:2fe7ec9c9c5c8080452b13388259c0ff949d357a
+2025-10-07T10:11:29.6907405Z     logger.go:42: 10:11:29 | install/0-start | ✔ digest index.docker.io/mesosphere/git-operator-manifests@sha256:d5f2149ec717a4db534d567bd4f774900e9e7d596c652fdc817fb803a2fefd45
+2025-10-07T10:11:29.6908864Z     logger.go:42: 10:11:29 | install/0-start | ✔ artifact content extracted to /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests
+2025-10-07T10:11:29.6942223Z     logger.go:42: 10:11:29 | install/0-start | sed -i -r 's/(image\: docker\.io\/mesosphere\/git-operator\:v[0-9]+\.[0-9]+.[0-9]+)\@sha256\:.*?$/\1/g' /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests/manager/manager.yaml
+2025-10-07T10:11:29.7149503Z     logger.go:42: 10:11:29 | install/0-start | kustomize build manifests/skip-capi-cluster | env KO_DOCKER_REPO=kind.local KIND_CLUSTER_NAME=bootstrap-dev ko resolve -f - | NAMESPACE=kuttl-test-noted-osprey FLUX_NAMESPACE=kuttl-test-noted-osprey KOMMANDER_NAMESPACE=kuttl-test-noted-osprey GIT_OPERATOR_NAMESPACE=some-git-namespace envsubst | kubectl apply -f -
+2025-10-07T10:11:30.1964970Z     logger.go:42: 10:11:30 | install/0-start | 2025/10/07 10:11:30 Using base cgr.dev/chainguard/static:latest@sha256:b2e1c3d3627093e54f6805823e73edd17ab93d6c7202e672988080c863e0412b for github.com/mesosphere/kommander/bootstrapper/cmd
+2025-10-07T10:11:30.2679467Z     logger.go:42: 10:11:30 | install/0-start | 2025/10/07 10:11:30 git doesn't contain any tags. Tag info will not be available
+2025-10-07T10:11:30.2680331Z     logger.go:42: 10:11:30 | install/0-start | git is in a dirty state
+2025-10-07T10:11:30.2681119Z     logger.go:42: 10:11:30 | install/0-start | Please check in your pipeline what can be changing the following files:
+2025-10-07T10:11:30.2681855Z     logger.go:42: 10:11:30 | install/0-start | ?? bootstrapper/internal/fluxmanifests/manifests/mirror/
+2025-10-07T10:11:30.2682904Z     logger.go:42: 10:11:30 | install/0-start | ?? bootstrapper/internal/fluxmanifests/manifests/patch-proxy-env-vars.yaml
+2025-10-07T10:11:30.2683629Z     logger.go:42: 10:11:30 | install/0-start | ?? bootstrapper/internal/fluxmanifests/manifests/templates/
+2025-10-07T10:11:30.2684293Z     logger.go:42: 10:11:30 | install/0-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/crd/
+2025-10-07T10:11:30.2685128Z     logger.go:42: 10:11:30 | install/0-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/default/
+2025-10-07T10:11:30.2685829Z     logger.go:42: 10:11:30 | install/0-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/gitwebserver/
+2025-10-07T10:11:30.2686523Z     logger.go:42: 10:11:30 | install/0-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/manager/
+2025-10-07T10:11:30.2687204Z     logger.go:42: 10:11:30 | install/0-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/prometheus/
+2025-10-07T10:11:30.2688117Z     logger.go:42: 10:11:30 | install/0-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/rbac/
+2025-10-07T10:11:30.2688776Z     logger.go:42: 10:11:30 | install/0-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/samples/
+2025-10-07T10:11:30.2689607Z     logger.go:42: 10:11:30 | install/0-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/tls/
+2025-10-07T10:11:30.2690314Z     logger.go:42: 10:11:30 | install/0-start | ?? bootstrapper/kubeconfig
+2025-10-07T10:11:30.2690906Z     logger.go:42: 10:11:30 | install/0-start | ?? bootstrapper/~/
+2025-10-07T10:11:30.2691372Z     logger.go:42: 10:11:30 | install/0-start | 
+2025-10-07T10:11:30.2692297Z     logger.go:42: 10:11:30 | install/0-start | 2025/10/07 10:11:30 Building github.com/mesosphere/kommander/bootstrapper/cmd for linux/amd64
+2025-10-07T10:11:30.6633345Z     logger.go:42: 10:11:30 | install/0-start | 2025/10/07 10:11:30 Loading kind.local/cmd-02a858f764b6c320f56e528e7f1a7f40:1205abb557330a78faec0e7efa8857f1631c06f02d31935473b907325b0123b0
+2025-10-07T10:11:32.1385791Z     logger.go:42: 10:11:32 | install/0-start | 2025/10/07 10:11:32 Loaded kind.local/cmd-02a858f764b6c320f56e528e7f1a7f40:1205abb557330a78faec0e7efa8857f1631c06f02d31935473b907325b0123b0
+2025-10-07T10:11:32.1386827Z     logger.go:42: 10:11:32 | install/0-start | 2025/10/07 10:11:32 Adding tag latest
+2025-10-07T10:11:32.2387742Z     logger.go:42: 10:11:32 | install/0-start | 2025/10/07 10:11:32 Added tag latest
+2025-10-07T10:11:32.3153123Z     logger.go:42: 10:11:32 | install/0-start | serviceaccount/kommander-bootstrap created
+2025-10-07T10:11:32.3347455Z     logger.go:42: 10:11:32 | install/0-start | clusterrole.rbac.authorization.k8s.io/kommander-bootstrap-role unchanged
+2025-10-07T10:11:32.3564219Z     logger.go:42: 10:11:32 | install/0-start | clusterrolebinding.rbac.authorization.k8s.io/kommander-bootstrap-rolebinding configured
+2025-10-07T10:11:32.3622910Z     logger.go:42: 10:11:32 | install/0-start | job.batch/kommander-bootstrap created
+2025-10-07T10:11:32.3665737Z     logger.go:42: 10:11:32 | install/0-start | cd /runner/_work/kommander/kommander/bootstrapper/internal/fluxmanifests/manifests; find . -type f ! -name "empty.yaml" -exec rm -- {} +
+2025-10-07T10:11:32.3737567Z     logger.go:42: 10:11:32 | install/0-start | cd /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests; find . -maxdepth 1 ! -name "." ! -name "kustomization.yaml" -exec rm -rf -- {} +
+2025-10-07T10:11:32.3806124Z [controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
+2025-10-07T10:11:32.3806990Z Detected at:
+2025-10-07T10:11:32.3807458Z 	>  goroutine 26 [running]:
+2025-10-07T10:11:32.3807998Z 	>  runtime/debug.Stack()
+2025-10-07T10:11:32.3808535Z 	>  	runtime/debug/stack.go:24 +0x5e
+2025-10-07T10:11:32.3809255Z 	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
+2025-10-07T10:11:32.3810100Z 	>  	sigs.k8s.io/controller-runtime@v0.16.3/pkg/log/log.go:60 +0xcd
+2025-10-07T10:11:32.3811150Z 	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc0002ebc00, {0x1858f7f, 0x14})
+2025-10-07T10:11:32.3812476Z 	>  	sigs.k8s.io/controller-runtime@v0.16.3/pkg/log/deleg.go:147 +0x3e
+2025-10-07T10:11:32.3813501Z 	>  github.com/go-logr/logr.Logger.WithName({{0x1adbaf8, 0xc0002ebc00}, 0x0}, {0x1858f7f?, 0xc00078bf80?})
+2025-10-07T10:11:32.3814450Z 	>  	github.com/go-logr/logr@v1.2.4/logr.go:336 +0x36
+2025-10-07T10:11:32.3815578Z 	>  sigs.k8s.io/controller-runtime/pkg/client.newClient(0x1329fb3?, {0x0, 0xc000452af0, {0x1add110, 0xc00057c280}, 0x0, {0x0, 0x0}, 0x0})
+2025-10-07T10:11:32.3816798Z 	>  	sigs.k8s.io/controller-runtime@v0.16.3/pkg/client/client.go:122 +0xf1
+2025-10-07T10:11:32.3817970Z 	>  sigs.k8s.io/controller-runtime/pkg/client.New(0xc000594908?, {0x0, 0xc000452af0, {0x1add110, 0xc00057c280}, 0x0, {0x0, 0x0}, 0x0})
+2025-10-07T10:11:32.3819143Z 	>  	sigs.k8s.io/controller-runtime@v0.16.3/pkg/client/client.go:103 +0x7d
+2025-10-07T10:11:32.3820406Z 	>  github.com/kudobuilder/kuttl/pkg/test/utils.NewRetryClient(0xc000594908, {0x0, 0xc000452af0, {0x1add110, 0xc00057c280}, 0x0, {0x0, 0x0}, 0x0})
+2025-10-07T10:11:32.3822372Z 	>  	github.com/kudobuilder/kuttl/pkg/test/utils/kubernetes.go:177 +0x127
+2025-10-07T10:11:32.3823367Z 	>  github.com/kudobuilder/kuttl/pkg/test.(*Harness).Client(0xc0003fec08, 0xa1?)
+2025-10-07T10:11:32.3824291Z 	>  	github.com/kudobuilder/kuttl/pkg/test/harness.go:323 +0x18e
+2025-10-07T10:11:32.3825331Z 	>  github.com/kudobuilder/kuttl/pkg/test.(*Step).Create(0xc000515520, 0xc0005249c0, {0xc00051d7e8, 0x17})
+2025-10-07T10:11:32.3826334Z 	>  	github.com/kudobuilder/kuttl/pkg/test/step.go:177 +0x63
+2025-10-07T10:11:32.3827296Z 	>  github.com/kudobuilder/kuttl/pkg/test.(*Step).Run(0xc000515520, 0xc0005249c0, {0xc00051d7e8, 0x17})
+2025-10-07T10:11:32.3828264Z 	>  	github.com/kudobuilder/kuttl/pkg/test/step.go:457 +0x24a
+2025-10-07T10:11:32.3829190Z 	>  github.com/kudobuilder/kuttl/pkg/test.(*Case).Run(0xc000274960, 0xc0005249c0, 0xc0001e91f0)
+2025-10-07T10:11:32.3830146Z 	>  	github.com/kudobuilder/kuttl/pkg/test/case.go:362 +0x825
+2025-10-07T10:11:32.3831050Z 	>  github.com/kudobuilder/kuttl/pkg/test.(*Harness).RunTests.func1.1(0xc0005249c0)
+2025-10-07T10:11:32.3831978Z 	>  	github.com/kudobuilder/kuttl/pkg/test/harness.go:401 +0x1b8
+2025-10-07T10:11:32.3832895Z 	>  testing.tRunner(0xc0005249c0, 0xc00011d8c0)
+2025-10-07T10:11:32.3833536Z 	>  	testing/testing.go:1689 +0xfb
+2025-10-07T10:11:32.3834141Z 	>  created by testing.(*T).Run in goroutine 22
+2025-10-07T10:11:32.3834768Z 	>  	testing/testing.go:1742 +0x390
+2025-10-07T10:16:32.4666469Z     logger.go:42: 10:16:32 | install/0-start | test step failed 0-start
+2025-10-07T10:16:32.4668746Z     logger.go:42: 10:16:32 | install/0-start | collecting log output for [type==pod,label: batch.kubernetes.io/job-name=kommander-bootstrap]
+2025-10-07T10:16:32.4670911Z     logger.go:42: 10:16:32 | install/0-start | running command: [kubectl logs --prefix -l batch.kubernetes.io/job-name=kommander-bootstrap -n kuttl-test-noted-osprey --all-containers --tail=100]
+2025-10-07T10:16:32.5231658Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "ClusterRole", "Name": "flux-edit-kommander-flux"}
+2025-10-07T10:16:32.5234503Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "ClusterRole", "Name": "flux-view"}
+2025-10-07T10:16:32.5236798Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "ClusterRole", "Name": "flux-view-kommander-flux"}
+2025-10-07T10:16:32.5238832Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "ClusterRoleBinding", "Name": "cluster-reconciler"}
+2025-10-07T10:16:32.5241228Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "ClusterRoleBinding", "Name": "cluster-reconciler-kommander-flux"}
+2025-10-07T10:16:32.5243676Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "ClusterRoleBinding", "Name": "crd-controller"}
+2025-10-07T10:16:32.5245907Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "ClusterRoleBinding", "Name": "crd-controller-kommander-flux"}
+2025-10-07T10:16:32.5247659Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "Secret", "Name": "flux-oci-mirror-config"}
+2025-10-07T10:16:32.5249126Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "Service", "Name": "flux-oci-mirror"}
+2025-10-07T10:16:32.5250375Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "Service", "Name": "notification-controller"}
+2025-10-07T10:16:32.5251661Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "Service", "Name": "source-controller"}
+2025-10-07T10:16:32.5253132Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "Service", "Name": "webhook-receiver"}
+2025-10-07T10:16:32.5255600Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "manager" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "manager" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "manager" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "manager" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:16:32.5258059Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "Deployment", "Name": "flux-oci-mirror"}
+2025-10-07T10:16:32.5259271Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "Deployment", "Name": "helm-controller"}
+2025-10-07T10:16:32.5260525Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "Deployment", "Name": "image-automation-controller"}
+2025-10-07T10:16:32.5262200Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "Deployment", "Name": "image-reflector-controller"}
+2025-10-07T10:16:32.5263539Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "Deployment", "Name": "kustomize-controller"}
+2025-10-07T10:16:32.5264797Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "Deployment", "Name": "notification-controller"}
+2025-10-07T10:16:32.5266213Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "Deployment", "Name": "source-controller"}
+2025-10-07T10:16:32.5267466Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "Certificate", "Name": "flux-oci-mirror-ca"}
+2025-10-07T10:16:32.5268718Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "Issuer", "Name": "flux-oci-mirror-self-signed"}
+2025-10-07T10:16:32.5269987Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "NetworkPolicy", "Name": "allow-egress"}
+2025-10-07T10:16:32.5271359Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "NetworkPolicy", "Name": "allow-scraping"}
+2025-10-07T10:16:32.5272806Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "NetworkPolicy", "Name": "allow-source"}
+2025-10-07T10:16:32.5274113Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "NetworkPolicy", "Name": "allow-source-controller-oci-mirror"}
+2025-10-07T10:16:32.5275887Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	applied resource	{"kommander_version": "v2.17.0-dev", "Kind": "NetworkPolicy", "Name": "allow-webhooks"}
+2025-10-07T10:16:32.5277519Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	Waiting for installer flux	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:16:32.5278778Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	waiting for flux deployments	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:16:32.5279821Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	Running installer root-ca	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:16:32.5281029Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	Waiting for installer root-ca	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:16:32.5282514Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	waiting certificate issuers	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:16:32.5283632Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	Running installer kommander-configuration	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:16:32.5284995Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	kommander namespace updated	{"kommander_version": "v2.17.0-dev", "namespace": "kuttl-test-noted-osprey"}
+2025-10-07T10:16:32.5286288Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	empty ingress configuration. skipping kommander ingress installation.	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:16:32.5288236Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	Waiting for installer kommander-configuration	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:16:32.5290139Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	Running installer git-operator	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:16:32.5291883Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	Waiting for installer git-operator	{"kommander_version": "v2.17.0-dev"}
+2025-10-07T10:16:32.5293941Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	waiting for CRD	{"kommander_version": "v2.17.0-dev", "name": "gitclaims.git.nutanix.com"}
+2025-10-07T10:16:32.5295920Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	waiting for CRD	{"kommander_version": "v2.17.0-dev", "name": "gitclaimusers.git.nutanix.com"}
+2025-10-07T10:16:32.5298187Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5300893Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5303660Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5306200Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5308611Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5310366Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:11:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5312764Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:12:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5315072Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:12:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5317342Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:12:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5319672Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:12:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5322361Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:12:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5324629Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:12:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5326571Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:12:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5328007Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:12:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5329845Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:12:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5331636Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:12:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5333785Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:12:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5335518Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:12:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5336905Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:13:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5338305Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:13:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5339715Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:13:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5341091Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:13:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5342817Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:13:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5344384Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:13:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5346530Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:13:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5349063Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:13:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5351553Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:13:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5353554Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:13:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5354973Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:13:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5356389Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:13:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5358609Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:14:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5360573Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:14:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5362830Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:14:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5364687Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:14:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5366104Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:14:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5367869Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:14:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5369870Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:14:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5371362Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:14:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5373413Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:14:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5374861Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:14:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5376277Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:14:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5377678Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:14:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5379082Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:15:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5380458Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:15:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5382305Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:15:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5383760Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:15:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5385146Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:15:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5386525Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:15:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5387912Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:15:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5389297Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:15:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5390696Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:15:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5392261Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:15:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5393660Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:15:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5395159Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:15:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5396604Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:16:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5398034Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:16:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5399431Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:16:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5400813Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:16:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5402336Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:16:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5404003Z     logger.go:42: 10:16:32 | install/0-start | [pod/kommander-bootstrap-lsh7r/bootstrap] 2025-10-07T10:16:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "some-git-namespace"}
+2025-10-07T10:16:32.5404889Z     case.go:366: failed in step 0-start
+2025-10-07T10:16:32.5405361Z     case.go:368: --- Deployment:kuttl-test-noted-osprey/source-controller
+2025-10-07T10:16:32.5405877Z         +++ Deployment:kuttl-test-noted-osprey/source-controller
+2025-10-07T10:16:32.5406293Z         @@ -1,8 +1,22 @@
+2025-10-07T10:16:32.5406620Z          apiVersion: apps/v1
+2025-10-07T10:16:32.5406953Z          kind: Deployment
+2025-10-07T10:16:32.5407287Z          metadata:
+2025-10-07T10:16:32.5407585Z         +  labels:
+2025-10-07T10:16:32.5407918Z         +    app.kubernetes.io/component: source-controller
+2025-10-07T10:16:32.5408359Z         +    app.kubernetes.io/instance: kommander-flux
+2025-10-07T10:16:32.5408960Z         +    app.kubernetes.io/managed-by: Helm
+2025-10-07T10:16:32.5409364Z         +    app.kubernetes.io/part-of: flux
+2025-10-07T10:16:32.5409748Z         +    app.kubernetes.io/version: 2.6.4
+2025-10-07T10:16:32.5410133Z         +    control-plane: controller
+2025-10-07T10:16:32.5410513Z         +    helm.sh/chart: flux2-2.16.4
+2025-10-07T10:16:32.5410952Z         +  managedFields: '[... elided field over 10 lines long ...]'
+2025-10-07T10:16:32.5411371Z            name: source-controller
+2025-10-07T10:16:32.5411747Z            namespace: kuttl-test-noted-osprey
+2025-10-07T10:16:32.5412309Z         +spec: '[... elided field over 10 lines long ...]'
+2025-10-07T10:16:32.5412704Z          status:
+2025-10-07T10:16:32.5413007Z         -  readyReplicas: 1
+2025-10-07T10:16:32.5413406Z         +  conditions: '[... elided field over 10 lines long ...]'
+2025-10-07T10:16:32.5413815Z         +  observedGeneration: 1
+2025-10-07T10:16:32.5414147Z         +  replicas: 1
+2025-10-07T10:16:32.5414464Z         +  unavailableReplicas: 1
+2025-10-07T10:16:32.5414821Z         +  updatedReplicas: 1
+2025-10-07T10:16:32.5415151Z          
+2025-10-07T10:16:32.5423623Z         
+2025-10-07T10:16:32.5424321Z     case.go:368: resource Deployment:kuttl-test-noted-osprey/source-controller: .status.readyReplicas: key is missing from map
+2025-10-07T10:16:32.5425263Z     logger.go:42: 10:16:32 | install | install events from ns kuttl-test-noted-osprey:
+2025-10-07T10:16:32.5426303Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:32 +0000 UTC	Normal	Pod kommander-bootstrap-lsh7r		Scheduled	Successfully assigned kuttl-test-noted-osprey/kommander-bootstrap-lsh7r to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:16:32.5428103Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:32 +0000 UTC	Normal	Pod kommander-bootstrap-lsh7r.spec.containers{bootstrap}		Pulled	Container image "kind.local/cmd-02a858f764b6c320f56e528e7f1a7f40:1205abb557330a78faec0e7efa8857f1631c06f02d31935473b907325b0123b0" already present on machine	kubelet	
+2025-10-07T10:16:32.5429552Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:32 +0000 UTC	Normal	Pod kommander-bootstrap-lsh7r.spec.containers{bootstrap}		Created	Created container bootstrap	kubelet	
+2025-10-07T10:16:32.5430581Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:32 +0000 UTC	Normal	Pod kommander-bootstrap-lsh7r.spec.containers{bootstrap}		Started	Started container bootstrap	kubelet	
+2025-10-07T10:16:32.5431601Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:32 +0000 UTC	Normal	Job.batch kommander-bootstrap		SuccessfulCreate	Created pod: kommander-bootstrap-lsh7r	job-controller	
+2025-10-07T10:16:32.5433080Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-x6cq6		Scheduled	Successfully assigned kuttl-test-noted-osprey/flux-oci-mirror-6cbf6f6759-x6cq6 to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:16:32.5434650Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Warning	Pod flux-oci-mirror-6cbf6f6759-x6cq6		FailedMount	MountVolume.SetUp failed for volume "proxy-ca" : secret "flux-oci-mirror-ca-secret" not found	kubelet	
+2025-10-07T10:16:32.5435900Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	ReplicaSet.apps flux-oci-mirror-6cbf6f6759		SuccessfulCreate	Created pod: flux-oci-mirror-6cbf6f6759-x6cq6	replicaset-controller	
+2025-10-07T10:16:32.5437264Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-venafi	
+2025-10-07T10:16:32.5438742Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-ca	
+2025-10-07T10:16:32.5440204Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-vault	
+2025-10-07T10:16:32.5441688Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-acme	
+2025-10-07T10:16:32.5443317Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-selfsigned	
+2025-10-07T10:16:32.5444807Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		cert-manager.io	Certificate request has been approved by cert-manager.io	cert-manager-certificaterequests-approver	
+2025-10-07T10:16:32.5446280Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		CertificateIssued	Certificate fetched from issuer successfully	cert-manager-certificaterequests-issuer-selfsigned	
+2025-10-07T10:16:32.5447740Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Issuing	Issuing certificate as Secret does not exist	cert-manager-certificates-trigger	
+2025-10-07T10:16:32.5449070Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Generated	Stored new private key in temporary Secret resource "flux-oci-mirror-ca-xdz9n"	cert-manager-certificates-key-manager	
+2025-10-07T10:16:32.5450475Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Requested	Created new CertificateRequest resource "flux-oci-mirror-ca-1"	cert-manager-certificates-request-manager	
+2025-10-07T10:16:32.5451771Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Issuing	The certificate has been successfully issued	cert-manager-certificates-issuing	
+2025-10-07T10:16:32.5453076Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Deployment.apps flux-oci-mirror		ScalingReplicaSet	Scaled up replica set flux-oci-mirror-6cbf6f6759 to 1	deployment-controller	
+2025-10-07T10:16:32.5454421Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-cwghk		Scheduled	Successfully assigned kuttl-test-noted-osprey/helm-controller-59c6d95f56-cwghk to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:16:32.5455860Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-cwghk.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/helm-controller:v1.3.0" already present on machine	kubelet	
+2025-10-07T10:16:32.5457180Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-cwghk.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:16:32.5458205Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-cwghk.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:16:32.5459319Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	ReplicaSet.apps helm-controller-59c6d95f56		SuccessfulCreate	Created pod: helm-controller-59c6d95f56-cwghk	replicaset-controller	
+2025-10-07T10:16:32.5460482Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Deployment.apps helm-controller		ScalingReplicaSet	Scaled up replica set helm-controller-59c6d95f56 to 1	deployment-controller	
+2025-10-07T10:16:32.5462163Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-7lg95		Scheduled	Successfully assigned kuttl-test-noted-osprey/image-automation-controller-686b6755cf-7lg95 to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:16:32.5463827Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-7lg95.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/image-automation-controller:v0.41.2" already present on machine	kubelet	
+2025-10-07T10:16:32.5465167Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-7lg95.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:16:32.5466312Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-7lg95.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:16:32.5467568Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	ReplicaSet.apps image-automation-controller-686b6755cf		SuccessfulCreate	Created pod: image-automation-controller-686b6755cf-7lg95	replicaset-controller	
+2025-10-07T10:16:32.5469060Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Deployment.apps image-automation-controller		ScalingReplicaSet	Scaled up replica set image-automation-controller-686b6755cf to 1	deployment-controller	
+2025-10-07T10:16:32.5470569Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-gmpd7		Scheduled	Successfully assigned kuttl-test-noted-osprey/image-reflector-controller-844d8d4f8c-gmpd7 to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:16:32.5472630Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-gmpd7.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/image-reflector-controller:v0.35.2" already present on machine	kubelet	
+2025-10-07T10:16:32.5474326Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-gmpd7.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:16:32.5475589Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	ReplicaSet.apps image-reflector-controller-844d8d4f8c		SuccessfulCreate	Created pod: image-reflector-controller-844d8d4f8c-gmpd7	replicaset-controller	
+2025-10-07T10:16:32.5476930Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Deployment.apps image-reflector-controller		ScalingReplicaSet	Scaled up replica set image-reflector-controller-844d8d4f8c to 1	deployment-controller	
+2025-10-07T10:16:32.5478397Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-vml6l		Scheduled	Successfully assigned kuttl-test-noted-osprey/kustomize-controller-f957cbb99-vml6l to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:16:32.5480077Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-vml6l.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/kustomize-controller:v1.6.1" already present on machine	kubelet	
+2025-10-07T10:16:32.5481348Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-vml6l.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:16:32.5482630Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-vml6l.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:16:32.5483798Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	ReplicaSet.apps kustomize-controller-f957cbb99		SuccessfulCreate	Created pod: kustomize-controller-f957cbb99-vml6l	replicaset-controller	
+2025-10-07T10:16:32.5485068Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Deployment.apps kustomize-controller		ScalingReplicaSet	Scaled up replica set kustomize-controller-f957cbb99 to 1	deployment-controller	
+2025-10-07T10:16:32.5486501Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod notification-controller-78f9dc766-4gwsk		Scheduled	Successfully assigned kuttl-test-noted-osprey/notification-controller-78f9dc766-4gwsk to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:16:32.5488051Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod notification-controller-78f9dc766-4gwsk.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/notification-controller:v1.6.0" already present on machine	kubelet	
+2025-10-07T10:16:32.5489340Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod notification-controller-78f9dc766-4gwsk.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:16:32.5490551Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	ReplicaSet.apps notification-controller-78f9dc766		SuccessfulCreate	Created pod: notification-controller-78f9dc766-4gwsk	replicaset-controller	
+2025-10-07T10:16:32.5491970Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Deployment.apps notification-controller		ScalingReplicaSet	Scaled up replica set notification-controller-78f9dc766 to 1	deployment-controller	
+2025-10-07T10:16:32.5493585Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod source-controller-cddb46ccb-hvsdx		Scheduled	Successfully assigned kuttl-test-noted-osprey/source-controller-cddb46ccb-hvsdx to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:16:32.5495035Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod source-controller-cddb46ccb-hvsdx.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/source-controller:v1.6.2" already present on machine	kubelet	
+2025-10-07T10:16:32.5496286Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Pod source-controller-cddb46ccb-hvsdx.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:16:32.5497426Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	ReplicaSet.apps source-controller-cddb46ccb		SuccessfulCreate	Created pod: source-controller-cddb46ccb-hvsdx	replicaset-controller	
+2025-10-07T10:16:32.5498625Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:34 +0000 UTC	Normal	Deployment.apps source-controller		ScalingReplicaSet	Scaled up replica set source-controller-cddb46ccb to 1	deployment-controller	
+2025-10-07T10:16:32.5499879Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:35 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-x6cq6.spec.containers{manager}		Pulled	Container image "mesosphere/flux-oci-mirror:v0.2.5" already present on machine	kubelet	
+2025-10-07T10:16:32.5501172Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:35 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-x6cq6.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:16:32.5502534Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:35 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-x6cq6.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:16:32.5503629Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:35 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-gmpd7.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:16:32.5504754Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:35 +0000 UTC	Normal	Pod notification-controller-78f9dc766-4gwsk.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:16:32.5506126Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:35 +0000 UTC	Normal	Pod source-controller-cddb46ccb-hvsdx.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:16:32.5507673Z     logger.go:42: 10:16:32 | install | 2025-10-07 10:11:35 +0000 UTC	Warning	Pod source-controller-cddb46ccb-hvsdx.spec.containers{manager}		Unhealthy	Readiness probe failed: Get "http://10.244.0.26:9090/": dial tcp 10.244.0.26:9090: connect: connection refused	kubelet	
+2025-10-07T10:16:32.5508816Z     logger.go:42: 10:16:32 | install | Deleting namespace: kuttl-test-noted-osprey
+2025-10-07T10:26:32.5322954Z     case.go:116: context deadline exceeded
+2025-10-07T10:26:32.5323701Z === CONT  kuttl/harness/skipcapicluster
+2025-10-07T10:26:32.5352843Z     logger.go:42: 10:26:32 | skipcapicluster | Creating namespace: kuttl-test-patient-yeti
+2025-10-07T10:26:32.5409260Z     logger.go:42: 10:26:32 | skipcapicluster/0-configure | starting test step 0-configure
+2025-10-07T10:26:32.5410545Z     logger.go:42: 10:26:32 | skipcapicluster/0-configure | running command: [sh -c NODE_NAME=$(kubectl get nodes -oname | head -n1)
+2025-10-07T10:26:32.5411754Z         kubectl annotate ${NODE_NAME} cluster.x-k8s.io/cluster-namespace=default
+2025-10-07T10:26:32.5413028Z         kubectl annotate ${NODE_NAME} cluster.x-k8s.io/cluster-name=test-capi-cluster-name
+2025-10-07T10:26:32.5413818Z         ]
+2025-10-07T10:26:32.6555780Z     logger.go:42: 10:26:32 | skipcapicluster/0-configure | node/bootstrap-dev-control-plane annotated
+2025-10-07T10:26:32.7211002Z     logger.go:42: 10:26:32 | skipcapicluster/0-configure | node/bootstrap-dev-control-plane annotated
+2025-10-07T10:26:32.7250253Z     logger.go:42: 10:26:32 | skipcapicluster/0-configure | running command: [sh -c kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/v1.8.4/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+2025-10-07T10:26:32.7251237Z         sleep 2
+2025-10-07T10:26:32.7251826Z         # Create a fake CAPI Cluster resource. There are no capi controllers running in this test so this is a no-op.
+2025-10-07T10:26:32.7252801Z         cat <<EOF | kubectl apply -f -
+2025-10-07T10:26:32.7253234Z         apiVersion: cluster.x-k8s.io/v1beta1
+2025-10-07T10:26:32.7253612Z         kind: Cluster
+2025-10-07T10:26:32.7253918Z         metadata:
+2025-10-07T10:26:32.7254258Z           name: test-capi-cluster-name
+2025-10-07T10:26:32.7254631Z           namespace: default
+2025-10-07T10:26:32.7254951Z         EOF
+2025-10-07T10:26:32.7255242Z         ]
+2025-10-07T10:26:32.9953484Z     logger.go:42: 10:26:32 | skipcapicluster/0-configure | customresourcedefinition.apiextensions.k8s.io/clusters.cluster.x-k8s.io created
+2025-10-07T10:26:35.0992926Z     logger.go:42: 10:26:35 | skipcapicluster/0-configure | cluster.cluster.x-k8s.io/test-capi-cluster-name created
+2025-10-07T10:26:35.1026297Z     logger.go:42: 10:26:35 | skipcapicluster/0-configure | test step completed 0-configure
+2025-10-07T10:26:35.1027298Z     logger.go:42: 10:26:35 | skipcapicluster/1-start | starting test step 1-start
+2025-10-07T10:26:35.1028313Z     logger.go:42: 10:26:35 | skipcapicluster/1-start | running command: [sh -c cd ../../../bootstrapper
+2025-10-07T10:26:35.1029597Z         kubectl create namespace $NAMESPACE-git
+2025-10-07T10:26:35.1030377Z         just bootstrap-deploy $NAMESPACE $NAMESPACE $NAMESPACE $NAMESPACE-git
+2025-10-07T10:26:35.1031108Z         ]
+2025-10-07T10:26:35.1580365Z     logger.go:42: 10:26:35 | skipcapicluster/1-start | namespace/kuttl-test-patient-yeti-git created
+2025-10-07T10:26:35.1837185Z     logger.go:42: 10:26:35 | skipcapicluster/1-start | flux pull artifact oci://docker.io/mesosphere/git-operator-manifests:v0.13.11 --output /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests
+2025-10-07T10:26:35.2175471Z     logger.go:42: 10:26:35 | skipcapicluster/1-start | ► pulling artifact from docker.io/mesosphere/git-operator-manifests:v0.13.11
+2025-10-07T10:26:35.8840438Z     logger.go:42: 10:26:35 | skipcapicluster/1-start | ✔ source https://github.com/mesosphere/git-operator
+2025-10-07T10:26:35.8841346Z     logger.go:42: 10:26:35 | skipcapicluster/1-start | ✔ revision v0.13.11@sha1:2fe7ec9c9c5c8080452b13388259c0ff949d357a
+2025-10-07T10:26:35.8842780Z     logger.go:42: 10:26:35 | skipcapicluster/1-start | ✔ digest index.docker.io/mesosphere/git-operator-manifests@sha256:d5f2149ec717a4db534d567bd4f774900e9e7d596c652fdc817fb803a2fefd45
+2025-10-07T10:26:35.8844034Z     logger.go:42: 10:26:35 | skipcapicluster/1-start | ✔ artifact content extracted to /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests
+2025-10-07T10:26:35.8877070Z     logger.go:42: 10:26:35 | skipcapicluster/1-start | sed -i -r 's/(image\: docker\.io\/mesosphere\/git-operator\:v[0-9]+\.[0-9]+.[0-9]+)\@sha256\:.*?$/\1/g' /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests/manager/manager.yaml
+2025-10-07T10:26:35.8905329Z     logger.go:42: 10:26:35 | skipcapicluster/1-start | kustomize build manifests/job | env KO_DOCKER_REPO=kind.local KIND_CLUSTER_NAME=bootstrap-dev ko resolve -f - | NAMESPACE=kuttl-test-patient-yeti FLUX_NAMESPACE=kuttl-test-patient-yeti KOMMANDER_NAMESPACE=kuttl-test-patient-yeti GIT_OPERATOR_NAMESPACE=kuttl-test-patient-yeti-git envsubst | kubectl apply -f -
+2025-10-07T10:26:36.1669898Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | 2025/10/07 10:26:36 Using base cgr.dev/chainguard/static:latest@sha256:b2e1c3d3627093e54f6805823e73edd17ab93d6c7202e672988080c863e0412b for github.com/mesosphere/kommander/bootstrapper/cmd
+2025-10-07T10:26:36.2129135Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | 2025/10/07 10:26:36 git doesn't contain any tags. Tag info will not be available
+2025-10-07T10:26:36.2130154Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | git is in a dirty state
+2025-10-07T10:26:36.2130860Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | Please check in your pipeline what can be changing the following files:
+2025-10-07T10:26:36.2131605Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | ?? bootstrapper/internal/fluxmanifests/manifests/mirror/
+2025-10-07T10:26:36.2132737Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | ?? bootstrapper/internal/fluxmanifests/manifests/patch-proxy-env-vars.yaml
+2025-10-07T10:26:36.2133534Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | ?? bootstrapper/internal/fluxmanifests/manifests/templates/
+2025-10-07T10:26:36.2134263Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/crd/
+2025-10-07T10:26:36.2134987Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/default/
+2025-10-07T10:26:36.2135740Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/gitwebserver/
+2025-10-07T10:26:36.2136482Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/manager/
+2025-10-07T10:26:36.2137372Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/prometheus/
+2025-10-07T10:26:36.2138528Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/rbac/
+2025-10-07T10:26:36.2139390Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/samples/
+2025-10-07T10:26:36.2140233Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/tls/
+2025-10-07T10:26:36.2140975Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | ?? bootstrapper/kubeconfig
+2025-10-07T10:26:36.2141627Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | ?? bootstrapper/~/
+2025-10-07T10:26:36.2142366Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | 
+2025-10-07T10:26:36.2143207Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | 2025/10/07 10:26:36 Building github.com/mesosphere/kommander/bootstrapper/cmd for linux/amd64
+2025-10-07T10:26:36.5859102Z     logger.go:42: 10:26:36 | skipcapicluster/1-start | 2025/10/07 10:26:36 Loading kind.local/cmd-02a858f764b6c320f56e528e7f1a7f40:1205abb557330a78faec0e7efa8857f1631c06f02d31935473b907325b0123b0
+2025-10-07T10:26:37.9621713Z     logger.go:42: 10:26:37 | skipcapicluster/1-start | 2025/10/07 10:26:37 Loaded kind.local/cmd-02a858f764b6c320f56e528e7f1a7f40:1205abb557330a78faec0e7efa8857f1631c06f02d31935473b907325b0123b0
+2025-10-07T10:26:37.9623439Z     logger.go:42: 10:26:37 | skipcapicluster/1-start | 2025/10/07 10:26:37 Adding tag latest
+2025-10-07T10:26:38.0563477Z     logger.go:42: 10:26:38 | skipcapicluster/1-start | 2025/10/07 10:26:38 Added tag latest
+2025-10-07T10:26:38.1379927Z     logger.go:42: 10:26:38 | skipcapicluster/1-start | serviceaccount/kommander-bootstrap created
+2025-10-07T10:26:38.1493976Z     logger.go:42: 10:26:38 | skipcapicluster/1-start | clusterrole.rbac.authorization.k8s.io/kommander-bootstrap-role unchanged
+2025-10-07T10:26:38.1652686Z     logger.go:42: 10:26:38 | skipcapicluster/1-start | clusterrolebinding.rbac.authorization.k8s.io/kommander-bootstrap-rolebinding configured
+2025-10-07T10:26:38.1699849Z     logger.go:42: 10:26:38 | skipcapicluster/1-start | job.batch/kommander-bootstrap created
+2025-10-07T10:26:38.1741162Z     logger.go:42: 10:26:38 | skipcapicluster/1-start | cd /runner/_work/kommander/kommander/bootstrapper/internal/fluxmanifests/manifests; find . -type f ! -name "empty.yaml" -exec rm -- {} +
+2025-10-07T10:26:38.1795270Z     logger.go:42: 10:26:38 | skipcapicluster/1-start | cd /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests; find . -maxdepth 1 ! -name "." ! -name "kustomization.yaml" -exec rm -rf -- {} +
+2025-10-07T10:41:38.9423596Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | test step failed 1-start
+2025-10-07T10:41:38.9426046Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | collecting log output for [type==pod,label: batch.kubernetes.io/job-name=kommander-bootstrap]
+2025-10-07T10:41:38.9429418Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | running command: [kubectl logs --prefix -l batch.kubernetes.io/job-name=kommander-bootstrap -n kuttl-test-patient-yeti --all-containers --tail=100]
+2025-10-07T10:41:38.9974731Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:33:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:38.9977736Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:33:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:38.9980444Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:33:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:38.9983242Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:33:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:38.9986509Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:33:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:38.9989195Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:33:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:38.9991757Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:33:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:38.9994352Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:33:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:38.9996684Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:33:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:38.9998906Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:34:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0000593Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:34:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0002579Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:34:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0004148Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:34:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0005924Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:34:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0007494Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:34:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0009007Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:34:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0010504Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:34:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0012367Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:34:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0013909Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:34:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0015388Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:34:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0016879Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:34:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0018360Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:35:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0019856Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:35:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0021453Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:35:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0023149Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:35:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0024888Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:35:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0026827Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:35:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0028750Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:35:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0030272Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:35:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0031767Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:35:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0033471Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:35:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0035633Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:35:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0037169Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:35:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0039723Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:36:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0042461Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:36:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0044870Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:36:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0047440Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:36:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0049929Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:36:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0051508Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:36:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0053481Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:36:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0055197Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:36:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0057781Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:36:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0059482Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:36:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0061772Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:36:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0064374Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:36:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0066877Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:37:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0068385Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:37:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0069877Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:37:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0071381Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:37:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0073259Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:37:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0075091Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:37:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0077228Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:37:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0079418Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:37:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0081448Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:37:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0083290Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:37:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0084808Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:37:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0086318Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:37:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0087821Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:38:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0090020Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:38:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0092689Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:38:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0094907Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:38:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0097732Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:38:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0099726Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:38:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0101594Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:38:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0103872Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:38:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0105900Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:38:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0108659Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:38:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0110499Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:38:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0112274Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:38:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0124177Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:39:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0125782Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:39:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0127294Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:39:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0129007Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:39:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0131217Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:39:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0133323Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:39:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0134864Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:39:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0136397Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:39:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0138028Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:39:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0140069Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:39:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0142272Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:39:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0144032Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:39:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0145565Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:40:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0147067Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:40:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0148581Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:40:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0150089Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:40:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0151582Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:40:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0153563Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:40:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0155115Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:40:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0156633Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:40:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0158144Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:40:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0159661Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:40:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0161171Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:40:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0163021Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:40:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0164561Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:41:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0166232Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:41:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0167752Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:41:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0169268Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:41:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0170768Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:41:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0172484Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:41:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0174022Z     logger.go:42: 10:41:38 | skipcapicluster/1-start | [pod/kommander-bootstrap-7j5rb/bootstrap] 2025-10-07T10:41:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-patient-yeti-git"}
+2025-10-07T10:41:39.0175153Z     case.go:366: failed in step 1-start
+2025-10-07T10:41:39.0175617Z     case.go:368: --- Job:kuttl-test-patient-yeti/kommander-bootstrap
+2025-10-07T10:41:39.0176100Z         +++ Job:kuttl-test-patient-yeti/kommander-bootstrap
+2025-10-07T10:41:39.0176517Z         @@ -1,9 +1,19 @@
+2025-10-07T10:41:39.0176857Z          apiVersion: batch/v1
+2025-10-07T10:41:39.0177177Z          kind: Job
+2025-10-07T10:41:39.0177472Z          metadata:
+2025-10-07T10:41:39.0177775Z         +  annotations:
+2025-10-07T10:41:39.0178156Z         +    kubectl.kubernetes.io/last-applied-configuration: |
+2025-10-07T10:41:39.0180627Z         +      {"apiVersion":"batch/v1","kind":"Job","metadata":{"annotations":{},"labels":{"app.kubernetes.io/part-of":"kommander-bootstrap"},"name":"kommander-bootstrap","namespace":"kuttl-test-patient-yeti"},"spec":{"activeDeadlineSeconds":3628800,"backoffLimit":99999,"template":{"spec":{"containers":[{"args":["-flux-namespace=kuttl-test-patient-yeti","-kommander-namespace=kuttl-test-patient-yeti","-git-operator-namespace=kuttl-test-patient-yeti-git"],"image":"kind.local/cmd-02a858f764b6c320f56e528e7f1a7f40:1205abb557330a78faec0e7efa8857f1631c06f02d31935473b907325b0123b0","imagePullPolicy":"IfNotPresent","name":"bootstrap"}],"priorityClassName":"system-cluster-critical","restartPolicy":"OnFailure","serviceAccountName":"kommander-bootstrap"}}}}
+2025-10-07T10:41:39.0183277Z         +  labels:
+2025-10-07T10:41:39.0183634Z         +    app.kubernetes.io/part-of: kommander-bootstrap
+2025-10-07T10:41:39.0184113Z         +  managedFields: '[... elided field over 10 lines long ...]'
+2025-10-07T10:41:39.0184554Z            name: kommander-bootstrap
+2025-10-07T10:41:39.0184932Z            namespace: kuttl-test-patient-yeti
+2025-10-07T10:41:39.0185340Z         +spec: '[... elided field over 10 lines long ...]'
+2025-10-07T10:41:39.0185731Z          status:
+2025-10-07T10:41:39.0186042Z         -  succeeded: 1
+2025-10-07T10:41:39.0186359Z         +  active: 1
+2025-10-07T10:41:39.0186667Z         +  ready: 1
+2025-10-07T10:41:39.0186981Z         +  startTime: "2025-10-07T10:26:38Z"
+2025-10-07T10:41:39.0187348Z            terminating: 0
+2025-10-07T10:41:39.0187673Z         +  uncountedTerminatedPods: {}
+2025-10-07T10:41:39.0188030Z          
+2025-10-07T10:41:39.0188322Z         
+2025-10-07T10:41:39.0189068Z     case.go:368: resource Job:kuttl-test-patient-yeti/kommander-bootstrap: .status.succeeded: key is missing from map
+2025-10-07T10:41:39.0189741Z     case.go:368: --- Cluster:default/test-capi-cluster-name
+2025-10-07T10:41:39.0190174Z         +++ Cluster:default/test-capi-cluster-name
+2025-10-07T10:41:39.0190548Z         @@ -1,10 +1,19 @@
+2025-10-07T10:41:39.0190895Z          apiVersion: cluster.x-k8s.io/v1beta1
+2025-10-07T10:41:39.0191261Z          kind: Cluster
+2025-10-07T10:41:39.0191572Z          metadata:
+2025-10-07T10:41:39.0191885Z         +  annotations:
+2025-10-07T10:41:39.0192597Z         +    kubectl.kubernetes.io/last-applied-configuration: |
+2025-10-07T10:41:39.0193302Z         +      {"apiVersion":"cluster.x-k8s.io/v1beta1","kind":"Cluster","metadata":{"annotations":{},"name":"test-capi-cluster-name","namespace":"default"}}
+2025-10-07T10:41:39.0194003Z         +  managedFields: '[... elided field over 10 lines long ...]'
+2025-10-07T10:41:39.0194454Z            name: test-capi-cluster-name
+2025-10-07T10:41:39.0194832Z            namespace: default
+2025-10-07T10:41:39.0195159Z          status:
+2025-10-07T10:41:39.0195447Z            conditions:
+2025-10-07T10:41:39.0195758Z         -  - status: "True"
+2025-10-07T10:41:39.0196125Z         +  - lastTransitionTime: "2025-10-07T10:26:39Z"
+2025-10-07T10:41:39.0196540Z         +    message: Deploying Git Operator
+2025-10-07T10:41:39.0196909Z         +    reason: WaitingForGitOperator
+2025-10-07T10:41:39.0197282Z         +    status: "False"
+2025-10-07T10:41:39.0197804Z              type: KommanderInitialized
+2025-10-07T10:41:39.0198182Z         +  controlPlaneReady: false
+2025-10-07T10:41:39.0198546Z         +  infrastructureReady: false
+2025-10-07T10:41:39.0198902Z          
+2025-10-07T10:41:39.0199187Z         
+2025-10-07T10:41:39.0199772Z     case.go:368: resource Cluster:default/test-capi-cluster-name: .status.conditions.status: value mismatch, expected: True != actual: False
+2025-10-07T10:41:39.0200594Z     logger.go:42: 10:41:39 | skipcapicluster | skipcapicluster events from ns kuttl-test-patient-yeti:
+2025-10-07T10:41:39.0201702Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:38 +0000 UTC	Normal	Pod kommander-bootstrap-7j5rb		Scheduled	Successfully assigned kuttl-test-patient-yeti/kommander-bootstrap-7j5rb to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:41:39.0203758Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:38 +0000 UTC	Normal	Pod kommander-bootstrap-7j5rb.spec.containers{bootstrap}		Pulled	Container image "kind.local/cmd-02a858f764b6c320f56e528e7f1a7f40:1205abb557330a78faec0e7efa8857f1631c06f02d31935473b907325b0123b0" already present on machine	kubelet	
+2025-10-07T10:41:39.0205269Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:38 +0000 UTC	Normal	Pod kommander-bootstrap-7j5rb.spec.containers{bootstrap}		Created	Created container bootstrap	kubelet	
+2025-10-07T10:41:39.0206375Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:38 +0000 UTC	Normal	Pod kommander-bootstrap-7j5rb.spec.containers{bootstrap}		Started	Started container bootstrap	kubelet	
+2025-10-07T10:41:39.0207604Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:38 +0000 UTC	Normal	Job.batch kommander-bootstrap		SuccessfulCreate	Created pod: kommander-bootstrap-7j5rb	job-controller	
+2025-10-07T10:41:39.0208947Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-stcjn		Scheduled	Successfully assigned kuttl-test-patient-yeti/flux-oci-mirror-6cbf6f6759-stcjn to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:41:39.0210415Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Warning	Pod flux-oci-mirror-6cbf6f6759-stcjn		FailedMount	MountVolume.SetUp failed for volume "proxy-ca" : secret "flux-oci-mirror-ca-secret" not found	kubelet	
+2025-10-07T10:41:39.0212196Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	ReplicaSet.apps flux-oci-mirror-6cbf6f6759		SuccessfulCreate	Created pod: flux-oci-mirror-6cbf6f6759-stcjn	replicaset-controller	
+2025-10-07T10:41:39.0213681Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-ca	
+2025-10-07T10:41:39.0215225Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-vault	
+2025-10-07T10:41:39.0216827Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-selfsigned	
+2025-10-07T10:41:39.0218372Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-acme	
+2025-10-07T10:41:39.0219897Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-venafi	
+2025-10-07T10:41:39.0221612Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		cert-manager.io	Certificate request has been approved by cert-manager.io	cert-manager-certificaterequests-approver	
+2025-10-07T10:41:39.0223592Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		CertificateIssued	Certificate fetched from issuer successfully	cert-manager-certificaterequests-issuer-selfsigned	
+2025-10-07T10:41:39.0225000Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Issuing	Issuing certificate as Secret does not exist	cert-manager-certificates-trigger	
+2025-10-07T10:41:39.0226378Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Generated	Stored new private key in temporary Secret resource "flux-oci-mirror-ca-mdvzp"	cert-manager-certificates-key-manager	
+2025-10-07T10:41:39.0227855Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Requested	Created new CertificateRequest resource "flux-oci-mirror-ca-1"	cert-manager-certificates-request-manager	
+2025-10-07T10:41:39.0229216Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Issuing	The certificate has been successfully issued	cert-manager-certificates-issuing	
+2025-10-07T10:41:39.0230449Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Deployment.apps flux-oci-mirror		ScalingReplicaSet	Scaled up replica set flux-oci-mirror-6cbf6f6759 to 1	deployment-controller	
+2025-10-07T10:41:39.0231833Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-jqd8l		Scheduled	Successfully assigned kuttl-test-patient-yeti/helm-controller-59c6d95f56-jqd8l to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:41:39.0233739Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-jqd8l.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/helm-controller:v1.3.0" already present on machine	kubelet	
+2025-10-07T10:41:39.0235150Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-jqd8l.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:41:39.0236363Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	ReplicaSet.apps helm-controller-59c6d95f56		SuccessfulCreate	Created pod: helm-controller-59c6d95f56-jqd8l	replicaset-controller	
+2025-10-07T10:41:39.0237596Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Deployment.apps helm-controller		ScalingReplicaSet	Scaled up replica set helm-controller-59c6d95f56 to 1	deployment-controller	
+2025-10-07T10:41:39.0239100Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-tkx8z		Scheduled	Successfully assigned kuttl-test-patient-yeti/image-automation-controller-686b6755cf-tkx8z to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:41:39.0240801Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-tkx8z.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/image-automation-controller:v0.41.2" already present on machine	kubelet	
+2025-10-07T10:41:39.0242518Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-tkx8z.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:41:39.0243920Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	ReplicaSet.apps image-automation-controller-686b6755cf		SuccessfulCreate	Created pod: image-automation-controller-686b6755cf-tkx8z	replicaset-controller	
+2025-10-07T10:41:39.0245477Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Deployment.apps image-automation-controller		ScalingReplicaSet	Scaled up replica set image-automation-controller-686b6755cf to 1	deployment-controller	
+2025-10-07T10:41:39.0247059Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-gb57l		Scheduled	Successfully assigned kuttl-test-patient-yeti/image-reflector-controller-844d8d4f8c-gb57l to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:41:39.0248736Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-gb57l.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/image-reflector-controller:v0.35.2" already present on machine	kubelet	
+2025-10-07T10:41:39.0250116Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-gb57l.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:41:39.0251435Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	ReplicaSet.apps image-reflector-controller-844d8d4f8c		SuccessfulCreate	Created pod: image-reflector-controller-844d8d4f8c-gb57l	replicaset-controller	
+2025-10-07T10:41:39.0253050Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Deployment.apps image-reflector-controller		ScalingReplicaSet	Scaled up replica set image-reflector-controller-844d8d4f8c to 1	deployment-controller	
+2025-10-07T10:41:39.0254583Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-g8hz4		Scheduled	Successfully assigned kuttl-test-patient-yeti/kustomize-controller-f957cbb99-g8hz4 to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:41:39.0256167Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-g8hz4.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/kustomize-controller:v1.6.1" already present on machine	kubelet	
+2025-10-07T10:41:39.0257604Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-g8hz4.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:41:39.0258850Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	ReplicaSet.apps kustomize-controller-f957cbb99		SuccessfulCreate	Created pod: kustomize-controller-f957cbb99-g8hz4	replicaset-controller	
+2025-10-07T10:41:39.0260166Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Deployment.apps kustomize-controller		ScalingReplicaSet	Scaled up replica set kustomize-controller-f957cbb99 to 1	deployment-controller	
+2025-10-07T10:41:39.0261749Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod notification-controller-78f9dc766-sf96f		Scheduled	Successfully assigned kuttl-test-patient-yeti/notification-controller-78f9dc766-sf96f to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:41:39.0263810Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod notification-controller-78f9dc766-sf96f.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/notification-controller:v1.6.0" already present on machine	kubelet	
+2025-10-07T10:41:39.0265174Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod notification-controller-78f9dc766-sf96f.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:41:39.0266440Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	ReplicaSet.apps notification-controller-78f9dc766		SuccessfulCreate	Created pod: notification-controller-78f9dc766-sf96f	replicaset-controller	
+2025-10-07T10:41:39.0267947Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Deployment.apps notification-controller		ScalingReplicaSet	Scaled up replica set notification-controller-78f9dc766 to 1	deployment-controller	
+2025-10-07T10:41:39.0269435Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Pod source-controller-cddb46ccb-2zppn		Scheduled	Successfully assigned kuttl-test-patient-yeti/source-controller-cddb46ccb-2zppn to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T10:41:39.0271178Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	ReplicaSet.apps source-controller-cddb46ccb		SuccessfulCreate	Created pod: source-controller-cddb46ccb-2zppn	replicaset-controller	
+2025-10-07T10:41:39.0272951Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:39 +0000 UTC	Normal	Deployment.apps source-controller		ScalingReplicaSet	Scaled up replica set source-controller-cddb46ccb to 1	deployment-controller	
+2025-10-07T10:41:39.0274353Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:40 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-stcjn.spec.containers{manager}		Pulled	Container image "mesosphere/flux-oci-mirror:v0.2.5" already present on machine	kubelet	
+2025-10-07T10:41:39.0275597Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:40 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-stcjn.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:41:39.0276689Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:40 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-stcjn.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:41:39.0277788Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:40 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-jqd8l.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:41:39.0278939Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:40 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-tkx8z.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:41:39.0280142Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:40 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-gb57l.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:41:39.0281456Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:40 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-g8hz4.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:41:39.0282879Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:40 +0000 UTC	Normal	Pod notification-controller-78f9dc766-sf96f.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:41:39.0284198Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:40 +0000 UTC	Normal	Pod source-controller-cddb46ccb-2zppn.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/source-controller:v1.6.2" already present on machine	kubelet	
+2025-10-07T10:41:39.0285485Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:40 +0000 UTC	Normal	Pod source-controller-cddb46ccb-2zppn.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T10:41:39.0286631Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:40 +0000 UTC	Normal	Pod source-controller-cddb46ccb-2zppn.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T10:41:39.0288087Z     logger.go:42: 10:41:39 | skipcapicluster | 2025-10-07 10:26:40 +0000 UTC	Warning	Pod source-controller-cddb46ccb-2zppn.spec.containers{manager}		Unhealthy	Readiness probe failed: Get "http://10.244.0.37:9090/": dial tcp 10.244.0.37:9090: connect: connection refused	kubelet	
+2025-10-07T10:41:39.0289146Z     logger.go:42: 10:41:39 | skipcapicluster | Deleting namespace: kuttl-test-patient-yeti
+2025-10-07T10:51:39.0071809Z     case.go:116: context deadline exceeded
+2025-10-07T10:51:39.0072638Z === CONT  kuttl/harness/ingress
+2025-10-07T10:51:39.0112941Z     logger.go:42: 10:51:39 | ingress | Creating namespace: kuttl-test-still-halibut
+2025-10-07T10:51:39.0167839Z     logger.go:42: 10:51:39 | ingress/0-configure | starting test step 0-configure
+2025-10-07T10:51:39.0241710Z     logger.go:42: 10:51:39 | ingress/0-configure | ConfigMap:kuttl-test-still-halibut/kommander-bootstrap-configuration created
+2025-10-07T10:51:39.0243123Z     logger.go:42: 10:51:39 | ingress/0-configure | test step completed 0-configure
+2025-10-07T10:51:39.0243965Z     logger.go:42: 10:51:39 | ingress/1-start | starting test step 1-start
+2025-10-07T10:51:39.0244859Z     logger.go:42: 10:51:39 | ingress/1-start | running command: [sh -c cd ../../../bootstrapper
+2025-10-07T10:51:39.0245662Z         kubectl create namespace $NAMESPACE-git
+2025-10-07T10:51:39.0246531Z         just bootstrap-deploy $NAMESPACE $NAMESPACE $NAMESPACE $NAMESPACE-git skip-capi-cluster
+2025-10-07T10:51:39.0247346Z         ]
+2025-10-07T10:51:39.0728065Z     logger.go:42: 10:51:39 | ingress/1-start | namespace/kuttl-test-still-halibut-git created
+2025-10-07T10:51:39.0995976Z     logger.go:42: 10:51:39 | ingress/1-start | flux pull artifact oci://docker.io/mesosphere/git-operator-manifests:v0.13.11 --output /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests
+2025-10-07T10:51:39.1240755Z     logger.go:42: 10:51:39 | ingress/1-start | ► pulling artifact from docker.io/mesosphere/git-operator-manifests:v0.13.11
+2025-10-07T10:51:39.8210416Z     logger.go:42: 10:51:39 | ingress/1-start | ✔ source https://github.com/mesosphere/git-operator
+2025-10-07T10:51:39.8211320Z     logger.go:42: 10:51:39 | ingress/1-start | ✔ revision v0.13.11@sha1:2fe7ec9c9c5c8080452b13388259c0ff949d357a
+2025-10-07T10:51:39.8213274Z     logger.go:42: 10:51:39 | ingress/1-start | ✔ digest index.docker.io/mesosphere/git-operator-manifests@sha256:d5f2149ec717a4db534d567bd4f774900e9e7d596c652fdc817fb803a2fefd45
+2025-10-07T10:51:39.8215405Z     logger.go:42: 10:51:39 | ingress/1-start | ✔ artifact content extracted to /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests
+2025-10-07T10:51:39.8248548Z     logger.go:42: 10:51:39 | ingress/1-start | sed -i -r 's/(image\: docker\.io\/mesosphere\/git-operator\:v[0-9]+\.[0-9]+.[0-9]+)\@sha256\:.*?$/\1/g' /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests/manager/manager.yaml
+2025-10-07T10:51:39.8279264Z     logger.go:42: 10:51:39 | ingress/1-start | kustomize build manifests/skip-capi-cluster | env KO_DOCKER_REPO=kind.local KIND_CLUSTER_NAME=bootstrap-dev ko resolve -f - | NAMESPACE=kuttl-test-still-halibut FLUX_NAMESPACE=kuttl-test-still-halibut KOMMANDER_NAMESPACE=kuttl-test-still-halibut GIT_OPERATOR_NAMESPACE=kuttl-test-still-halibut-git envsubst | kubectl apply -f -
+2025-10-07T10:51:40.1398566Z     logger.go:42: 10:51:40 | ingress/1-start | 2025/10/07 10:51:40 Using base cgr.dev/chainguard/static:latest@sha256:b2e1c3d3627093e54f6805823e73edd17ab93d6c7202e672988080c863e0412b for github.com/mesosphere/kommander/bootstrapper/cmd
+2025-10-07T10:51:40.1868885Z     logger.go:42: 10:51:40 | ingress/1-start | 2025/10/07 10:51:40 git doesn't contain any tags. Tag info will not be available
+2025-10-07T10:51:40.1869806Z     logger.go:42: 10:51:40 | ingress/1-start | git is in a dirty state
+2025-10-07T10:51:40.1870494Z     logger.go:42: 10:51:40 | ingress/1-start | Please check in your pipeline what can be changing the following files:
+2025-10-07T10:51:40.1871346Z     logger.go:42: 10:51:40 | ingress/1-start | ?? bootstrapper/internal/fluxmanifests/manifests/mirror/
+2025-10-07T10:51:40.1872308Z     logger.go:42: 10:51:40 | ingress/1-start | ?? bootstrapper/internal/fluxmanifests/manifests/patch-proxy-env-vars.yaml
+2025-10-07T10:51:40.1873058Z     logger.go:42: 10:51:40 | ingress/1-start | ?? bootstrapper/internal/fluxmanifests/manifests/templates/
+2025-10-07T10:51:40.1873737Z     logger.go:42: 10:51:40 | ingress/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/crd/
+2025-10-07T10:51:40.1874696Z     logger.go:42: 10:51:40 | ingress/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/default/
+2025-10-07T10:51:40.1875428Z     logger.go:42: 10:51:40 | ingress/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/gitwebserver/
+2025-10-07T10:51:40.1876148Z     logger.go:42: 10:51:40 | ingress/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/manager/
+2025-10-07T10:51:40.1876837Z     logger.go:42: 10:51:40 | ingress/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/prometheus/
+2025-10-07T10:51:40.1877526Z     logger.go:42: 10:51:40 | ingress/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/rbac/
+2025-10-07T10:51:40.1878347Z     logger.go:42: 10:51:40 | ingress/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/samples/
+2025-10-07T10:51:40.1879219Z     logger.go:42: 10:51:40 | ingress/1-start | ?? bootstrapper/internal/gitoperatorobjects/manifests/tls/
+2025-10-07T10:51:40.1879933Z     logger.go:42: 10:51:40 | ingress/1-start | ?? bootstrapper/kubeconfig
+2025-10-07T10:51:40.1880471Z     logger.go:42: 10:51:40 | ingress/1-start | ?? bootstrapper/~/
+2025-10-07T10:51:40.1880975Z     logger.go:42: 10:51:40 | ingress/1-start | 
+2025-10-07T10:51:40.1881728Z     logger.go:42: 10:51:40 | ingress/1-start | 2025/10/07 10:51:40 Building github.com/mesosphere/kommander/bootstrapper/cmd for linux/amd64
+2025-10-07T10:51:40.5757901Z     logger.go:42: 10:51:40 | ingress/1-start | 2025/10/07 10:51:40 Loading kind.local/cmd-02a858f764b6c320f56e528e7f1a7f40:1205abb557330a78faec0e7efa8857f1631c06f02d31935473b907325b0123b0
+2025-10-07T10:51:41.9694630Z     logger.go:42: 10:51:41 | ingress/1-start | 2025/10/07 10:51:41 Loaded kind.local/cmd-02a858f764b6c320f56e528e7f1a7f40:1205abb557330a78faec0e7efa8857f1631c06f02d31935473b907325b0123b0
+2025-10-07T10:51:41.9695543Z     logger.go:42: 10:51:41 | ingress/1-start | 2025/10/07 10:51:41 Adding tag latest
+2025-10-07T10:51:42.0755499Z     logger.go:42: 10:51:42 | ingress/1-start | 2025/10/07 10:51:42 Added tag latest
+2025-10-07T10:51:42.1703620Z     logger.go:42: 10:51:42 | ingress/1-start | serviceaccount/kommander-bootstrap created
+2025-10-07T10:51:42.1837750Z     logger.go:42: 10:51:42 | ingress/1-start | clusterrole.rbac.authorization.k8s.io/kommander-bootstrap-role unchanged
+2025-10-07T10:51:42.2015956Z     logger.go:42: 10:51:42 | ingress/1-start | clusterrolebinding.rbac.authorization.k8s.io/kommander-bootstrap-rolebinding configured
+2025-10-07T10:51:42.2091205Z     logger.go:42: 10:51:42 | ingress/1-start | job.batch/kommander-bootstrap created
+2025-10-07T10:51:42.2138967Z     logger.go:42: 10:51:42 | ingress/1-start | cd /runner/_work/kommander/kommander/bootstrapper/internal/fluxmanifests/manifests; find . -type f ! -name "empty.yaml" -exec rm -- {} +
+2025-10-07T10:51:42.2197578Z     logger.go:42: 10:51:42 | ingress/1-start | cd /runner/_work/kommander/kommander/bootstrapper/internal/gitoperatorobjects/manifests; find . -maxdepth 1 ! -name "." ! -name "kustomization.yaml" -exec rm -rf -- {} +
+2025-10-07T11:06:43.2320229Z     logger.go:42: 11:06:43 | ingress/1-start | test step failed 1-start
+2025-10-07T11:06:43.2321186Z     logger.go:42: 11:06:43 | ingress/1-start | collecting log output for [type==pod,label: batch.kubernetes.io/job-name=kommander-bootstrap]
+2025-10-07T11:06:43.2322968Z     logger.go:42: 11:06:43 | ingress/1-start | running command: [kubectl logs --prefix -l batch.kubernetes.io/job-name=kommander-bootstrap -n kuttl-test-still-halibut --all-containers --tail=100]
+2025-10-07T11:06:43.2912634Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:58:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2915537Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:58:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2918636Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:58:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2921107Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:58:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2923675Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:58:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2926067Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:58:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2928423Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:58:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2930744Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:58:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2933251Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:59:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2935617Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:59:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2938273Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:59:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2948716Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:59:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2951343Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:59:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2953976Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:59:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2956398Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:59:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2958828Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:59:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2961280Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:59:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2963936Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:59:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2966284Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:59:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2968319Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T10:59:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2969850Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:00:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2971315Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:00:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2973034Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:00:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2974998Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:00:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2976655Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:00:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2978282Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:00:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2980170Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:00:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2981832Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:00:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2983793Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:00:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2986185Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:00:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2988781Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:00:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2991381Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:00:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2994104Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:01:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2996556Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:01:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.2998941Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:01:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3001280Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:01:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3003868Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:01:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3006176Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:01:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3009138Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:01:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3011787Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:01:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3014281Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:01:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3016786Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:01:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3019276Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:01:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3021863Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:01:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3029738Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:02:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3031534Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:02:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3033487Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:02:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3035214Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:02:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3037144Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:02:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3038858Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:02:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3040545Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:02:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3042425Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:02:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3044272Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:02:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3046026Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:02:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3047700Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:02:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3049813Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:02:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3052584Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:03:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3054920Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:03:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3056901Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:03:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3058387Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:03:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3060237Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:03:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3062346Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:03:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3063957Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:03:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3065904Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:03:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3067632Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:03:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3069335Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:03:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3071223Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:03:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3073245Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:03:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3074973Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:04:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3076946Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:04:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3079136Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:04:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3081452Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:04:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3083582Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:04:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3085083Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:04:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3086556Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:04:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3087989Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:04:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3089493Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:04:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3091513Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:04:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3093611Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:04:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3095253Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:04:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3096881Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:05:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3098342Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:05:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3099783Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:05:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3101460Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:05:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3103304Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:05:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3104994Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:05:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3117625Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:05:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3119372Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:05:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3121074Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:05:44Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3122890Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:05:49Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3125059Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:05:54Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3127705Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:05:59Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3130170Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:06:04Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3131898Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:06:09Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3133856Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:06:14Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3135451Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:06:19Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3137344Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:06:24Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3139904Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:06:29Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3141962Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:06:34Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3143945Z     logger.go:42: 11:06:43 | ingress/1-start | [pod/kommander-bootstrap-k5nww/bootstrap] 2025-10-07T11:06:39Z	INFO	waiting for git operator statefulset	{"kommander_version": "v2.17.0-dev", "name": "git-operator-git", "namespace": "kuttl-test-still-halibut-git"}
+2025-10-07T11:06:43.3145083Z     case.go:366: failed in step 1-start
+2025-10-07T11:06:43.3145731Z     case.go:368: --- Job:kuttl-test-still-halibut/kommander-bootstrap
+2025-10-07T11:06:43.3146312Z         +++ Job:kuttl-test-still-halibut/kommander-bootstrap
+2025-10-07T11:06:43.3146712Z         @@ -1,9 +1,19 @@
+2025-10-07T11:06:43.3147043Z          apiVersion: batch/v1
+2025-10-07T11:06:43.3147363Z          kind: Job
+2025-10-07T11:06:43.3147673Z          metadata:
+2025-10-07T11:06:43.3148031Z         +  annotations:
+2025-10-07T11:06:43.3148585Z         +    kubectl.kubernetes.io/last-applied-configuration: |
+2025-10-07T11:06:43.3152361Z         +      {"apiVersion":"batch/v1","kind":"Job","metadata":{"annotations":{},"labels":{"app.kubernetes.io/part-of":"kommander-bootstrap"},"name":"kommander-bootstrap","namespace":"kuttl-test-still-halibut"},"spec":{"activeDeadlineSeconds":3628800,"backoffLimit":99999,"template":{"spec":{"containers":[{"args":["-flux-namespace=kuttl-test-still-halibut","-kommander-namespace=kuttl-test-still-halibut","-git-operator-namespace=kuttl-test-still-halibut-git","--skip-capi-cluster"],"image":"kind.local/cmd-02a858f764b6c320f56e528e7f1a7f40:1205abb557330a78faec0e7efa8857f1631c06f02d31935473b907325b0123b0","imagePullPolicy":"IfNotPresent","name":"bootstrap"}],"priorityClassName":"system-cluster-critical","restartPolicy":"OnFailure","serviceAccountName":"kommander-bootstrap"}}}}
+2025-10-07T11:06:43.3154973Z         +  labels:
+2025-10-07T11:06:43.3155344Z         +    app.kubernetes.io/part-of: kommander-bootstrap
+2025-10-07T11:06:43.3155830Z         +  managedFields: '[... elided field over 10 lines long ...]'
+2025-10-07T11:06:43.3156275Z            name: kommander-bootstrap
+2025-10-07T11:06:43.3156654Z            namespace: kuttl-test-still-halibut
+2025-10-07T11:06:43.3157064Z         +spec: '[... elided field over 10 lines long ...]'
+2025-10-07T11:06:43.3157442Z          status:
+2025-10-07T11:06:43.3157755Z         -  succeeded: 1
+2025-10-07T11:06:43.3158068Z         +  active: 1
+2025-10-07T11:06:43.3158367Z         +  ready: 1
+2025-10-07T11:06:43.3158733Z         +  startTime: "2025-10-07T10:51:42Z"
+2025-10-07T11:06:43.3159274Z            terminating: 0
+2025-10-07T11:06:43.3159675Z         +  uncountedTerminatedPods: {}
+2025-10-07T11:06:43.3160020Z          
+2025-10-07T11:06:43.3160302Z         
+2025-10-07T11:06:43.3160827Z     case.go:368: resource Job:kuttl-test-still-halibut/kommander-bootstrap: .status.succeeded: key is missing from map
+2025-10-07T11:06:43.3161840Z     logger.go:42: 11:06:43 | ingress | ingress events from ns kuttl-test-still-halibut:
+2025-10-07T11:06:43.3163104Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:42 +0000 UTC	Normal	Pod kommander-bootstrap-k5nww		Scheduled	Successfully assigned kuttl-test-still-halibut/kommander-bootstrap-k5nww to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T11:06:43.3164770Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:42 +0000 UTC	Normal	Pod kommander-bootstrap-k5nww.spec.containers{bootstrap}		Pulled	Container image "kind.local/cmd-02a858f764b6c320f56e528e7f1a7f40:1205abb557330a78faec0e7efa8857f1631c06f02d31935473b907325b0123b0" already present on machine	kubelet	
+2025-10-07T11:06:43.3166209Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:42 +0000 UTC	Normal	Pod kommander-bootstrap-k5nww.spec.containers{bootstrap}		Created	Created container bootstrap	kubelet	
+2025-10-07T11:06:43.3167234Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:42 +0000 UTC	Normal	Pod kommander-bootstrap-k5nww.spec.containers{bootstrap}		Started	Started container bootstrap	kubelet	
+2025-10-07T11:06:43.3168254Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:42 +0000 UTC	Normal	Job.batch kommander-bootstrap		SuccessfulCreate	Created pod: kommander-bootstrap-k5nww	job-controller	
+2025-10-07T11:06:43.3169515Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-rmlr2		Scheduled	Successfully assigned kuttl-test-still-halibut/flux-oci-mirror-6cbf6f6759-rmlr2 to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T11:06:43.3171083Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Warning	Pod flux-oci-mirror-6cbf6f6759-rmlr2		FailedMount	MountVolume.SetUp failed for volume "proxy-ca" : secret "flux-oci-mirror-ca-secret" not found	kubelet	
+2025-10-07T11:06:43.3172764Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	ReplicaSet.apps flux-oci-mirror-6cbf6f6759		SuccessfulCreate	Created pod: flux-oci-mirror-6cbf6f6759-rmlr2	replicaset-controller	
+2025-10-07T11:06:43.3174114Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-vault	
+2025-10-07T11:06:43.3175593Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-venafi	
+2025-10-07T11:06:43.3177066Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-selfsigned	
+2025-10-07T11:06:43.3178548Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-acme	
+2025-10-07T11:06:43.3179990Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		WaitingForApproval	Not signing CertificateRequest until it is Approved	cert-manager-certificaterequests-issuer-ca	
+2025-10-07T11:06:43.3181646Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		cert-manager.io	Certificate request has been approved by cert-manager.io	cert-manager-certificaterequests-approver	
+2025-10-07T11:06:43.3183498Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	CertificateRequest.cert-manager.io flux-oci-mirror-ca-1		CertificateIssued	Certificate fetched from issuer successfully	cert-manager-certificaterequests-issuer-selfsigned	
+2025-10-07T11:06:43.3184985Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Issuing	Issuing certificate as Secret does not exist	cert-manager-certificates-trigger	
+2025-10-07T11:06:43.3186313Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Generated	Stored new private key in temporary Secret resource "flux-oci-mirror-ca-zrjs4"	cert-manager-certificates-key-manager	
+2025-10-07T11:06:43.3187728Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Requested	Created new CertificateRequest resource "flux-oci-mirror-ca-1"	cert-manager-certificates-request-manager	
+2025-10-07T11:06:43.3189308Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Deployment.apps flux-oci-mirror		ScalingReplicaSet	Scaled up replica set flux-oci-mirror-6cbf6f6759 to 1	deployment-controller	
+2025-10-07T11:06:43.3191435Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-rzfwp		Scheduled	Successfully assigned kuttl-test-still-halibut/helm-controller-59c6d95f56-rzfwp to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T11:06:43.3193830Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	ReplicaSet.apps helm-controller-59c6d95f56		SuccessfulCreate	Created pod: helm-controller-59c6d95f56-rzfwp	replicaset-controller	
+2025-10-07T11:06:43.3195766Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Deployment.apps helm-controller		ScalingReplicaSet	Scaled up replica set helm-controller-59c6d95f56 to 1	deployment-controller	
+2025-10-07T11:06:43.3198406Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-prtgp		Scheduled	Successfully assigned kuttl-test-still-halibut/image-automation-controller-686b6755cf-prtgp to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T11:06:43.3201039Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	ReplicaSet.apps image-automation-controller-686b6755cf		SuccessfulCreate	Created pod: image-automation-controller-686b6755cf-prtgp	replicaset-controller	
+2025-10-07T11:06:43.3203488Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Deployment.apps image-automation-controller		ScalingReplicaSet	Scaled up replica set image-automation-controller-686b6755cf to 1	deployment-controller	
+2025-10-07T11:06:43.3206047Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-k8jkk		Scheduled	Successfully assigned kuttl-test-still-halibut/image-reflector-controller-844d8d4f8c-k8jkk to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T11:06:43.3208798Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	ReplicaSet.apps image-reflector-controller-844d8d4f8c		SuccessfulCreate	Created pod: image-reflector-controller-844d8d4f8c-k8jkk	replicaset-controller	
+2025-10-07T11:06:43.3211090Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Deployment.apps image-reflector-controller		ScalingReplicaSet	Scaled up replica set image-reflector-controller-844d8d4f8c to 1	deployment-controller	
+2025-10-07T11:06:43.3213714Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-mlffb		Scheduled	Successfully assigned kuttl-test-still-halibut/kustomize-controller-f957cbb99-mlffb to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T11:06:43.3216653Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	ReplicaSet.apps kustomize-controller-f957cbb99		SuccessfulCreate	Created pod: kustomize-controller-f957cbb99-mlffb	replicaset-controller	
+2025-10-07T11:06:43.3218974Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Deployment.apps kustomize-controller		ScalingReplicaSet	Scaled up replica set kustomize-controller-f957cbb99 to 1	deployment-controller	
+2025-10-07T11:06:43.3221514Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Pod notification-controller-78f9dc766-gdq47		Scheduled	Successfully assigned kuttl-test-still-halibut/notification-controller-78f9dc766-gdq47 to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T11:06:43.3223666Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	ReplicaSet.apps notification-controller-78f9dc766		SuccessfulCreate	Created pod: notification-controller-78f9dc766-gdq47	replicaset-controller	
+2025-10-07T11:06:43.3225077Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Deployment.apps notification-controller		ScalingReplicaSet	Scaled up replica set notification-controller-78f9dc766 to 1	deployment-controller	
+2025-10-07T11:06:43.3226710Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Pod source-controller-cddb46ccb-j2lgm		Scheduled	Successfully assigned kuttl-test-still-halibut/source-controller-cddb46ccb-j2lgm to bootstrap-dev-control-plane	default-scheduler	
+2025-10-07T11:06:43.3228100Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	ReplicaSet.apps source-controller-cddb46ccb		SuccessfulCreate	Created pod: source-controller-cddb46ccb-j2lgm	replicaset-controller	
+2025-10-07T11:06:43.3229323Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:43 +0000 UTC	Normal	Deployment.apps source-controller		ScalingReplicaSet	Scaled up replica set source-controller-cddb46ccb to 1	deployment-controller	
+2025-10-07T11:06:43.3230786Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-rmlr2.spec.containers{manager}		Pulled	Container image "mesosphere/flux-oci-mirror:v0.2.5" already present on machine	kubelet	
+2025-10-07T11:06:43.3232377Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-rmlr2.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T11:06:43.3233620Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod flux-oci-mirror-6cbf6f6759-rmlr2.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T11:06:43.3234887Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Certificate.cert-manager.io flux-oci-mirror-ca		Issuing	The certificate has been successfully issued	cert-manager-certificates-issuing	
+2025-10-07T11:06:43.3236599Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-rzfwp.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/helm-controller:v1.3.0" already present on machine	kubelet	
+2025-10-07T11:06:43.3238273Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-rzfwp.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T11:06:43.3239463Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod helm-controller-59c6d95f56-rzfwp.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T11:06:43.3241133Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Warning	Pod helm-controller-59c6d95f56-rzfwp.spec.containers{manager}		Unhealthy	Readiness probe failed: Get "http://10.244.0.43:9440/readyz": dial tcp 10.244.0.43:9440: connect: connection refused	kubelet	
+2025-10-07T11:06:43.3243236Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-prtgp.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/image-automation-controller:v0.41.2" already present on machine	kubelet	
+2025-10-07T11:06:43.3244819Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-prtgp.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T11:06:43.3246141Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod image-automation-controller-686b6755cf-prtgp.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T11:06:43.3247522Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-k8jkk.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/image-reflector-controller:v0.35.2" already present on machine	kubelet	
+2025-10-07T11:06:43.3248871Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-k8jkk.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T11:06:43.3250026Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod image-reflector-controller-844d8d4f8c-k8jkk.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T11:06:43.3251419Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Warning	Pod image-reflector-controller-844d8d4f8c-k8jkk.spec.containers{manager}		Unhealthy	Readiness probe failed: Get "http://10.244.0.45:9440/readyz": dial tcp 10.244.0.45:9440: connect: connection refused	kubelet	
+2025-10-07T11:06:43.3253214Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-mlffb.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/kustomize-controller:v1.6.1" already present on machine	kubelet	
+2025-10-07T11:06:43.3254494Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-mlffb.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T11:06:43.3255713Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod kustomize-controller-f957cbb99-mlffb.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T11:06:43.3257000Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod notification-controller-78f9dc766-gdq47.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/notification-controller:v1.6.0" already present on machine	kubelet	
+2025-10-07T11:06:43.3258281Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod notification-controller-78f9dc766-gdq47.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T11:06:43.3259380Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod notification-controller-78f9dc766-gdq47.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T11:06:43.3260630Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod source-controller-cddb46ccb-j2lgm.spec.containers{manager}		Pulled	Container image "ghcr.io/fluxcd/source-controller:v1.6.2" already present on machine	kubelet	
+2025-10-07T11:06:43.3261944Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod source-controller-cddb46ccb-j2lgm.spec.containers{manager}		Created	Created container manager	kubelet	
+2025-10-07T11:06:43.3263209Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:44 +0000 UTC	Normal	Pod source-controller-cddb46ccb-j2lgm.spec.containers{manager}		Started	Started container manager	kubelet	
+2025-10-07T11:06:43.3264475Z     logger.go:42: 11:06:43 | ingress | 2025-10-07 10:51:45 +0000 UTC	Warning	Pod source-controller-cddb46ccb-j2lgm.spec.containers{manager}		Unhealthy	Readiness probe failed: Get "http://10.244.0.48:9090/": dial tcp 10.244.0.48:9090: connect: connection refused	kubelet	
+2025-10-07T11:06:43.3265486Z     logger.go:42: 11:06:43 | ingress | Deleting namespace: kuttl-test-still-halibut
+2025-10-07T11:16:43.3086143Z     case.go:116: context deadline exceeded
+2025-10-07T11:16:43.3086742Z === CONT  kuttl/harness/flux-manifests
+2025-10-07T11:16:43.3111605Z     logger.go:42: 11:16:43 | flux-manifests | Creating namespace: kuttl-test-still-raccoon
+2025-10-07T11:16:43.3154999Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | starting test step 0-apply
+2025-10-07T11:16:43.3156076Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | running command: [sh -c cd ../../../bootstrapper
+2025-10-07T11:16:43.3156982Z         just flux-apply-kustomization new-namespace
+2025-10-07T11:16:43.3157609Z         ]
+2025-10-07T11:16:43.3422799Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | ++ mktemp
+2025-10-07T11:16:43.3434828Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | + export KUBECONFIG=/runner/_work/_temp/tmp.HKl4w0UyrC
+2025-10-07T11:16:43.3436094Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | + KUBECONFIG=/runner/_work/_temp/tmp.HKl4w0UyrC
+2025-10-07T11:16:43.3437156Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | + kind get kubeconfig --name bootstrap-dev
+2025-10-07T11:16:43.5090017Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | ++ mktemp -d
+2025-10-07T11:16:43.5102550Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | + KUSTOMIZE_PATH=/runner/_work/_temp/tmp.2OtuDAG3V9
+2025-10-07T11:16:43.5103708Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | + pushd /runner/_work/_temp/tmp.2OtuDAG3V9
+2025-10-07T11:16:43.5104928Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | /runner/_work/_temp/tmp.2OtuDAG3V9 /runner/_work/kommander/kommander/bootstrapper
+2025-10-07T11:16:43.5106511Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | ++ realpath --relative-to=. /runner/_work/kommander/kommander/bootstrapper/internal/fluxmanifests/manifests
+2025-10-07T11:16:43.5126666Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | + kustomize create --resources ../../kommander/kommander/bootstrapper/internal/fluxmanifests/manifests --namespace new-namespace
+2025-10-07T11:16:43.5201671Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | + popd
+2025-10-07T11:16:43.5202812Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | /runner/_work/kommander/kommander/bootstrapper
+2025-10-07T11:16:43.5204368Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | + kustomize build /runner/_work/_temp/tmp.2OtuDAG3V9
+2025-10-07T11:16:43.5205765Z     logger.go:42: 11:16:43 | flux-manifests/0-apply | + kubectl apply -f -
+2025-10-07T11:16:44.6040593Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | namespace/new-namespace created
+2025-10-07T11:16:44.6114737Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | resourcequota/critical-pods-kommander-flux created
+2025-10-07T11:16:44.6162741Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | Warning: resource customresourcedefinitions/alerts.notification.toolkit.fluxcd.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:44.6367280Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | customresourcedefinition.apiextensions.k8s.io/alerts.notification.toolkit.fluxcd.io configured
+2025-10-07T11:16:44.6517228Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | Warning: resource customresourcedefinitions/buckets.source.toolkit.fluxcd.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:44.6930985Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | customresourcedefinition.apiextensions.k8s.io/buckets.source.toolkit.fluxcd.io configured
+2025-10-07T11:16:44.6998503Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | Warning: resource customresourcedefinitions/gitrepositories.source.toolkit.fluxcd.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:44.7315659Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | customresourcedefinition.apiextensions.k8s.io/gitrepositories.source.toolkit.fluxcd.io configured
+2025-10-07T11:16:44.7358592Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | Warning: resource customresourcedefinitions/helmcharts.source.toolkit.fluxcd.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:44.7672688Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | customresourcedefinition.apiextensions.k8s.io/helmcharts.source.toolkit.fluxcd.io configured
+2025-10-07T11:16:44.7813153Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | Warning: resource customresourcedefinitions/helmreleases.helm.toolkit.fluxcd.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:44.8751941Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | customresourcedefinition.apiextensions.k8s.io/helmreleases.helm.toolkit.fluxcd.io configured
+2025-10-07T11:16:44.8897134Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | Warning: resource customresourcedefinitions/helmrepositories.source.toolkit.fluxcd.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:44.9188821Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | customresourcedefinition.apiextensions.k8s.io/helmrepositories.source.toolkit.fluxcd.io configured
+2025-10-07T11:16:44.9226342Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | Warning: resource customresourcedefinitions/imagepolicies.image.toolkit.fluxcd.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:44.9477714Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | customresourcedefinition.apiextensions.k8s.io/imagepolicies.image.toolkit.fluxcd.io configured
+2025-10-07T11:16:44.9512486Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | Warning: resource customresourcedefinitions/imagerepositories.image.toolkit.fluxcd.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:44.9819563Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | customresourcedefinition.apiextensions.k8s.io/imagerepositories.image.toolkit.fluxcd.io configured
+2025-10-07T11:16:44.9866859Z     logger.go:42: 11:16:44 | flux-manifests/0-apply | Warning: resource customresourcedefinitions/imageupdateautomations.image.toolkit.fluxcd.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:45.0093050Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | customresourcedefinition.apiextensions.k8s.io/imageupdateautomations.image.toolkit.fluxcd.io configured
+2025-10-07T11:16:45.0160342Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | Warning: resource customresourcedefinitions/kustomizations.kustomize.toolkit.fluxcd.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:45.0691783Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | customresourcedefinition.apiextensions.k8s.io/kustomizations.kustomize.toolkit.fluxcd.io configured
+2025-10-07T11:16:45.0733899Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | Warning: resource customresourcedefinitions/ocirepositories.source.toolkit.fluxcd.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:45.1024916Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | customresourcedefinition.apiextensions.k8s.io/ocirepositories.source.toolkit.fluxcd.io configured
+2025-10-07T11:16:45.1058757Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | Warning: resource customresourcedefinitions/providers.notification.toolkit.fluxcd.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:45.1319969Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | customresourcedefinition.apiextensions.k8s.io/providers.notification.toolkit.fluxcd.io configured
+2025-10-07T11:16:45.1406738Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | Warning: resource customresourcedefinitions/receivers.notification.toolkit.fluxcd.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:45.1853370Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | customresourcedefinition.apiextensions.k8s.io/receivers.notification.toolkit.fluxcd.io configured
+2025-10-07T11:16:45.1956467Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | serviceaccount/helm-controller created
+2025-10-07T11:16:45.2005799Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | serviceaccount/image-automation-controller created
+2025-10-07T11:16:45.2054184Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | serviceaccount/image-reflector-controller created
+2025-10-07T11:16:45.2121179Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | serviceaccount/kustomize-controller created
+2025-10-07T11:16:45.2169169Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | serviceaccount/notification-controller created
+2025-10-07T11:16:45.2215412Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | serviceaccount/source-controller created
+2025-10-07T11:16:45.2230060Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | Warning: resource clusterroles/crd-controller is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:45.2387070Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | clusterrole.rbac.authorization.k8s.io/crd-controller configured
+2025-10-07T11:16:45.2402476Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | Warning: resource clusterroles/crd-controller-kommander-flux is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:45.2568702Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | clusterrole.rbac.authorization.k8s.io/crd-controller-kommander-flux configured
+2025-10-07T11:16:45.2581125Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | Warning: resource clusterroles/flux-edit is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:45.2718520Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | clusterrole.rbac.authorization.k8s.io/flux-edit configured
+2025-10-07T11:16:45.2731506Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | Warning: resource clusterroles/flux-edit-kommander-flux is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:45.2888421Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | clusterrole.rbac.authorization.k8s.io/flux-edit-kommander-flux configured
+2025-10-07T11:16:45.2928552Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | Warning: resource clusterroles/flux-view is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:45.3060116Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | clusterrole.rbac.authorization.k8s.io/flux-view configured
+2025-10-07T11:16:45.3073385Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | Warning: resource clusterroles/flux-view-kommander-flux is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:45.3222733Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | clusterrole.rbac.authorization.k8s.io/flux-view-kommander-flux configured
+2025-10-07T11:16:45.3237081Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | Warning: resource clusterrolebindings/cluster-reconciler is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:45.3414684Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | clusterrolebinding.rbac.authorization.k8s.io/cluster-reconciler configured
+2025-10-07T11:16:45.3429700Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | Warning: resource clusterrolebindings/cluster-reconciler-kommander-flux is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:45.3564412Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | clusterrolebinding.rbac.authorization.k8s.io/cluster-reconciler-kommander-flux configured
+2025-10-07T11:16:45.3578542Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | Warning: resource clusterrolebindings/crd-controller is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:45.3740415Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | clusterrolebinding.rbac.authorization.k8s.io/crd-controller configured
+2025-10-07T11:16:45.3753470Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | Warning: resource clusterrolebindings/crd-controller-kommander-flux is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+2025-10-07T11:16:45.3895586Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | clusterrolebinding.rbac.authorization.k8s.io/crd-controller-kommander-flux configured
+2025-10-07T11:16:45.3955307Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | secret/flux-oci-mirror-config created
+2025-10-07T11:16:45.4046539Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | service/flux-oci-mirror created
+2025-10-07T11:16:45.4204255Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | service/notification-controller created
+2025-10-07T11:16:45.4353797Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | service/source-controller created
+2025-10-07T11:16:45.4477778Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | service/webhook-receiver created
+2025-10-07T11:16:45.4579117Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | Warning: would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "manager" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "manager" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "manager" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "manager" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
+2025-10-07T11:16:45.4581866Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | deployment.apps/flux-oci-mirror created
+2025-10-07T11:16:45.4671824Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | deployment.apps/helm-controller created
+2025-10-07T11:16:45.4837202Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | deployment.apps/image-automation-controller created
+2025-10-07T11:16:45.5018587Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | deployment.apps/image-reflector-controller created
+2025-10-07T11:16:45.5211658Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | deployment.apps/kustomize-controller created
+2025-10-07T11:16:45.5361097Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | deployment.apps/notification-controller created
+2025-10-07T11:16:45.5567086Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | deployment.apps/source-controller created
+2025-10-07T11:16:45.5746337Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | certificate.cert-manager.io/flux-oci-mirror-ca created
+2025-10-07T11:16:45.5864679Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | issuer.cert-manager.io/flux-oci-mirror-self-signed created
+2025-10-07T11:16:45.5942883Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | networkpolicy.networking.k8s.io/allow-egress created
+2025-10-07T11:16:45.6029071Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | networkpolicy.networking.k8s.io/allow-scraping created
+2025-10-07T11:16:45.6076942Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | networkpolicy.networking.k8s.io/allow-source created
+2025-10-07T11:16:45.6124484Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | networkpolicy.networking.k8s.io/allow-source-controller-oci-mirror created
+2025-10-07T11:16:45.6187324Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | networkpolicy.networking.k8s.io/allow-webhooks created
+2025-10-07T11:16:45.6230154Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | + rm -rf /runner/_work/_temp/tmp.HKl4w0UyrC
+2025-10-07T11:16:45.6246442Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | + rm -rf /runner/_work/_temp/tmp.2OtuDAG3V9
+2025-10-07T11:16:45.6263976Z     logger.go:42: 11:16:45 | flux-manifests/0-apply | cd /runner/_work/kommander/kommander/bootstrapper/internal/fluxmanifests/manifests; find . -type f ! -name "empty.yaml" -exec rm -- {} +
+2025-10-07T11:21:46.6118485Z     logger.go:42: 11:21:46 | flux-manifests/0-apply | test step failed 0-apply
+2025-10-07T11:21:46.6120182Z     logger.go:42: 11:21:46 | flux-manifests/0-apply | collecting log output for [type==pod,label: app=source-controller]
+2025-10-07T11:21:46.6122990Z     logger.go:42: 11:21:46 | flux-manifests/0-apply | running command: [kubectl logs --prefix -l app=source-controller -n kuttl-test-still-raccoon --all-containers --tail=100]
+2025-10-07T11:21:46.6584500Z     logger.go:42: 11:21:46 | flux-manifests/0-apply | No resources found in kuttl-test-still-raccoon namespace.
+2025-10-07T11:21:46.6615238Z     logger.go:42: 11:21:46 | flux-manifests/0-apply | collecting log output for [type==pod,label: app=helm-controller]
+2025-10-07T11:21:46.6616741Z     logger.go:42: 11:21:46 | flux-manifests/0-apply | running command: [kubectl logs --prefix -l app=helm-controller -n kuttl-test-still-raccoon --all-containers --tail=100]
+2025-10-07T11:21:46.7062308Z     logger.go:42: 11:21:46 | flux-manifests/0-apply | No resources found in kuttl-test-still-raccoon namespace.
+2025-10-07T11:21:46.7089555Z     logger.go:42: 11:21:46 | flux-manifests/0-apply | collecting log output for [type==pod,label: app=kustomize-controller]
+2025-10-07T11:21:46.7091494Z     logger.go:42: 11:21:46 | flux-manifests/0-apply | running command: [kubectl logs --prefix -l app=kustomize-controller -n kuttl-test-still-raccoon --all-containers --tail=100]
+2025-10-07T11:21:46.7538660Z     logger.go:42: 11:21:46 | flux-manifests/0-apply | No resources found in kuttl-test-still-raccoon namespace.
+2025-10-07T11:21:46.7563341Z     logger.go:42: 11:21:46 | flux-manifests/0-apply | collecting log output for [type==pod,label: app=notification-controller]
+2025-10-07T11:21:46.7564404Z     logger.go:42: 11:21:46 | flux-manifests/0-apply | running command: [kubectl logs --prefix -l app=notification-controller -n kuttl-test-still-raccoon --all-containers --tail=100]
+2025-10-07T11:21:46.8001538Z     logger.go:42: 11:21:46 | flux-manifests/0-apply | No resources found in kuttl-test-still-raccoon namespace.
+2025-10-07T11:21:46.8026999Z     case.go:366: failed in step 0-apply
+2025-10-07T11:21:46.8027711Z     case.go:368: --- Deployment:new-namespace/source-controller
+2025-10-07T11:21:46.8028421Z         +++ Deployment:new-namespace/source-controller
+2025-10-07T11:21:46.8029049Z         @@ -1,8 +1,25 @@
+2025-10-07T11:21:46.8029532Z          apiVersion: apps/v1
+2025-10-07T11:21:46.8030174Z          kind: Deployment
+2025-10-07T11:21:46.8030500Z          metadata:
+2025-10-07T11:21:46.8030811Z         +  annotations:
+2025-10-07T11:21:46.8031188Z         +    kubectl.kubernetes.io/last-applied-configuration: |
+2025-10-07T11:21:46.8039720Z         +      {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app.kubernetes.io/component":"source-controller","app.kubernetes.io/instance":"kommander-flux","app.kubernetes.io/managed-by":"Helm","app.kubernetes.io/part-of":"flux","app.kubernetes.io/version":"2.6.4","control-plane":"controller","helm.sh/chart":"flux2-2.16.4"},"name":"source-controller","namespace":"new-namespace"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"source-controller"}},"strategy":{"type":"Recreate"},"template":{"metadata":{"annotations":{"prometheus.io/port":"8080","prometheus.io/scrape":"true"},"labels":{"app":"source-controller"}},"spec":{"automountServiceAccountToken":true,"containers":[{"args":["--events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.","--watch-all-namespaces=true","--log-level=info","--log-encoding=json","--enable-leader-election","--storage-path=/data","--storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local."],"env":[{"name":"HTTP_PROXY","value":"${httpProxy:-\"\"}"},{"name":"HTTPS_PROXY","value":"${httpsProxy:-\"\"}"},{"name":"NO_PROXY","value":"${noProxy:=\"\"}"},{"name":"RUNTIME_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}}],"image":"ghcr.io/fluxcd/source-controller:v1.6.2","imagePullPolicy":"IfNotPresent","livenessProbe":{"httpGet":{"path":"/healthz","port":"healthz"}},"name":"manager","ports":[{"containerPort":9090,"name":"http","protocol":"TCP"},{"containerPort":8080,"name":"http-prom","protocol":"TCP"},{"containerPort":9440,"name":"healthz","protocol":"TCP"}],"readinessProbe":{"httpGet":{"path":"/","port":"http"}},"resources":{"limits":{},"requests":{"cpu":"100m","memory":"64Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}},"volumeMounts":[{"mountPath":"/data","name":"data"},{"mountPath":"/tmp","name":"tmp"}]}],"securityContext":{"fsGroup":1337},"serviceAccountName":"source-controller","terminationGracePeriodSeconds":10,"volumes":[{"emptyDir":{},"name":"data"},{"emptyDir":{},"name":"tmp"}]}}}}
+2025-10-07T11:21:46.8048963Z         +  labels:
+2025-10-07T11:21:46.8049397Z         +    app.kubernetes.io/component: source-controller
+2025-10-07T11:21:46.8049944Z         +    app.kubernetes.io/instance: kommander-flux
+2025-10-07T11:21:46.8050468Z         +    app.kubernetes.io/managed-by: Helm
+2025-10-07T11:21:46.8050863Z         +    app.kubernetes.io/part-of: flux
+2025-10-07T11:21:46.8051616Z         +    app.kubernetes.io/version: 2.6.4
+2025-10-07T11:21:46.8052343Z         +    control-plane: controller
+2025-10-07T11:21:46.8052963Z         +    helm.sh/chart: flux2-2.16.4
+2025-10-07T11:21:46.8053622Z         +  managedFields: '[... elided field over 10 lines long ...]'
+2025-10-07T11:21:46.8054349Z            name: source-controller
+2025-10-07T11:21:46.8054875Z            namespace: new-namespace
+2025-10-07T11:21:46.8055303Z         +spec: '[... elided field over 10 lines long ...]'
+2025-10-07T11:21:46.8055702Z          status:
+2025-10-07T11:21:46.8056027Z         -  readyReplicas: 1
+2025-10-07T11:21:46.8056417Z         +  conditions: '[... elided field over 10 lines long ...]'
+2025-10-07T11:21:46.8056837Z         +  observedGeneration: 1
+2025-10-07T11:21:46.8057181Z         +  replicas: 1
+2025-10-07T11:21:46.8057520Z         +  unavailableReplicas: 1
+2025-10-07T11:21:46.8058025Z         +  updatedReplicas: 1
+2025-10-07T11:21:46.8058345Z          
+2025-10-07T11:21:46.8058638Z         
+2025-10-07T11:21:46.8059167Z     case.go:368: resource Deployment:new-namespace/source-controller: .status.readyReplicas: key is missing from map
+2025-10-07T11:21:46.8060070Z     logger.go:42: 11:21:46 | flux-manifests | flux-manifests events from ns kuttl-test-still-raccoon:
+2025-10-07T11:21:46.8060813Z     logger.go:42: 11:21:46 | flux-manifests | Deleting namespace: kuttl-test-still-raccoon
+2025-10-07T11:21:52.0129040Z === NAME  kuttl
+2025-10-07T11:21:52.0129849Z     harness.go:408: run tests finished
+2025-10-07T11:21:52.0130479Z     harness.go:516: cleaning up
+2025-10-07T11:21:52.0131057Z     harness.go:573: removing temp folder: ""
+2025-10-07T11:21:52.0131660Z --- FAIL: kuttl (5738.70s)
+2025-10-07T11:21:52.0132449Z     --- FAIL: kuttl/harness (0.00s)
+2025-10-07T11:21:52.0133074Z         --- FAIL: kuttl/harness/airgapped (1515.20s)
+2025-10-07T11:21:52.0133744Z         --- FAIL: kuttl/harness/install (904.00s)
+2025-10-07T11:21:52.0134438Z         --- FAIL: kuttl/harness/skipcapicluster (1506.47s)
+2025-10-07T11:21:52.0135163Z         --- FAIL: kuttl/harness/ingress (1504.30s)
+2025-10-07T11:21:52.0135817Z         --- FAIL: kuttl/harness/flux-manifests (308.70s)
+2025-10-07T11:21:52.0136429Z FAIL
+2025-10-07T11:21:52.0164262Z error: Recipe `bootstrap-test` failed with exit code 1
+2025-10-07T11:21:52.0173114Z Error: error running script "just" in Devbox: exit status 1
+2025-10-07T11:21:52.0173615Z 
+2025-10-07T11:21:52.0217272Z ##[error]Process completed with exit code 1.
+2025-10-07T11:21:52.0347778Z Post job cleanup.
+2025-10-07T11:21:52.0389992Z Post job cleanup.
+2025-10-07T11:21:52.0416536Z Post job cleanup.
+2025-10-07T11:21:52.1559578Z [command]/usr/local/bin/docker logout https://docker-proxy.devprod-production.d2iq.cloud
+2025-10-07T11:21:52.1704028Z Removing login credentials for docker-proxy.devprod-production.d2iq.cloud
+2025-10-07T11:21:52.1833438Z Post job cleanup.
+2025-10-07T11:21:52.2920576Z [command]/usr/local/bin/docker logout 
+2025-10-07T11:21:52.3082973Z Removing login credentials for https://index.docker.io/v1/
+2025-10-07T11:21:52.3230743Z Post job cleanup.
+2025-10-07T11:21:52.4241668Z [command]/usr/bin/git version
+2025-10-07T11:21:52.4277737Z git version 2.43.2
+2025-10-07T11:21:52.4313040Z Copying '/home/runner/.gitconfig' to '/runner/_work/_temp/72bfb029-6eb5-4fe5-b8da-462d2e9dc02e/.gitconfig'
+2025-10-07T11:21:52.4323984Z Temporarily overriding HOME='/runner/_work/_temp/72bfb029-6eb5-4fe5-b8da-462d2e9dc02e' before making global git config changes
+2025-10-07T11:21:52.4324961Z Adding repository directory to the temporary git global config as a safe directory
+2025-10-07T11:21:52.4337334Z [command]/usr/bin/git config --global --add safe.directory /runner/_work/kommander/kommander
+2025-10-07T11:21:52.4383543Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-10-07T11:21:52.4416093Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-10-07T11:21:52.4726988Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-10-07T11:21:52.4752700Z http.https://github.com/.extraheader
+2025-10-07T11:21:52.4765215Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2025-10-07T11:21:52.4796949Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-10-07T11:21:52.5216835Z Post job cleanup.
+2025-10-07T11:21:52.6247486Z Token expired, skipping token revocation
+2025-10-07T11:21:52.6400324Z Post job cleanup.
+2025-10-07T11:21:52.7347276Z Token expired, skipping token revocation
+2025-10-07T11:21:52.7427099Z A job completed hook has been configured by the self-hosted runner administrator
+2025-10-07T11:21:52.7457751Z ##[group]Run '/etc/arc/hooks/job-completed.sh'
+2025-10-07T11:21:52.7472997Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2025-10-07T11:21:52.7473469Z ##[endgroup]
+2025-10-07T11:21:52.7564491Z [0;37m2025-10-07 11:21:52.755  DEBUG --- Running ARC Job Completed Hooks[0m
+2025-10-07T11:21:52.7585961Z [0;37m2025-10-07 11:21:52.758  DEBUG --- Running hook: /etc/arc/hooks/job-completed.d/update-status[0m
+2025-10-07T11:21:52.7671842Z Cleaning up orphan processes


### PR DESCRIPTION
**What problem does this PR solve?**:
A `kuttl` test is failing because the `kommander-operator` HelmRelease is not reaching a `Ready` state, leading to a timeout. The underlying cause appears to be a stalled reconciliation of the HelmRelease rather than an explicit Helm installation error.

**Which issue(s) does this PR fix?**:
N/A

**Special notes for your reviewer**:
The log analysis indicates that while core Flux components and related sources (cert-manager, flux-oci-mirror) are coming up, the `kommander-operator` HelmRelease itself is not progressing to a `Ready` state. There are no explicit Helm installation errors in the provided logs, suggesting a dependency issue or a condition that is not being met for the HelmRelease to become ready.

To investigate further, focus on:
*   Verifying the readiness of `HelmRepository/OCIRepository` or `GitRepository` sources for `kommander-operator`.
*   Checking OCI registry accessibility and credentials if applicable.
*   Inspecting the `status.conditions` of the `HelmRelease/kommander-operator` and its corresponding Helm release history (`kubectl -n <ns> get hr kommander-operator -o yaml`, `kubectl -n <ns> describe hr kommander-operator`, `kubectl -n <ns> get events --sort-by=.lastTimestamp`).
*   Reviewing logs for `helm-controller` and `kustomize-controller` in the Flux namespace.
*   Ensuring all required CRDs, namespaces, Secrets, or ConfigMaps that `kommander-operator` depends on are created and available.

**Does this PR introduce a user-facing change?**:
```release-note
No. This PR is an analysis of a CI/CD log to diagnose a deployment issue.
```

**Checklist**
- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).

---
<a href="https://cursor.com/background-agent?bcId=bc-73ad7a40-82fa-4ee2-a2fd-9b67d9ada406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-73ad7a40-82fa-4ee2-a2fd-9b67d9ada406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

