### PR TITLE
fix: rm flux oci mirror secret stub

### DIFF
--- a/applications/kommander-flux/2.8.5/mirror/flux-oci-mirror.yaml
+++ b/applications/kommander-flux/2.8.5/mirror/flux-oci-mirror.yaml
@@ -1,15 +1,4 @@
 apiVersion: v1
-data:
-  ca.crt: ""
-kind: Secret
-metadata:
-  name: flux-oci-mirror-config
-stringData:
-  config.yaml: |
-    listen_addr: ":8443"
-type: Opaque
----
-apiVersion: v1
 kind: Service
 metadata:
   name: flux-oci-mirror
@@ -81,6 +70,7 @@ spec:
         - name: flux-oci-mirror-config
           secret:
             secretName: flux-oci-mirror-config
+            optional: true
         - name: proxy-ca
           secret:
             secretName: flux-oci-mirror-ca-secret


### PR DESCRIPTION
**What problem does this PR solve?**:
when `nkp install kommander` is rerun with, the kommander-flux bundle re-applies a stub flux-oci-mirror-config Secret containing only listen_addr: ":8443" and an empty ca.crt. This overwrites the real Secret previously generated by the kommander-core-installer operator with the full mirror URL, credentials, and CA certificate — effectively breaking the OCI mirror proxy. This is affecting both kcli and bootstrapper.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-112985

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
