### PR TITLE
chore: handle pre-release overrides for release operator

### DIFF
--- a/hack/release/cmd/postrelease/postrelease.go
+++ b/hack/release/cmd/postrelease/postrelease.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/appversion"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/chartversion"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/extraimages"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/releasemetadata"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/upgradematrix"
 )
 
@@ -68,6 +69,11 @@ func init() { //nolint:gochecknoinits // Initializing cobra application.
 			if err := extraimages.UpdateExtraImagesVersions(kommanderApplicationsRepo, chartVersion.Original()); err != nil {
 				return err
 			}
+
+			if err := releasemetadata.DeleteReleaseOperatorConfig(kommanderApplicationsRepo); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Cleaned up pre-release config for release-operator\n")
 
 			return nil
 		},

--- a/hack/release/cmd/prerelease/prerelease.go
+++ b/hack/release/cmd/prerelease/prerelease.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/chartversion"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/extraimages"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/manifests"
+	"github.com/mesosphere/kommander-applications/hack/release/pkg/releasemetadata"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/updatecapimate"
 )
 
@@ -60,6 +61,12 @@ func init() { //nolint:gochecknoinits // Initializing cobra application.
 				return err
 			}
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Updated artifacts_full.yaml to %s\n", chartVersionString)
+
+			if err = releasemetadata.WriteReleaseOperatorConfig(kommanderApplicationsRepo, chartVersionString); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Generated release-operator config with version %s\n", chartVersionString)
+
 			return nil
 		},
 	}

--- a/hack/release/pkg/releasemetadata/releasemetadata.go
+++ b/hack/release/pkg/releasemetadata/releasemetadata.go
@@ -1,0 +1,133 @@
+package releasemetadata
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	stagingOCIURL = "oci://harbor.eng.nutanix.com/nkp_release_metadata/releases"
+
+	releaseConfigDir                = "common/release/config"
+	releaseOperatorVarsFile         = "release-operator-vars.yaml"
+	configKustomizationFile         = "kustomization.yaml"
+	fluxPreReleaseKustomizationFile = "common/release/flux-pre-release-kustomization.yaml"
+	releaseKustomizationFile        = "common/release/kustomization.yaml"
+	releaseFluxKustomizationFile    = "common/release/flux-kustomization.yaml"
+)
+
+const configMapTemplate = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-operator-vars
+data:
+  releaseMetadataOCIURL: %s
+  releaseMetadataOCITag: %s
+`
+
+const configKustomizationTemplate = `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- release-operator-vars.yaml
+namespace: ${releaseNamespace:-kommander}
+`
+
+const fluxPreReleaseKustomizationTemplate = `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: release-operator-config
+  namespace: "${releaseNamespace:-kommander}"
+spec:
+  interval: 10m
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  path: ./common/release/config
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: kommander-vars
+  prune: true
+  wait: true
+`
+
+const releaseKustomizationTemplate = `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- flux-pre-release-kustomization.yaml
+- flux-kustomization.yaml
+`
+
+const fluxKustomizationWithDependsOnTemplate = `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: release-operator
+  namespace: "${releaseNamespace:-kommander}"
+  annotations:
+    managementplane.nkp.nutanix.com/version: "${kommanderChartVersion:=v2.18.0-dev}"
+spec:
+  dependsOn:
+    - name: release-operator-config
+  interval: 10m
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  path: ./common/release/manifests
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: kommander-vars
+  prune: true
+  wait: true
+`
+
+// WriteReleaseOperatorConfig generates all the config files needed for pre-release
+// staging OCI configuration. This includes:
+// - common/release/config/release-operator-vars.yaml (ConfigMap)
+// - common/release/config/kustomization.yaml
+// - common/release/flux-pre-release-kustomization.yaml (Flux Kustomization)
+// - Updates common/release/kustomization.yaml to include flux-pre-release-kustomization.yaml
+// - Updates common/release/flux-kustomization.yaml to add dependsOn
+func WriteReleaseOperatorConfig(repo, version string) error {
+	configDir := filepath.Join(repo, releaseConfigDir)
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		return fmt.Errorf("create config directory %s: %w", configDir, err)
+	}
+
+	files := []struct {
+		path    string
+		content string
+	}{
+		{
+			path:    filepath.Join(configDir, releaseOperatorVarsFile),
+			content: fmt.Sprintf(configMapTemplate, stagingOCIURL, version),
+		},
+		{
+			path:    filepath.Join(configDir, configKustomizationFile),
+			content: configKustomizationTemplate,
+		},
+		{
+			path:    filepath.Join(repo, fluxPreReleaseKustomizationFile),
+			content: fluxPreReleaseKustomizationTemplate,
+		},
+		{
+			path:    filepath.Join(repo, releaseKustomizationFile),
+			content: releaseKustomizationTemplate,
+		},
+		{
+			path:    filepath.Join(repo, releaseFluxKustomizationFile),
+			content: fluxKustomizationWithDependsOnTemplate,
+		},
+	}
+
+	for _, f := range files {
+		if err := os.WriteFile(f.path, []byte(f.content), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", f.path, err)
+		}
+	}
+
+	return nil
+}

--- a/hack/release/pkg/releasemetadata/releasemetadata.go
+++ b/hack/release/pkg/releasemetadata/releasemetadata.go
@@ -53,10 +53,16 @@ spec:
   wait: true
 `
 
-const releaseKustomizationTemplate = `apiVersion: kustomize.config.k8s.io/v1beta1
+const releaseKustomizationPreReleaseTemplate = `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - flux-pre-release-kustomization.yaml
+- flux-kustomization.yaml
+`
+
+const releaseKustomizationDefaultTemplate = `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - flux-kustomization.yaml
 `
 
@@ -70,6 +76,28 @@ metadata:
 spec:
   dependsOn:
     - name: release-operator-config
+  interval: 10m
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  path: ./common/release/manifests
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: kommander-vars
+  prune: true
+  wait: true
+`
+
+const fluxKustomizationDefaultTemplate = `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: release-operator
+  namespace: "${releaseNamespace:-kommander}"
+  annotations:
+    managementplane.nkp.nutanix.com/version: "${kommanderChartVersion:=v2.18.0-dev}"
+spec:
   interval: 10m
   sourceRef:
     kind: GitRepository
@@ -115,11 +143,51 @@ func WriteReleaseOperatorConfig(repo, version string) error {
 		},
 		{
 			path:    filepath.Join(repo, releaseKustomizationFile),
-			content: releaseKustomizationTemplate,
+			content: releaseKustomizationPreReleaseTemplate,
 		},
 		{
 			path:    filepath.Join(repo, releaseFluxKustomizationFile),
 			content: fluxKustomizationWithDependsOnTemplate,
+		},
+	}
+
+	for _, f := range files {
+		if err := os.WriteFile(f.path, []byte(f.content), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", f.path, err)
+		}
+	}
+
+	return nil
+}
+
+// DeleteReleaseOperatorConfig removes all pre-release config files and restores
+// the release operator configuration to its default (production) state. This includes:
+// - Removing common/release/config/ directory
+// - Removing common/release/flux-pre-release-kustomization.yaml
+// - Restoring common/release/kustomization.yaml to default (without flux-pre-release-kustomization.yaml)
+// - Restoring common/release/flux-kustomization.yaml to default (without dependsOn)
+func DeleteReleaseOperatorConfig(repo string) error {
+	configDir := filepath.Join(repo, releaseConfigDir)
+	if err := os.RemoveAll(configDir); err != nil {
+		return fmt.Errorf("remove config directory %s: %w", configDir, err)
+	}
+
+	fluxPreReleasePath := filepath.Join(repo, fluxPreReleaseKustomizationFile)
+	if err := os.Remove(fluxPreReleasePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove %s: %w", fluxPreReleasePath, err)
+	}
+
+	files := []struct {
+		path    string
+		content string
+	}{
+		{
+			path:    filepath.Join(repo, releaseKustomizationFile),
+			content: releaseKustomizationDefaultTemplate,
+		},
+		{
+			path:    filepath.Join(repo, releaseFluxKustomizationFile),
+			content: fluxKustomizationDefaultTemplate,
 		},
 	}
 

--- a/hack/release/pkg/releasemetadata/releasemetadata_test.go
+++ b/hack/release/pkg/releasemetadata/releasemetadata_test.go
@@ -119,6 +119,77 @@ func TestWriteReleaseOperatorConfig_AllFilesCreated(t *testing.T) {
 	}
 }
 
+func TestDeleteReleaseOperatorConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupBaseFiles(t, tmpDir)
+
+	err := WriteReleaseOperatorConfig(tmpDir, "v2.18.0-dev.12")
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(tmpDir, releaseConfigDir))
+	require.NoError(t, err, "config directory should exist after WriteReleaseOperatorConfig")
+
+	err = DeleteReleaseOperatorConfig(tmpDir)
+	require.NoError(t, err)
+
+	t.Run("removes config directory", func(t *testing.T) {
+		_, err := os.Stat(filepath.Join(tmpDir, releaseConfigDir))
+		assert.True(t, os.IsNotExist(err), "config directory should be removed")
+	})
+
+	t.Run("removes flux-pre-release-kustomization.yaml", func(t *testing.T) {
+		_, err := os.Stat(filepath.Join(tmpDir, fluxPreReleaseKustomizationFile))
+		assert.True(t, os.IsNotExist(err), "flux-pre-release-kustomization.yaml should be removed")
+	})
+
+	t.Run("restores release kustomization.yaml to default", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(tmpDir, releaseKustomizationFile))
+		require.NoError(t, err)
+
+		assert.NotContains(t, string(content), "flux-pre-release-kustomization.yaml")
+		assert.Contains(t, string(content), "- flux-kustomization.yaml")
+	})
+
+	t.Run("restores flux-kustomization.yaml to default without dependsOn", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(tmpDir, releaseFluxKustomizationFile))
+		require.NoError(t, err)
+
+		assert.NotContains(t, string(content), "dependsOn:")
+		assert.NotContains(t, string(content), "release-operator-config")
+		assert.Contains(t, string(content), "name: release-operator")
+	})
+}
+
+func TestDeleteReleaseOperatorConfig_Idempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupBaseFiles(t, tmpDir)
+
+	err := DeleteReleaseOperatorConfig(tmpDir)
+	require.NoError(t, err, "should not error when pre-release files don't exist")
+
+	err = DeleteReleaseOperatorConfig(tmpDir)
+	require.NoError(t, err, "should be idempotent")
+}
+
+func TestDeleteReleaseOperatorConfig_RestoresCorrectContent(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupBaseFiles(t, tmpDir)
+
+	err := WriteReleaseOperatorConfig(tmpDir, "v2.18.0-dev.12")
+	require.NoError(t, err)
+
+	err = DeleteReleaseOperatorConfig(tmpDir)
+	require.NoError(t, err)
+
+	kustomizationContent, err := os.ReadFile(filepath.Join(tmpDir, releaseKustomizationFile))
+	require.NoError(t, err)
+	assert.Equal(t, releaseKustomizationDefaultTemplate, string(kustomizationContent))
+
+	fluxKustomizationContent, err := os.ReadFile(filepath.Join(tmpDir, releaseFluxKustomizationFile))
+	require.NoError(t, err)
+	assert.Equal(t, fluxKustomizationDefaultTemplate, string(fluxKustomizationContent))
+}
+
 func setupBaseFiles(t *testing.T, tmpDir string) {
 	t.Helper()
 
@@ -130,29 +201,9 @@ func setupBaseFiles(t *testing.T, tmpDir string) {
 	err = os.MkdirAll(manifestsDir, 0o755)
 	require.NoError(t, err)
 
-	kustomizationContent := `apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- flux-kustomization.yaml
-`
-	err = os.WriteFile(filepath.Join(releaseDir, "kustomization.yaml"), []byte(kustomizationContent), 0o644)
+	err = os.WriteFile(filepath.Join(releaseDir, "kustomization.yaml"), []byte(releaseKustomizationDefaultTemplate), 0o644)
 	require.NoError(t, err)
 
-	fluxKustomizationContent := `apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: release-operator
-  namespace: "${releaseNamespace:-kommander}"
-spec:
-  interval: 10m
-  sourceRef:
-    kind: GitRepository
-    name: management
-    namespace: kommander-flux
-  path: ./common/release/manifests
-  prune: true
-  wait: true
-`
-	err = os.WriteFile(filepath.Join(releaseDir, "flux-kustomization.yaml"), []byte(fluxKustomizationContent), 0o644)
+	err = os.WriteFile(filepath.Join(releaseDir, "flux-kustomization.yaml"), []byte(fluxKustomizationDefaultTemplate), 0o644)
 	require.NoError(t, err)
 }

--- a/hack/release/pkg/releasemetadata/releasemetadata_test.go
+++ b/hack/release/pkg/releasemetadata/releasemetadata_test.go
@@ -1,0 +1,158 @@
+package releasemetadata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteReleaseOperatorConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	setupBaseFiles(t, tmpDir)
+
+	version := "v2.18.0-dev.12"
+	err := WriteReleaseOperatorConfig(tmpDir, version)
+	require.NoError(t, err)
+
+	t.Run("creates config directory", func(t *testing.T) {
+		configDir := filepath.Join(tmpDir, releaseConfigDir)
+		info, err := os.Stat(configDir)
+		require.NoError(t, err)
+		assert.True(t, info.IsDir())
+	})
+
+	t.Run("creates release-operator-vars ConfigMap", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(tmpDir, releaseConfigDir, releaseOperatorVarsFile))
+		require.NoError(t, err)
+
+		assert.Contains(t, string(content), "name: release-operator-vars")
+		assert.Contains(t, string(content), "releaseMetadataOCIURL: "+stagingOCIURL)
+		assert.Contains(t, string(content), "releaseMetadataOCITag: "+version)
+	})
+
+	t.Run("creates config kustomization.yaml", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(tmpDir, releaseConfigDir, configKustomizationFile))
+		require.NoError(t, err)
+
+		assert.Contains(t, string(content), "kind: Kustomization")
+		assert.Contains(t, string(content), "- release-operator-vars.yaml")
+		assert.Contains(t, string(content), "namespace: ${releaseNamespace:-kommander}")
+	})
+
+	t.Run("creates flux-pre-release-kustomization.yaml", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(tmpDir, fluxPreReleaseKustomizationFile))
+		require.NoError(t, err)
+
+		assert.Contains(t, string(content), "name: release-operator-config")
+		assert.Contains(t, string(content), "path: ./common/release/config")
+		assert.Contains(t, string(content), "wait: true")
+	})
+
+	t.Run("updates release kustomization.yaml with flux-pre-release-kustomization", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(tmpDir, releaseKustomizationFile))
+		require.NoError(t, err)
+
+		assert.Contains(t, string(content), "- flux-pre-release-kustomization.yaml")
+		assert.Contains(t, string(content), "- flux-kustomization.yaml")
+	})
+
+	t.Run("updates flux-kustomization.yaml with dependsOn", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(tmpDir, releaseFluxKustomizationFile))
+		require.NoError(t, err)
+
+		assert.Contains(t, string(content), "dependsOn:")
+		assert.Contains(t, string(content), "- name: release-operator-config")
+		assert.Contains(t, string(content), "name: release-operator")
+	})
+}
+
+func TestWriteReleaseOperatorConfig_DifferentVersions(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version string
+	}{
+		{name: "dev version", version: "v2.18.0-dev.12"},
+		{name: "rc version", version: "v2.18.0-rc.1"},
+		{name: "release version", version: "v2.18.0"},
+		{name: "patch version", version: "v2.18.1"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			setupBaseFiles(t, tmpDir)
+
+			err := WriteReleaseOperatorConfig(tmpDir, tc.version)
+			require.NoError(t, err)
+
+			content, err := os.ReadFile(filepath.Join(tmpDir, releaseConfigDir, releaseOperatorVarsFile))
+			require.NoError(t, err)
+
+			assert.Contains(t, string(content), "releaseMetadataOCITag: "+tc.version)
+			assert.Contains(t, string(content), "releaseMetadataOCIURL: "+stagingOCIURL)
+		})
+	}
+}
+
+func TestWriteReleaseOperatorConfig_AllFilesCreated(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupBaseFiles(t, tmpDir)
+
+	err := WriteReleaseOperatorConfig(tmpDir, "v1.0.0")
+	require.NoError(t, err)
+
+	expectedFiles := []string{
+		filepath.Join(tmpDir, releaseConfigDir, releaseOperatorVarsFile),
+		filepath.Join(tmpDir, releaseConfigDir, configKustomizationFile),
+		filepath.Join(tmpDir, fluxPreReleaseKustomizationFile),
+		filepath.Join(tmpDir, releaseKustomizationFile),
+		filepath.Join(tmpDir, releaseFluxKustomizationFile),
+	}
+
+	for _, f := range expectedFiles {
+		_, err := os.Stat(f)
+		assert.NoError(t, err, "expected file to exist: %s", f)
+	}
+}
+
+func setupBaseFiles(t *testing.T, tmpDir string) {
+	t.Helper()
+
+	releaseDir := filepath.Join(tmpDir, "common", "release")
+	err := os.MkdirAll(releaseDir, 0o755)
+	require.NoError(t, err)
+
+	manifestsDir := filepath.Join(releaseDir, "manifests")
+	err = os.MkdirAll(manifestsDir, 0o755)
+	require.NoError(t, err)
+
+	kustomizationContent := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- flux-kustomization.yaml
+`
+	err = os.WriteFile(filepath.Join(releaseDir, "kustomization.yaml"), []byte(kustomizationContent), 0o644)
+	require.NoError(t, err)
+
+	fluxKustomizationContent := `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: release-operator
+  namespace: "${releaseNamespace:-kommander}"
+spec:
+  interval: 10m
+  sourceRef:
+    kind: GitRepository
+    name: management
+    namespace: kommander-flux
+  path: ./common/release/manifests
+  prune: true
+  wait: true
+`
+	err = os.WriteFile(filepath.Join(releaseDir, "flux-kustomization.yaml"), []byte(fluxKustomizationContent), 0o644)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Release operator will point to staging harbor registry and pre-release tag incase of dev/rc builds (so only discoverable version would be this pre-release version). For now since QA isn’t sure either how/what will be tested with custom/fake releases during upgrade qual. For prod, operator will point to prod ghcr and a mutable “latest” tag (publishing/tagging this will be done as part of release-ops)

**What problem does this PR solve?**:

- Add releasemetadata package to generate staging OCI configuration for the release operator during pre-release builds
- Use separate Flux Kustomizations with dependsOn to ensure the ConfigMap is created before the release-operator Deployment
- Production builds remain unaffected (no config files generated)
- During post release, it undo the changes done in pre-release.

When the pre-release command runs, it should generate -
```
common/release/
├── kustomization.yaml                    
├── flux-kustomization.yaml       (include dependsOn flux-pre-release-kustomization)
├── flux-pre-release-kustomization.yaml   
└── config/                               
    ├── kustomization.yaml               
    └── release-operator-vars.yaml        # ConfigMap with staging OCI config details
```
for production, the config/ directory and flux-kustomization-config.yaml shouldn't exist, and kustomization.yaml only references flux-kustomization.yaml (no dependsOn).

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
