### PR TITLE
feat: add AMD GPU applications for NKP catalog

### DIFF
--- a/.github/app-labeler.yaml
+++ b/.github/app-labeler.yaml
@@ -162,6 +162,18 @@ applications/nkp-pulse-workspace:
 - changed-files:
   - any-glob-to-any-file:
     - applications/nkp-pulse-workspace/**
+applications/amd-device-metrics-exporter:
+- changed-files:
+  - any-glob-to-any-file:
+    - applications/amd-device-metrics-exporter/**
+applications/amd-gpu-operator:
+- changed-files:
+  - any-glob-to-any-file:
+    - applications/amd-gpu-operator/**
+applications/amd-network-operator:
+- changed-files:
+  - any-glob-to-any-file:
+    - applications/amd-network-operator/**
 applications/nvidia-gpu-operator:
 - changed-files:
   - any-glob-to-any-file:

--- a/.github/app-pr-labeler.yaml
+++ b/.github/app-pr-labeler.yaml
@@ -12,6 +12,9 @@ open-kommander-pr:
     - applications/kube-oidc-proxy/**
     - applications/kube-prometheus-stack/**
     - applications/logging-operator/**
+    - applications/amd-device-metrics-exporter/**
+    - applications/amd-gpu-operator/**
+    - applications/amd-network-operator/**
     - applications/nvidia-gpu-operator/**
     - applications/project-grafana-logging/**
     - applications/project-grafana-loki/**
@@ -39,6 +42,9 @@ do-not-merge/testing:
     - applications/kube-oidc-proxy/**
     - applications/kube-prometheus-stack/**
     - applications/logging-operator/**
+    - applications/amd-device-metrics-exporter/**
+    - applications/amd-gpu-operator/**
+    - applications/amd-network-operator/**
     - applications/nvidia-gpu-operator/**
     - applications/project-grafana-logging/**
     - applications/project-grafana-loki/**

--- a/applications/amd-device-metrics-exporter/1.4.2/README.md
+++ b/applications/amd-device-metrics-exporter/1.4.2/README.md
@@ -1,0 +1,51 @@
+# AMD Device Metrics Exporter
+
+This application deploys the **AMD Device Metrics Exporter** on Kubernetes via Flux (HelmRepository + HelmRelease), using the official ROCm Helm chart.
+
+## Overview
+
+The AMD Device Metrics Exporter collects telemetry from **AMD GPUs** (and optionally **NICs**) and exposes it in **Prometheus** format:
+
+- Temperature, utilization, memory usage, power consumption
+- PCIe bandwidth and other performance metrics
+- Optional **ServiceMonitor** integration for Prometheus Operator
+- **DRA (Dynamic Resource Allocation)** claim association on Kubernetes 1.34+ (beta)
+
+It can run standalone (e.g. for clusters that already have the device plugin or GPU Operator elsewhere) or alongside the AMD GPU Operator. The GPU Operator can also embed metrics via its DeviceConfig; this app provides a dedicated deployment of the exporter with its own Helm values.
+
+## Documentation
+
+| Resource | Link |
+|----------|------|
+| **Installation (Helm)** | [Kubernetes (Helm) installation — AMD Device Metrics Exporter](https://instinct.docs.amd.com/projects/device-metrics-exporter/en/latest/installation/kubernetes-helm.html) |
+| **Prometheus / Grafana** | [Prometheus and Grafana integration](https://instinct.docs.amd.com/projects/device-metrics-exporter/en/latest/integrations/prometheus-grafana.html) |
+| **Configuration** | [Configuration](https://instinct.docs.amd.com/projects/device-metrics-exporter/en/latest/configuration/) (values, ConfigMap, DRA) |
+| **Troubleshooting** | [Troubleshooting Device Metrics Exporter](https://instinct.docs.amd.com/projects/device-metrics-exporter/en/latest/configuration/troubleshooting.html) |
+| **GitHub** | [ROCm/device-metrics-exporter](https://github.com/ROCm/device-metrics-exporter) |
+
+## Prerequisites
+
+- Nutanix Kubernetes Platform v2.17.0+ Kubernetes cluster
+- **ROCm** stack on GPU nodes (e.g. via AMD GPU Operator or pre-installed)
+- Ubuntu **22.04 or later** on nodes where the exporter runs
+- For DRA: Kubernetes **1.34+** and [AMD GPU DRA driver](https://github.com/ROCm/k8s-gpu-dra-driver) if using DRA claims (Experimental. Not recommended for Production use)
+
+## How This App Deploys It
+
+- **Helm repository:** `https://rocm.github.io/device-metrics-exporter`
+- **Chart:** `device-metrics-exporter-charts`
+- **Version:** `v1.4.2`
+- **Release name:** `amd-device-metrics-exporter`
+- **Target namespace:** Workspace release namespace (`releaseNamespace`)
+
+Defaults in the app enable **GPU** monitoring and **ServiceMonitor** with `prometheus.kommander.d2iq.io/select: "true"` for Kommander Prometheus. NIC monitoring is disabled by default; set `monitor.resources.nic: true` in values if needed.
+
+## Configuration
+
+- **platform:** `k8s` (default)
+- **monitor.resources.gpu** / **monitor.resources.nic** – Enable GPU and/or NIC metrics.
+- **image.repository** / **image.tag** – Exporter image (default `docker.io/rocm/device-metrics-exporter:v1.4.2`).
+- **service.type** – `ClusterIP` or `NodePort`.
+- **serviceMonitor** – Interval, labels, relabelings for Prometheus Operator (defaults include Kommander scrape label).
+
+Override via the app’s ConfigMap or your platform’s override mechanism. See [Kubernetes (Helm) installation](https://instinct.docs.amd.com/projects/device-metrics-exporter/en/latest/installation/kubernetes-helm.html) for the full values schema.

--- a/applications/amd-device-metrics-exporter/1.4.2/helmrelease.yaml
+++ b/applications/amd-device-metrics-exporter/1.4.2/helmrelease.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: amd-device-metrics-exporter-helmrelease
+  namespace: ${releaseNamespace}
+spec:
+  force: false
+  prune: true
+  wait: true
+  interval: 6h
+  retryInterval: 1m
+  path: ./applications/amd-device-metrics-exporter/1.4.2/helmrelease
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 1m
+  postBuild:
+    substitute:
+      appVersion: ${appVersion}
+      releaseName: ${releaseName}
+      releaseNamespace: ${releaseNamespace}

--- a/applications/amd-device-metrics-exporter/1.4.2/helmrelease/amd-device-metrics-exporter.yaml
+++ b/applications/amd-device-metrics-exporter/1.4.2/helmrelease/amd-device-metrics-exporter.yaml
@@ -1,0 +1,56 @@
+---
+# OCIRepository for AMD Device Metrics Exporter chart (push via docs/AMD_OCI_PUSH_STEPS.md)
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ${releaseName}-${appVersion}-chart
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: "oci://ghcr.io/mesosphere/charts/device-metrics-exporter-charts"
+  ref:
+    tag: v1.4.2
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: amd-device-metrics-exporter
+  namespace: ${releaseNamespace}
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: ${releaseName}-${appVersion}-chart
+    namespace: ${releaseNamespace}
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: amd-device-metrics-exporter
+  valuesFrom:
+    - kind: ConfigMap
+      name: ${releaseName}-${appVersion}-config-defaults
+  targetNamespace: ${releaseNamespace}
+  postRenderers:
+    - kustomize:
+        # Fix upstream chart bug: Service template uses nindent 2 so "app" ends up at metadata
+        # level instead of metadata.labels. Validation error (nkp-catalog-cli validate):
+        #   v1/Service amd-device-metrics-exporter-amd-metrics-exporter-svc: problem validating
+        #   schema - at '/metadata': additional properties 'app' not allowed (strict K8s schema).
+        # Chart: github.com/ROCm/device-metrics-exporter helm-charts/templates/
+        #   metrics-exporter-service.yaml
+        # No open upstream issue as of 2026-02.
+        # Fix: move metadata.app -> metadata.labels.app so "app" is a valid label.
+        patches:
+          - patch: |
+              - op: add
+                path: /metadata/labels
+                value: {}
+              - op: move
+                from: /metadata/app
+                path: /metadata/labels/app
+            target:
+              kind: Service
+              name: amd-device-metrics-exporter-amd-metrics-exporter-svc

--- a/applications/amd-device-metrics-exporter/1.4.2/helmrelease/cm.yaml
+++ b/applications/amd-device-metrics-exporter/1.4.2/helmrelease/cm.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${releaseName}-${appVersion}-config-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    # Default values for AMD Device Metrics Exporter.
+    # See https://github.com/ROCm/device-metrics-exporter for full options.
+    platform: k8s
+    monitor:
+      resources:
+        gpu: true
+        nic: false
+    image:
+      repository: docker.io/rocm/device-metrics-exporter
+      tag: v1.4.2
+      pullPolicy: Always
+    service:
+      type: ClusterIP
+    serviceMonitor:
+      enabled: true
+      interval: "30s"
+      additionalLabels:
+        prometheus.kommander.d2iq.io/select: "true"

--- a/applications/amd-device-metrics-exporter/1.4.2/helmrelease/kustomization.yaml
+++ b/applications/amd-device-metrics-exporter/1.4.2/helmrelease/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml
+  - amd-device-metrics-exporter.yaml

--- a/applications/amd-device-metrics-exporter/1.4.2/kustomization.yaml
+++ b/applications/amd-device-metrics-exporter/1.4.2/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/applications/amd-device-metrics-exporter/1.4.2/metadata.yaml
+++ b/applications/amd-device-metrics-exporter/1.4.2/metadata.yaml
@@ -1,0 +1,32 @@
+schema: "catalog.nkp.nutanix.com/v1/application-metadata"
+displayName: AMD Device Metrics Exporter
+description: Exports Prometheus-format metrics from AMD GPUs (and optionally NICs) for monitoring in HPC and AI environments.
+category:
+  - general
+type: nkp-core-platform
+allowMultipleInstances: false
+scope:
+  - workspace
+licensing:
+  - Pro
+  - Ultimate
+certifications:
+  - qualified
+overview: |-
+  # Overview
+  AMD Device Metrics Exporter collects telemetry from AMD devices (GPUs and optionally NICs) and exposes it in Prometheus format for integration with monitoring stacks such as Prometheus and Grafana.
+
+  ## Key Features
+  ### GPU and NIC Metrics
+  Configurable monitoring for AMD GPUs and optionally AMD NICs, with metrics suitable for HPC and AI workloads.
+
+  ### Prometheus Integration
+  Native Prometheus format output with optional ServiceMonitor support for seamless integration with Prometheus Operator.
+
+  ### Kubernetes Native
+  Helm-based deployment with DRA (Dynamic Resource Allocation) claim association on Kubernetes 1.34+.
+
+  ## More Information
+  - [AMD Device Metrics Exporter - Kubernetes (Helm)](https://instinct.docs.amd.com/projects/device-metrics-exporter/en/latest/installation/kubernetes-helm.html)
+  - [AMD Device Metrics Exporter - GitHub](https://github.com/ROCm/device-metrics-exporter)
+icon: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMDAiIGhlaWdodD0iMzAwIiB2aWV3Qm94PSIwIDAgMzAwIDMwMCI+PHJlY3Qgd2lkdGg9IjMwMCIgaGVpZ2h0PSIzMDAiIHJ4PSIxNiIgZmlsbD0iI0VEMUMyNCIvPjxnIGZpbGw9IndoaXRlIj48cmVjdCB4PSI5MCIgeT0iMTkwIiB3aWR0aD0iMzUiIGhlaWdodD0iNTAiIHJ4PSI0Ii8+PHJlY3QgeD0iMTMyIiB5PSIxNTAiIHdpZHRoPSIzNSIgaGVpZ2h0PSI5MCIgcng9IjQiLz48cmVjdCB4PSIxNzUiIHk9IjExMCIgd2lkdGg9IjM1IiBoZWlnaHQ9IjEzMCIgcng9IjQiLz48L2c+PC9zdmc+

--- a/applications/amd-gpu-operator/1.4.1/README.md
+++ b/applications/amd-gpu-operator/1.4.1/README.md
@@ -1,0 +1,56 @@
+# AMD GPU Operator
+
+This application deploys the **AMD GPU Operator** on Kubernetes via Flux (HelmRepository + HelmRelease), using the official ROCm Helm chart.
+
+## Overview
+
+The AMD GPU Operator automates the management of AMD software components needed to provision GPU nodes:
+
+- **Node Feature Discovery (NFD)** – Detects AMD GPU hardware and labels nodes (e.g. `feature.node.kubernetes.io/amd-gpu=true`).
+- **Kernel Module Management (KMM)** – Optional out-of-tree AMD GPU driver installation and lifecycle.
+- **Device plugin** – Exposes `amd.com/gpu` as a schedulable resource.
+- **Device Config Manager (DCM)** – GPU partitioning and configuration.
+- **Metrics** – Optional device metrics exporter integration.
+
+You can use **inbox or pre-installed drivers** (`spec.driver.enable: false` in DeviceConfig) or let the operator install **out-of-tree drivers** via KMM.
+
+## Documentation
+
+| Resource | Link |
+|----------|------|
+| **Installation (Helm)** | [Kubernetes (Helm) — AMD GPU Operator](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/kubernetes-helm.html) |
+| **Release notes** | [Release Notes](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/release_notes.html) |
+| **Full config reference** | [Full Reference Config](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/full_reference_config.html) |
+| **DeviceConfig / CRDs** | [Custom Resource Installation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/kubernetes-helm.html#install-custom-resource) |
+| **Troubleshooting** | [Troubleshooting](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/troubleshooting.html) |
+| **Uninstall** | [Uninstallation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/uninstallation/uninstallation.html) |
+| **GitHub** | [ROCm/gpu-operator](https://github.com/ROCm/gpu-operator) |
+
+## Prerequisites
+
+- Kubernetes cluster **v1.29.0 or later**
+- Helm **v3.2.0 or later** (for catalog/Flux tooling)
+- **cert-manager** installed (required for TLS; the operator uses it for webhooks)
+- Worker nodes with **AMD GPUs**
+- CNI and system pods healthy
+
+## How This App Deploys It
+
+- **Helm repository:** `https://rocm.github.io/gpu-operator`
+- **Chart:** `gpu-operator-charts`
+- **Version:** `v1.4.1`
+- **Release name:** `amd-gpu-operator`
+- **Target namespace:** Workspace release namespace (`releaseNamespace`)
+
+Default values (ConfigMap) can enable the default DeviceConfig (`crds.defaultCR.install: true`). After install, create or edit a `DeviceConfig` in the operator namespace to select nodes (e.g. `selector: feature.node.kubernetes.io/amd-gpu: "true"`) and choose driver strategy (inbox vs out-of-tree).
+
+## Configuration
+
+- Override defaults via the app’s ConfigMap or your platform’s override mechanism.
+- Key chart options: `node-feature-discovery.enabled`, `kmm.enabled`, `crds.defaultCR.install`, and sub-chart values (see [Helm chart customization](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/kubernetes-helm.html#helm-chart-customization-parameters)).
+- For **inbox/pre-installed drivers**, set `spec.driver.enable: false` in your DeviceConfig.
+- For **out-of-tree drivers**, set `spec.driver.enable: true` and `spec.driver.blacklist: true` (and reboot nodes as per AMD docs).
+
+## Installing With AMD Network Operator
+
+If you install both AMD GPU Operator and AMD Network Operator on the same cluster, follow AMD’s combined guide to avoid duplicate NFD/KMM and version conflicts: [Installation of GPU Operator and Network Operator together](https://instinct.docs.amd.com/projects/network-operator/en/main/installation/kubernetes-helm-operators.html).

--- a/applications/amd-gpu-operator/1.4.1/helmrelease.yaml
+++ b/applications/amd-gpu-operator/1.4.1/helmrelease.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: amd-gpu-operator-helmrelease
+  namespace: ${releaseNamespace}
+spec:
+  force: false
+  prune: true
+  wait: true
+  interval: 6h
+  retryInterval: 1m
+  path: ./applications/amd-gpu-operator/1.4.1/helmrelease
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 1m
+  postBuild:
+    substitute:
+      appVersion: ${appVersion}
+      releaseName: ${releaseName}
+      releaseNamespace: ${releaseNamespace}

--- a/applications/amd-gpu-operator/1.4.1/helmrelease/amd-gpu-operator.yaml
+++ b/applications/amd-gpu-operator/1.4.1/helmrelease/amd-gpu-operator.yaml
@@ -1,0 +1,37 @@
+---
+# OCIRepository for AMD GPU Operator chart (push via docs/AMD_OCI_PUSH_STEPS.md)
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ${releaseName}-${appVersion}-chart
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: "oci://ghcr.io/mesosphere/charts/gpu-operator-charts"
+  ref:
+    tag: v1.4.1
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: amd-gpu-operator
+  namespace: ${releaseNamespace}
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: ${releaseName}-${appVersion}-chart
+    namespace: ${releaseNamespace}
+  interval: 15s
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+  releaseName: amd-gpu-operator
+  valuesFrom:
+    - kind: ConfigMap
+      name: ${releaseName}-${appVersion}-config-defaults
+  targetNamespace: ${releaseNamespace}

--- a/applications/amd-gpu-operator/1.4.1/helmrelease/cm.yaml
+++ b/applications/amd-gpu-operator/1.4.1/helmrelease/cm.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${releaseName}-${appVersion}-config-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    # Default values for AMD GPU Operator (rocm/gpu-operator-charts).
+    # See https://github.com/ROCm/gpu-operator for full options.
+    # targetNamespace is set via HelmRelease targetNamespace (releaseNamespace).
+    crds:
+      defaultCR:
+        install: true

--- a/applications/amd-gpu-operator/1.4.1/helmrelease/kustomization.yaml
+++ b/applications/amd-gpu-operator/1.4.1/helmrelease/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml
+  - amd-gpu-operator.yaml

--- a/applications/amd-gpu-operator/1.4.1/kustomization.yaml
+++ b/applications/amd-gpu-operator/1.4.1/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/applications/amd-gpu-operator/1.4.1/metadata.yaml
+++ b/applications/amd-gpu-operator/1.4.1/metadata.yaml
@@ -1,0 +1,32 @@
+schema: "catalog.nkp.nutanix.com/v1/application-metadata"
+displayName: AMD GPU Operator
+description: The AMD GPU Operator manages AMD GPU resources in a Kubernetes cluster and automates tasks related to bootstrapping GPU nodes (drivers, device plugin, NFD, KMM, metrics).
+category:
+  - general
+type: nkp-core-platform
+allowMultipleInstances: false
+scope:
+  - workspace
+licensing:
+  - Pro
+  - Ultimate
+certifications:
+  - qualified
+overview: |-
+  # Overview
+  The AMD GPU Operator uses the operator framework within Kubernetes to automate the management of AMD software components needed to provision GPUs.
+
+  ## Key Features
+  ### Automated GPU Node Bootstrap
+  Manages drivers, device plugin, Node Feature Discovery (NFD), and Kernel Module Manager (KMM) for AMD GPU nodes.
+
+  ### Kubernetes Native
+  Integrates with Kubernetes device plugin API and supports out-of-tree AMD GPU drivers via KMM.
+
+  ### Metrics Integration
+  Includes metrics exporter for Prometheus monitoring of GPU resources.
+
+  ## More Information
+  - [AMD GPU Operator - Kubernetes (Helm)](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/kubernetes-helm.html)
+  - [AMD GPU Operator - GitHub](https://github.com/ROCm/gpu-operator)
+icon: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMDAiIGhlaWdodD0iMzAwIiB2aWV3Qm94PSIwIDAgMzAwIDMwMCI+PHJlY3Qgd2lkdGg9IjMwMCIgaGVpZ2h0PSIzMDAiIHJ4PSIxNiIgZmlsbD0iI0VEMUMyNCIvPjxnIGZpbGw9IndoaXRlIj48cmVjdCB4PSI3MCIgeT0iODAiIHdpZHRoPSIxNjAiIGhlaWdodD0iMTQwIiByeD0iOCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSI2Ii8+PHJlY3QgeD0iOTAiIHk9IjEwMCIgd2lkdGg9IjQwIiBoZWlnaHQ9IjMwIiByeD0iNCIvPjxyZWN0IHg9IjE3MCIgeT0iMTAwIiB3aWR0aD0iNDAiIGhlaWdodD0iMzAiIHJ4PSI0Ii8+PHJlY3QgeD0iOTAiIHk9IjE1MCIgd2lkdGg9IjEyMCIgaGVpZ2h0PSI1MCIgcng9IjQiLz48L2c+PC9zdmc+

--- a/applications/amd-network-operator/1.0.0/README.md
+++ b/applications/amd-network-operator/1.0.0/README.md
@@ -1,0 +1,54 @@
+# AMD Network Operator
+
+This application deploys the **AMD Network Operator** on Kubernetes via Flux (HelmRepository + HelmRelease), using the official ROCm Helm chart.
+
+## Overview
+
+The AMD Network Operator simplifies deployment and management of **AMD AI NICs (AINICs)** in Kubernetes:
+
+- **Node Feature Discovery (NFD)** – Detects AMD NIC hardware and labels nodes (e.g. `feature.node.kubernetes.io/amd-nic=true`).
+- **Kernel Module Management (KMM)** – Driver and firmware lifecycle for AMD NICs.
+- **Multus** – Optional multi-network support.
+- **NIC device plugin / resources** – Exposes AMD NIC resources (e.g. `amd.com/nic`, `amd.com/vnic`) for workloads.
+- **Metrics** – Prometheus-compatible metrics for NIC health and utilization.
+
+It is designed to work alongside the **AMD GPU Operator** for high-performance networking in AI/ML and HPC clusters.
+
+## Documentation
+
+| Resource | Link |
+|----------|------|
+| **Installation (Helm)** | [Kubernetes (Helm) — Network Operator](https://instinct.docs.amd.com/projects/network-operator/en/main/installation/kubernetes-helm.html) |
+| **NetworkConfig CRD** | [Custom Resource Installation / NetworkConfig](https://instinct.docs.amd.com/projects/network-operator/en/main/installation/networkconfig.html) |
+| **Helm chart parameters** | [Helm Chart Customization Parameters](https://instinct.docs.amd.com/projects/network-operator/en/main/installation/kubernetes-helm.html#helm-chart-customization-parameters) (and `helm show values rocm-network/network-operator-charts`) |
+| **Workload example** | [Test a Workload Deployment](https://instinct.docs.amd.com/projects/network-operator/en/main/installation/workload.html) |
+| **Troubleshooting** | [Troubleshooting](https://instinct.docs.amd.com/projects/network-operator/en/main/troubleshooting.html) |
+| **Uninstall** | [Uninstallation](https://instinct.docs.amd.com/projects/network-operator/en/main/uninstallation/uninstallation.html) |
+| **GitHub** | [ROCm/network-operator](https://github.com/ROCm/network-operator) |
+
+## Prerequisites
+
+- Kubernetes cluster **v1.29.0 or later**
+- Helm **v3.2.0 or later** (for catalog/Flux tooling)
+- **cert-manager** installed (required for TLS)
+- Worker nodes with **AMD NICs** (e.g. AMD Pensando Pollara AI NIC)
+- CNI and system pods healthy
+
+## How This App Deploys It
+
+- **Helm repository:** `https://rocm.github.io/network-operator`
+- **Chart:** `network-operator-charts`
+- **Version:** `v1.0.0`
+- **Release name:** `amd-network-operator`
+- **Target namespace:** Workspace release namespace (`releaseNamespace`)
+
+After the operator is installed, create a **NetworkConfig** custom resource in the operator namespace so the operator can manage NICs (driver install, device plugin, etc.). See the [NetworkConfig guide](https://instinct.docs.amd.com/projects/network-operator/en/main/installation/networkconfig.html) for examples.
+
+## Configuration
+
+- Override defaults via the app’s ConfigMap or your platform’s override mechanism.
+- Common options: `node-feature-discovery.enabled`, `kmm.enabled`, `multus.enabled`, `installdefaultNFDRule`, and controller resource limits (see [Resource Configuration](https://instinct.docs.amd.com/projects/network-operator/en/main/installation/kubernetes-helm.html#resource-configuration)).
+
+## Installing With AMD GPU Operator
+
+If both AMD GPU Operator and AMD Network Operator run on the same cluster, use AMD’s combined installation guide to align NFD/KMM and avoid conflicts: [Installation of GPU Operator and Network Operator together](https://instinct.docs.amd.com/projects/network-operator/en/main/installation/kubernetes-helm-operators.html).

--- a/applications/amd-network-operator/1.0.0/helmrelease.yaml
+++ b/applications/amd-network-operator/1.0.0/helmrelease.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: amd-network-operator-helmrelease
+  namespace: ${releaseNamespace}
+spec:
+  force: false
+  prune: true
+  wait: true
+  interval: 6h
+  retryInterval: 1m
+  path: ./applications/amd-network-operator/1.0.0/helmrelease
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  timeout: 1m
+  postBuild:
+    substitute:
+      appVersion: ${appVersion}
+      releaseName: ${releaseName}
+      releaseNamespace: ${releaseNamespace}

--- a/applications/amd-network-operator/1.0.0/helmrelease/amd-network-operator.yaml
+++ b/applications/amd-network-operator/1.0.0/helmrelease/amd-network-operator.yaml
@@ -1,0 +1,37 @@
+---
+# OCIRepository for AMD Network Operator chart (push via docs/AMD_OCI_PUSH_STEPS.md)
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ${releaseName}-${appVersion}-chart
+  namespace: ${releaseNamespace}
+spec:
+  interval: 1m
+  url: "oci://ghcr.io/mesosphere/charts/network-operator-charts"
+  ref:
+    tag: v1.0.0
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: amd-network-operator
+  namespace: ${releaseNamespace}
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: ${releaseName}-${appVersion}-chart
+    namespace: ${releaseNamespace}
+  interval: 15s
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 30
+  releaseName: amd-network-operator
+  valuesFrom:
+    - kind: ConfigMap
+      name: ${releaseName}-${appVersion}-config-defaults
+  targetNamespace: ${releaseNamespace}

--- a/applications/amd-network-operator/1.0.0/helmrelease/cm.yaml
+++ b/applications/amd-network-operator/1.0.0/helmrelease/cm.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${releaseName}-${appVersion}-config-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    # Default values for AMD Network Operator (rocm-network/network-operator-charts).
+    # See https://github.com/ROCm/network-operator for full options.

--- a/applications/amd-network-operator/1.0.0/helmrelease/kustomization.yaml
+++ b/applications/amd-network-operator/1.0.0/helmrelease/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml
+  - amd-network-operator.yaml

--- a/applications/amd-network-operator/1.0.0/kustomization.yaml
+++ b/applications/amd-network-operator/1.0.0/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/applications/amd-network-operator/1.0.0/metadata.yaml
+++ b/applications/amd-network-operator/1.0.0/metadata.yaml
@@ -1,0 +1,22 @@
+schema: "catalog.nkp.nutanix.com/v1/application-metadata"
+displayName: AMD Network Operator
+description: The AMD Network Operator simplifies deployment and management of AMD AI NICs (AINICs) in Kubernetes and works with the AMD GPU Operator for high-performance networking in AI/ML and HPC workloads.
+category:
+  - general
+type: nkp-core-platform
+allowMultipleInstances: false
+scope:
+  - workspace
+licensing:
+  - Pro
+  - Ultimate
+certifications:
+  - qualified
+overview: |-
+  # Overview
+  The AMD Network Operator automates NIC discovery and driver management for AMD AI NICs (e.g. AMD Pensando Pollara), with RDMA/RoCE support, Prometheus metrics, and dynamic resource allocation. It can be installed alongside the AMD GPU Operator on the same cluster.
+
+  ## More Information
+  - [AMD Network Operator - Kubernetes (Helm)](https://instinct.docs.amd.com/projects/network-operator/en/main/installation/kubernetes-helm.html)
+  - [AMD Network Operator - GitHub](https://github.com/ROCm/network-operator)
+icon: ""

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -559,6 +559,51 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag}
         url: https://github.com/NVIDIA/k8s-driver-manager
+  - container_image: docker.io/rocm/device-metrics-exporter:v1.4.2
+    sources:
+      - license_path: LICENSE
+        ref: ${image_tag}
+        url: https://github.com/ROCm/device-metrics-exporter
+  - container_image: docker.io/rocm/gpu-operator:v1.4.1
+    sources:
+      - license_path: LICENSE
+        ref: ${image_tag}
+        url: https://github.com/ROCm/gpu-operator
+  - container_image: docker.io/rocm/kernel-module-management-operator:v1.4.0
+    sources:
+      - license_path: LICENSE
+        ref: ${image_tag}
+        url: https://github.com/kubernetes-sigs/kernel-module-management
+  - container_image: docker.io/rocm/kernel-module-management-operator:v1.4.1
+    sources:
+      - license_path: LICENSE
+        ref: ${image_tag}
+        url: https://github.com/kubernetes-sigs/kernel-module-management
+  - container_image: docker.io/rocm/kernel-module-management-webhook-server:v1.4.0
+    sources:
+      - license_path: LICENSE
+        ref: ${image_tag}
+        url: https://github.com/kubernetes-sigs/kernel-module-management
+  - container_image: docker.io/rocm/kernel-module-management-webhook-server:v1.4.1
+    sources:
+      - license_path: LICENSE
+        ref: ${image_tag}
+        url: https://github.com/kubernetes-sigs/kernel-module-management
+  - container_image: docker.io/rocm/network-operator:v1.0.0
+    sources:
+      - license_path: LICENSE
+        ref: ${image_tag}
+        url: https://github.com/ROCm/network-operator
+  - container_image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.2
+    sources:
+      - license_path: LICENSE
+        ref: ${image_tag}
+        url: https://github.com/k8snetworkplumbingwg/multus-cni
+  - container_image: registry.k8s.io/nfd/node-feature-discovery:v0.16.1
+    sources:
+      - license_path: LICENSE
+        ref: ${image_tag}
+        url: https://github.com/kubernetes-sigs/node-feature-discovery
   - container_image: quay.io/ceph/ceph:v19.2.2
     sources:
       - license_path: COPYING
@@ -711,6 +756,11 @@ resources:
     sources:
       - url: https://github.com/mirror/busybox
         ref: master
+        license_path: LICENSE
+  - container_image: docker.io/library/busybox:1.36
+    sources:
+      - url: https://github.com/mirror/busybox
+        ref: 1_36_0
         license_path: LICENSE
   - container_image: registry.k8s.io/pause:3.10
     sources:

--- a/make/validate.mk
+++ b/make/validate.mk
@@ -6,12 +6,12 @@ list-images: $(NKP_CLI_BIN) $(YQ_BIN) list-images-full
 	echo "Removing applications from images.yaml: $(SKIP_APPLICATIONS)"
 	@if [ -n "$(SKIP_APPLICATIONS)" ]; then \
 		for app in $$(echo "$(SKIP_APPLICATIONS)" | tr ',' ' '); do \
-			yq eval "del(.applications[] | select(.name == \"$$app\"))" -i $(REPO_ROOT)/images.yaml; \
+			$(YQ_BIN) eval "del(.applications[] | select(.name == \"$$app\"))" -i $(REPO_ROOT)/images.yaml; \
 		done; \
 	fi
 	echo "Images after removing applications:"
 	cat $(REPO_ROOT)/images.yaml
-	yq '.applications[].images[]' $(REPO_ROOT)/images.yaml | sort | uniq | grep -v "oci://" > images.txt
+	$(YQ_BIN) '.applications[].images[]' $(REPO_ROOT)/images.yaml | sort | uniq | grep -v "oci://" > images.txt
 
 .PHONY: list-images-full
 list-images-full: $(NKP_CLI_BIN)


### PR DESCRIPTION
- amd-device-metrics-exporter 1.4.2: Prometheus metrics from AMD GPUs/NICs
- amd-gpu-operator 1.4.1: GPU node bootstrap (drivers, device plugin, NFD, KMM)
- amd-network-operator 1.0.0: AMD NIC management

Device Metrics Exporter: add postRenderer to fix upstream chart bug (Service metadata.app causes strict K8s schema validation failure). Metadata: add AMD-branded icons and Key Features sections.

**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
Charts used:
---
# AMD GPU Operator 1.4.1
| Input         | Value                                  |
|---------------|----------------------------------------|
| chart_repo    | `https://rocm.github.io/gpu-operator`  |
| chart_name    | `gpu-operator-charts`                  |
| chart_version | `v1.4.1`                               |
| repo_name     | `rocm`                                 |
---

# AMD Network Operator 1.0.0
| Input         | Value                                        |
|---------------|----------------------------------------------|
| chart_repo    | `https://rocm.github.io/network-operator`   |
| chart_name    | `network-operator-charts`                    |
| chart_version | `v1.0.0`                                    |
| repo_name     | `rocm-network`                              |
---

# AMD Device Metrics Exporter 1.4.2
| Input         | Value                                             |
|---------------|---------------------------------------------------|
| chart_repo    | `https://rocm.github.io/device-metrics-exporter` |
| chart_name    | `device-metrics-exporter-charts`                 |
| chart_version | `v1.4.2`                                         |
| repo_name     | `rocm-exporter`                                  |
---

<pre>
(devbox) ➜ ~/go/src/github.com/mesosphere/kommander-applications ➜ git:(gpu) ✗ ./nkp-catalog-cli validate catalog-repository --repo-dir=. --apps=amd-gpu-operator=1.4.1 
Skipping directory that doesn't adhere to semver convention: cert-manager/bootstrap, error: invalid semantic version
Skipping directory that doesn't adhere to semver convention: gatekeeper/bootstrap, error: invalid semantic version
Skipping directory that doesn't adhere to semver convention: kommander/charts, error: invalid semantic version
Validating 1 application(s) matching --apps filter
 ∅ Validating user-inputs.yaml for amd-gpu-operator/1.4.1
 ✓ K8s [1.33.2 1.34.1 1.35.0]: Parsing resources 
 ✓ K8s v1.33.2: Validating 
 ✓ K8s v1.34.1: Validating 
 ✓ K8s v1.35.0: Validating 

Validation Summary...
APP               VERSION  METADATA  APP MANIFESTS  ERROR
amd-gpu-operator  1.4.1    ✓         ✓              
All 1 application(s) passed validation
(devbox) ➜ ~/go/src/github.com/mesosphere/kommander-applications ➜ git:(gpu) ✗ ./nkp-catalog-cli validate catalog-repository --repo-dir=. --apps=amd-network-operator=1.0.0
Skipping directory that doesn't adhere to semver convention: cert-manager/bootstrap, error: invalid semantic version
Skipping directory that doesn't adhere to semver convention: gatekeeper/bootstrap, error: invalid semantic version
Skipping directory that doesn't adhere to semver convention: kommander/charts, error: invalid semantic version
Validating 1 application(s) matching --apps filter
 ∅ Validating user-inputs.yaml for amd-network-operator/1.0.0
 ✓ K8s [1.33.2 1.34.1 1.35.0]: Parsing resources 
 ✓ K8s v1.33.2: Validating 
 ✓ K8s v1.34.1: Validating 
 ✓ K8s v1.35.0: Validating 

Validation Summary...
APP                   VERSION  METADATA  APP MANIFESTS  ERROR
amd-network-operator  1.0.0    ✓         ✓              
All 1 application(s) passed validation
(devbox) ➜ ~/go/src/github.com/mesosphere/kommander-applications ➜ git:(gpu) ✗ ./nkp-catalog-cli validate catalog-repository --repo-dir=. --apps=amd-device-metrics-exporter=1.4.2                              
Skipping directory that doesn't adhere to semver convention: cert-manager/bootstrap, error: invalid semantic version
Skipping directory that doesn't adhere to semver convention: gatekeeper/bootstrap, error: invalid semantic version
Skipping directory that doesn't adhere to semver convention: kommander/charts, error: invalid semantic version
Validating 1 application(s) matching --apps filter
 ∅ Validating user-inputs.yaml for amd-device-metrics-exporter/1.4.2
 ✓ K8s [1.33.2 1.34.1 1.35.0]: Parsing resources 
 ✓ K8s v1.33.2: Validating 
 ✓ K8s v1.34.1: Validating 
 ✓ K8s v1.35.0: Validating 

Validation Summary...
APP                          VERSION  METADATA  APP MANIFESTS  ERROR
amd-device-metrics-exporter  1.4.2    ✓         ✓              
All 1 application(s) passed validation
</pre>

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
