### PR TITLE
ci: add docker hub login to test workflow - docker rate limiting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,12 @@ jobs:
       - name: Run unit tests
         run: devbox run -- make go-test
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Check if git-operator manifests are up to date
         run: |
           devbox run just git-operator-fetch-manifests


### PR DESCRIPTION
**What problem does this PR solve?**:

The "Go Test" CI workflow fails when running `devbox run just git-operator-fetch-manifests` because `flux pull artifact` pulls from `docker.io` without authentication, hitting Docker Hub's unauthenticated rate limit (`TOOMANYREQUESTS`).

This was not an issue previously because the workflow ran on `ubuntu-latest` (GitHub-hosted runners), which have built-in Docker Hub authentication. When runners were switched to `self-hosted-nutanix-docker-xsmall` in #4527, that implicit authentication was lost, and the `flux pull artifact` call became unauthenticated.

**Which issue(s) does this PR fix?**:


**Special notes for your reviewer**:

- The fix adds a `docker/login-action@v3` step using the existing `DOCKER_USERNAME` / `DOCKER_PASSWORD` repo secrets (same pattern used by `validate-licenses.yaml`).
- `flux pull artifact` respects credentials stored in `~/.docker/config.json`, which `docker/login-action` populates.
- Also adds `workflow_dispatch` to allow manually triggering the test workflow from the Actions UI, which is useful for debugging CI issues like this.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

- [x] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [x] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).