### PR TITLE
build: add nkp-mcp-server to skip applications

### DIFF
--- a/make/validate.mk
+++ b/make/validate.mk
@@ -1,4 +1,4 @@
-SKIP_APPLICATIONS ?= ai-navigator-app,nkp-pulse-management,nkp-pulse-workspace
+SKIP_APPLICATIONS ?= ai-navigator-app,nkp-mcp-server,nkp-pulse-management,nkp-pulse-workspace
 
 FULL_BUNDLE_FILE=artifacts_full.yaml
 AIRGAPPED_BUNDLE_FILE=artifacts_airgapped.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:

`nkp-mcp-server` is listed in `.exclude-airgapped` (so its application files are excluded from the air gap bundle tar.gz), but it was missing from the `SKIP_APPLICATIONS` list in `make/validate.mk`. This means its container images were still included in `artifacts_airgapped.yaml` and `artifacts_airgapped_images.txt`, and would end up in the air gap image bundle.

**Which issue(s) does this PR fix?**:

https://jira.nutanix.com/browse/NCN-109850

**Special notes for your reviewer**:

The three exclusion mechanisms in this repo should stay in sync:
1. `.exclude-airgapped` — controls which app directories are rsync'd into the bundle tar.gz
2. `SKIP_APPLICATIONS` in `make/validate.mk` — controls which apps are removed from the air gap image list
3. `release.just` `sed` strip — removes app references from Kommander's cm.yaml (only needed for apps referenced there; `nkp-mcp-server` is not, so no change needed)

`nkp-mcp-server` was already present in (1) but missing from (2). This PR adds it to (2) to make them consistent. No changes are needed in `kommander-cli` since `nkp-mcp-server` is not a default-enabled app.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

- [x] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [x] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).