### PR TITLE
feat: use helm v4 SSA for application upgrades

### DIFF
--- a/applications/ai-navigator-app/0.8.0-dev.7/helmrelease/ai-navigator-app.yaml
+++ b/applications/ai-navigator-app/0.8.0-dev.7/helmrelease/ai-navigator-app.yaml
@@ -26,11 +26,15 @@ spec:
   releaseName: ai-navigator-app
   targetNamespace: ${releaseNamespace}
   install:
+    serverSideApply: true
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   valuesFrom:
     - kind: ConfigMap
       name: ${releaseName}-${appVersion}-config-defaults

--- a/applications/centralized-grafana/82.13.6/helmrelease/centralized-grafana.yaml
+++ b/applications/centralized-grafana/82.13.6/helmrelease/centralized-grafana.yaml
@@ -21,14 +21,18 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: centralized-grafana
   valuesFrom:
     - kind: ConfigMap

--- a/applications/centralized-opencost/2.5.14/release/opencost.yaml
+++ b/applications/centralized-opencost/2.5.14/release/opencost.yaml
@@ -22,13 +22,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: centralized-opencost
   valuesFrom:
     - kind: ConfigMap

--- a/applications/cert-manager/1.19.3/release/release.yaml
+++ b/applications/cert-manager/1.19.3/release/release.yaml
@@ -33,14 +33,18 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: cert-manager
   targetNamespace: cert-manager
   valuesFrom:
@@ -59,13 +63,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     remediation:
       retries: 30
     createNamespace: true
     crds: CreateReplace
   upgrade:
+    serverSideApply: enabled
     remediation:
       retries: 30
     crds: CreateReplace
+  rollback:
+    serverSideApply: enabled
   releaseName: cert-manager-crds
   targetNamespace: cert-manager

--- a/applications/cilium-hubble-relay-traefik/0.0.5/helmrelease/cilium-hubble-relay-traefik.yaml
+++ b/applications/cilium-hubble-relay-traefik/0.0.5/helmrelease/cilium-hubble-relay-traefik.yaml
@@ -22,13 +22,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: cilium-hubble-relay-traefik
   valuesFrom:
     - kind: ConfigMap

--- a/applications/cloudnative-pg/0.28.0/helmrelease/cloudnative-pg.yaml
+++ b/applications/cloudnative-pg/0.28.0/helmrelease/cloudnative-pg.yaml
@@ -21,13 +21,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   timeout: 5m0s
   releaseName: kommander-cloudnative-pg
   valuesFrom:

--- a/applications/cosi-driver-nutanix/0.6.3/helmrelease/cosi-driver-nutanix.yaml
+++ b/applications/cosi-driver-nutanix/0.6.3/helmrelease/cosi-driver-nutanix.yaml
@@ -21,13 +21,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: cosi-driver-nutanix
   valuesFrom:
     - kind: ConfigMap

--- a/applications/cosi-driver-nutanix/0.6.3/helmrelease/cosi-resources-nutanix.yaml
+++ b/applications/cosi-driver-nutanix/0.6.3/helmrelease/cosi-resources-nutanix.yaml
@@ -25,14 +25,18 @@ spec:
     # We have this in place to ensure that the cosi-driver-nutanix HelmRelease is installed before creating the BucketClass CR.
     - name: cosi-driver-nutanix
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: cosi-resources-nutanix
   targetNamespace: ${releaseNamespace}
   valuesFrom:

--- a/applications/dex-k8s-authenticator/1.4.7/helmrelease/dex-k8s-authenticator.yaml
+++ b/applications/dex-k8s-authenticator/1.4.7/helmrelease/dex-k8s-authenticator.yaml
@@ -32,13 +32,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: dex-k8s-authenticator
   valuesFrom:
     - kind: ConfigMap

--- a/applications/dex/2.14.4/helmrelease/dex.yaml
+++ b/applications/dex/2.14.4/helmrelease/dex.yaml
@@ -22,13 +22,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: dex
   valuesFrom:
     - kind: ConfigMap

--- a/applications/external-dns/10.20.0/helmrelease/external-dns.yaml
+++ b/applications/external-dns/10.20.0/helmrelease/external-dns.yaml
@@ -22,13 +22,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: external-dns
   valuesFrom:
     - kind: ConfigMap

--- a/applications/external-secrets/2.3.0/release/release.yaml
+++ b/applications/external-secrets/2.3.0/release/release.yaml
@@ -24,14 +24,18 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   targetNamespace: external-secrets
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: external-secrets
   valuesFrom:
     - kind: ConfigMap

--- a/applications/fluent-bit/0.57.2/helmrelease/fluent-bit.yaml
+++ b/applications/fluent-bit/0.57.2/helmrelease/fluent-bit.yaml
@@ -21,13 +21,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   timeout: 5m0s
   releaseName: kommander-fluent-bit
   valuesFrom:

--- a/applications/gatekeeper/3.22.0/release/release.yaml
+++ b/applications/gatekeeper/3.22.0/release/release.yaml
@@ -32,13 +32,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   timeout: 5m0s
   releaseName: kommander-gatekeeper
   valuesFrom:
@@ -97,13 +101,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   timeout: 5m0s
   releaseName: gatekeeper-proxy-mutations
   valuesFrom:

--- a/applications/grafana-logging/11.3.3/helmrelease/grafana.yaml
+++ b/applications/grafana-logging/11.3.3/helmrelease/grafana.yaml
@@ -23,13 +23,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: grafana-logging
   valuesFrom:
     - kind: ConfigMap

--- a/applications/grafana-loki-v3/3.6.7/helmrelease/grafana-loki-v3.yaml
+++ b/applications/grafana-loki-v3/3.6.7/helmrelease/grafana-loki-v3.yaml
@@ -24,13 +24,17 @@ spec:
   interval: 15s
   timeout: 15m
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: grafana-loki-v3
   valuesFrom:
     - kind: ConfigMap

--- a/applications/grafana-loki/0.80.6/grafana-loki-helmrelease/grafana-loki.yaml
+++ b/applications/grafana-loki/0.80.6/grafana-loki-helmrelease/grafana-loki.yaml
@@ -24,13 +24,17 @@ spec:
   interval: 15s
   timeout: 15m
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: grafana-loki
   valuesFrom:
     - kind: ConfigMap

--- a/applications/harbor/1.18.3/cosi-storage/cosi-bucket.yaml
+++ b/applications/harbor/1.18.3/cosi-storage/cosi-bucket.yaml
@@ -21,14 +21,18 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: harbor-cosi-storage
   targetNamespace: ncr-system
   valuesFrom:

--- a/applications/harbor/1.18.3/database/cluster.yaml
+++ b/applications/harbor/1.18.3/database/cluster.yaml
@@ -21,13 +21,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   timeout: 5m0s
   releaseName: harbor-database
   targetNamespace: ncr-system

--- a/applications/harbor/1.18.3/manual-storage/manual-bucket.yaml
+++ b/applications/harbor/1.18.3/manual-storage/manual-bucket.yaml
@@ -21,14 +21,18 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: harbor-copy-secret
   targetNamespace: ${releaseNamespace}
   valuesFrom:

--- a/applications/harbor/1.18.3/release/harbor.yaml
+++ b/applications/harbor/1.18.3/release/harbor.yaml
@@ -21,13 +21,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   timeout: 5m0s
   releaseName: harbor
   targetNamespace: ncr-system

--- a/applications/harbor/1.18.3/valkey/valkey.yaml
+++ b/applications/harbor/1.18.3/valkey/valkey.yaml
@@ -21,13 +21,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   timeout: 10m0s
   releaseName: harbor-valkey
   targetNamespace: ncr-system

--- a/applications/istio-helm/1.24.0/helmrelease/helmrelease.yaml
+++ b/applications/istio-helm/1.24.0/helmrelease/helmrelease.yaml
@@ -75,13 +75,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: ${releaseName}-base
   targetNamespace: istio-helm-system
   valuesFrom:
@@ -107,11 +111,15 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: ${releaseName}-cni
   targetNamespace: kube-system
   valuesFrom:
@@ -137,11 +145,15 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: ${releaseName}-istiod
   targetNamespace: istio-helm-system
   valuesFrom:
@@ -167,11 +179,15 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: ${releaseName}-ztunnel
   targetNamespace: istio-helm-gateway-ns
   valuesFrom:
@@ -197,13 +213,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     remediation:
       retries: 30
     disableSchemaValidation: true
   upgrade:
+    serverSideApply: enabled
     remediation:
       retries: 30
     disableSchemaValidation: true
+  rollback:
+    serverSideApply: enabled
   releaseName: ${releaseName}-gateway
   targetNamespace: istio-helm-gateway-ns
   valuesFrom:

--- a/applications/istio/1.23.5/helmrelease/helmrelease.yaml
+++ b/applications/istio/1.23.5/helmrelease/helmrelease.yaml
@@ -25,14 +25,18 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: istio
   targetNamespace: istio-system
   valuesFrom:

--- a/applications/jaeger/2.57.3/helmrelease/release.yaml
+++ b/applications/jaeger/2.57.3/helmrelease/release.yaml
@@ -24,14 +24,18 @@ spec:
   # the istio-system namespace is actually created
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: jaeger
   targetNamespace: istio-system
   valuesFrom:

--- a/applications/karma-traefik/0.0.4/helmrelease/karma-traefik.yaml
+++ b/applications/karma-traefik/0.0.4/helmrelease/karma-traefik.yaml
@@ -22,13 +22,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: karma-traefik
   valuesFrom:
     - kind: ConfigMap

--- a/applications/karma/2.0.9/helmrelease/karma.yaml
+++ b/applications/karma/2.0.9/helmrelease/karma.yaml
@@ -25,13 +25,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: karma
   valuesFrom:
     - kind: ConfigMap

--- a/applications/kiali/2.24.0/helmrelease/kiali.yaml
+++ b/applications/kiali/2.24.0/helmrelease/kiali.yaml
@@ -21,14 +21,18 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: kiali
   valuesFrom:
     - kind: ConfigMap

--- a/applications/knative/1.21.0/helmrelease/knative-deployment.yaml
+++ b/applications/knative/1.21.0/helmrelease/knative-deployment.yaml
@@ -25,13 +25,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: knative-deploy
   valuesFrom:
     - kind: ConfigMap

--- a/applications/knative/1.21.0/helmrelease/knative-operator.yaml
+++ b/applications/knative/1.21.0/helmrelease/knative-operator.yaml
@@ -22,14 +22,18 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: knative
   targetNamespace: knative-operator
   valuesFrom:

--- a/applications/kommander-appmanagement/0.18.0/helmrelease/kommander-appmanagement.yaml
+++ b/applications/kommander-appmanagement/0.18.0/helmrelease/kommander-appmanagement.yaml
@@ -24,13 +24,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: kommander-appmanagement
   valuesFrom:
     - kind: ConfigMap

--- a/applications/kommander-flux/kustomization.yaml
+++ b/applications/kommander-flux/kustomization.yaml
@@ -8,7 +8,6 @@ patches:
   - path: ./2.8.5/patch-proxy-env-vars.yaml
     target:
       kind: Deployment
-  # TODO(takirala): Add this patch into HelmRelease post renders as well.
   - target:
       group: rbac.authorization.k8s.io
       version: v1

--- a/applications/kommander-ui/17.234.10/helmrelease/kommander-ui.yaml
+++ b/applications/kommander-ui/17.234.10/helmrelease/kommander-ui.yaml
@@ -25,13 +25,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   valuesFrom:
     - kind: ConfigMap
       name: ${releaseName}-${appVersion}-config-defaults

--- a/applications/kommander/0.18.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
+++ b/applications/kommander/0.18.0/dynamic-helmreleases/cluster-observer/cluster-observer.yaml
@@ -18,13 +18,17 @@ spec:
         namespace: kommander-flux
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: ${releaseName}
   valuesFrom:
     - kind: ConfigMap

--- a/applications/kommander/0.18.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
+++ b/applications/kommander/0.18.0/dynamic-helmreleases/mtls-proxy/mtls-proxy.yaml
@@ -18,15 +18,19 @@ spec:
         namespace: kommander-flux
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    serverSideApply: enabled
     force: true
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: ${releaseName}
   valuesFrom:
     - kind: ConfigMap

--- a/applications/kommander/0.18.0/helmrelease/kommander.yaml
+++ b/applications/kommander/0.18.0/helmrelease/kommander.yaml
@@ -31,13 +31,17 @@ spec:
   # the chance of the installation not timing out.
   timeout: 10m
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: kommander
   valuesFrom:
     - kind: ConfigMap

--- a/applications/kube-oidc-proxy/0.3.7/helmrelease/kube-oidc-proxy.yaml
+++ b/applications/kube-oidc-proxy/0.3.7/helmrelease/kube-oidc-proxy.yaml
@@ -31,13 +31,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: kube-oidc-proxy
   valuesFrom:
     - kind: ConfigMap

--- a/applications/kube-prometheus-stack/82.13.6/helmrelease/kube-prometheus-stack.yaml
+++ b/applications/kube-prometheus-stack/82.13.6/helmrelease/kube-prometheus-stack.yaml
@@ -21,19 +21,19 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     timeout: 5m0s
     crds: CreateReplace
-    # TODO(takirala): revert after https://github.com/mesosphere/charts/pull/1652/changes
-    serverSideApply: false
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     timeout: 5m0s
     crds: CreateReplace
-    # TODO(takirala): revert after https://github.com/mesosphere/charts/pull/1652/changes
-    serverSideApply: disabled
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   timeout: 5m0s
   releaseName: kube-prometheus-stack
   valuesFrom:

--- a/applications/kubernetes-dashboard/7.14.0/helmrelease/kubernetes-dashboard.yaml
+++ b/applications/kubernetes-dashboard/7.14.0/helmrelease/kubernetes-dashboard.yaml
@@ -21,13 +21,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: kubernetes-dashboard
   valuesFrom:
     - kind: ConfigMap

--- a/applications/kubetunnel/0.2.0/helmrelease/kubetunnel.yaml
+++ b/applications/kubetunnel/0.2.0/helmrelease/kubetunnel.yaml
@@ -22,13 +22,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: kubetunnel
   valuesFrom:
     - kind: ConfigMap

--- a/applications/logging-operator/6.4.0/logging-operator-logging/logging-operator-logging.yaml
+++ b/applications/logging-operator/6.4.0/logging-operator-logging/logging-operator-logging.yaml
@@ -24,13 +24,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: logging-operator-logging
   valuesFrom:
     - kind: ConfigMap

--- a/applications/logging-operator/6.4.0/logging-operator/logging-operator.yaml
+++ b/applications/logging-operator/6.4.0/logging-operator/logging-operator.yaml
@@ -22,13 +22,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: logging-operator
   valuesFrom:
     - kind: ConfigMap

--- a/applications/nkp-insights-management/1.8.0/helmrelease/helmrelease.yaml
+++ b/applications/nkp-insights-management/1.8.0/helmrelease/helmrelease.yaml
@@ -12,6 +12,7 @@ spec:
     - name: kubefed
       namespace: ${releaseNamespace}
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
@@ -19,9 +20,12 @@ spec:
   releaseName: nkp-insights-management
   targetNamespace: ${releaseNamespace}
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   valuesFrom:
     - kind: ConfigMap
       name: ${releaseName}-${appVersion}-config-defaults

--- a/applications/nkp-insights/1.8.0/helmrelease/helmrelease.yaml
+++ b/applications/nkp-insights/1.8.0/helmrelease/helmrelease.yaml
@@ -9,6 +9,7 @@ spec:
     name: ${releaseName}-${appVersion}
     namespace: ${releaseNamespace}
   install:
+    serverSideApply: true
     remediation:
       retries: 30
   interval: 15s
@@ -16,9 +17,12 @@ spec:
   targetNamespace: ${releaseNamespace}
   timeout: 10m
   upgrade:
+    serverSideApply: enabled
     remediation:
       retries: 30
       strategy: uninstall
+  rollback:
+    serverSideApply: enabled
   valuesFrom:
     - kind: ConfigMap
       name: ${releaseName}-${appVersion}-config-defaults

--- a/applications/nkp-mcp-server/0.1.0/helmrelease/nkp-mcp-server.yaml
+++ b/applications/nkp-mcp-server/0.1.0/helmrelease/nkp-mcp-server.yaml
@@ -24,11 +24,15 @@ spec:
   releaseName: nkp-mcp-server
   targetNamespace: ${releaseNamespace}
   install:
+    serverSideApply: true
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   valuesFrom:
     - kind: ConfigMap
       name: ${releaseName}-${appVersion}-config-defaults

--- a/applications/nkp-pulse-management/0.4.0/helmrelease.yaml
+++ b/applications/nkp-pulse-management/0.4.0/helmrelease.yaml
@@ -24,11 +24,16 @@ spec:
   releaseName: nkp-pulse-management
   targetNamespace: ${releaseNamespace}
   upgrade:
+    serverSideApply: enabled
     remediation:
       strategy: uninstall
+  rollback:
+    serverSideApply: enabled
   valuesFrom:
     - kind: ConfigMap
       name: nkp-pulse-management-0.4.0-config-defaults
+  install:
+    serverSideApply: true
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/applications/nkp-pulse-workspace/0.4.0/helmrelease.yaml
+++ b/applications/nkp-pulse-workspace/0.4.0/helmrelease.yaml
@@ -24,11 +24,16 @@ spec:
   releaseName: nkp-pulse-workspace
   targetNamespace: ${releaseNamespace}
   upgrade:
+    serverSideApply: enabled
     remediation:
       strategy: uninstall
+  rollback:
+    serverSideApply: enabled
   valuesFrom:
     - kind: ConfigMap
       name: nkp-pulse-workspace-0.4.0-config-defaults
+  install:
+    serverSideApply: true
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/applications/nvidia-gpu-operator/26.3.0/helmrelease/nvidia.yaml
+++ b/applications/nvidia-gpu-operator/26.3.0/helmrelease/nvidia.yaml
@@ -21,13 +21,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: nvidia-gpu-operator
   valuesFrom:
     - kind: ConfigMap

--- a/applications/nvidia-network-operator/26.1.0/helmrelease/nvidia.yaml
+++ b/applications/nvidia-network-operator/26.1.0/helmrelease/nvidia.yaml
@@ -20,15 +20,19 @@ spec:
     name: ${releaseName}-${appVersion}-chart
     namespace: ${releaseNamespace}
   install:
+    serverSideApply: true
     crds: CreateReplace
     createNamespace: true
     remediation:
       retries: 30
   interval: 15s
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: nvidia-network-operator
   valuesFrom:
     - kind: ConfigMap

--- a/applications/opencost/2.5.14/release/opencost.yaml
+++ b/applications/opencost/2.5.14/release/opencost.yaml
@@ -21,13 +21,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: opencost
   valuesFrom:
     - kind: ConfigMap

--- a/applications/project-grafana-logging/11.3.3/helmrelease/project-grafana.yaml
+++ b/applications/project-grafana-logging/11.3.3/helmrelease/project-grafana.yaml
@@ -23,13 +23,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   valuesFrom:
     - kind: ConfigMap
       name: ${releaseName}-${appVersion}-config-defaults

--- a/applications/project-grafana-loki-v3/3.6.7/helmrelease/object-bucket-claims.yaml
+++ b/applications/project-grafana-loki-v3/3.6.7/helmrelease/object-bucket-claims.yaml
@@ -22,13 +22,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: project-loki-v3-object-bucket-claims
   serviceAccountName: ${releaseNamespace}
   valuesFrom:

--- a/applications/project-grafana-loki-v3/3.6.7/helmrelease/project-grafana-loki-v3.yaml
+++ b/applications/project-grafana-loki-v3/3.6.7/helmrelease/project-grafana-loki-v3.yaml
@@ -24,13 +24,17 @@ spec:
   timeout: 15m
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: project-grafana-loki-v3
   serviceAccountName: ${releaseNamespace}
   valuesFrom:

--- a/applications/project-grafana-loki/0.80.6/helmrelease/object-bucket-claims.yaml
+++ b/applications/project-grafana-loki/0.80.6/helmrelease/object-bucket-claims.yaml
@@ -22,13 +22,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: project-loki-object-bucket-claims
   valuesFrom:
     - kind: ConfigMap

--- a/applications/project-grafana-loki/0.80.6/helmrelease/project-grafana-loki.yaml
+++ b/applications/project-grafana-loki/0.80.6/helmrelease/project-grafana-loki.yaml
@@ -24,13 +24,17 @@ spec:
   timeout: 15m
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: project-grafana-loki
   valuesFrom:
     - kind: ConfigMap

--- a/applications/prometheus-adapter/5.3.0/helmrelease/prometheus-adapter.yaml
+++ b/applications/prometheus-adapter/5.3.0/helmrelease/prometheus-adapter.yaml
@@ -24,13 +24,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: prometheus-adapter
   valuesFrom:
     - kind: ConfigMap

--- a/applications/prometheus-thanos-traefik/0.0.4/helmrelease/prometheus-thanos-traefik.yaml
+++ b/applications/prometheus-thanos-traefik/0.0.4/helmrelease/prometheus-thanos-traefik.yaml
@@ -22,13 +22,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: prometheus-thanos-traefik
   valuesFrom:
     - kind: ConfigMap

--- a/applications/reloader/2.2.11/helmrelease/reloader.yaml
+++ b/applications/reloader/2.2.11/helmrelease/reloader.yaml
@@ -21,13 +21,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   valuesFrom:
     - kind: ConfigMap
       name: ${releaseName}-${appVersion}-config-defaults

--- a/applications/rook-ceph-cluster/1.19.4/helmrelease/helmrelease.yaml
+++ b/applications/rook-ceph-cluster/1.19.4/helmrelease/helmrelease.yaml
@@ -21,18 +21,18 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
-    # TODO(takirala): revert in https://github.com/mesosphere/kommander-applications/pull/4786
-    serverSideApply: false
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
-    # TODO(takirala): revert in https://github.com/mesosphere/kommander-applications/pull/4786
-    serverSideApply: disabled
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   timeout: 15m
   releaseName: rook-ceph-cluster
   valuesFrom:

--- a/applications/rook-ceph-cluster/1.19.4/objectbucketclaims/cosi-bucket.yaml
+++ b/applications/rook-ceph-cluster/1.19.4/objectbucketclaims/cosi-bucket.yaml
@@ -21,14 +21,18 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: rook-ceph-cluster-cosi-driver
   targetNamespace: ${releaseNamespace}
   valuesFrom:

--- a/applications/rook-ceph-cluster/1.19.4/objectbucketclaims/helmrelease.yaml
+++ b/applications/rook-ceph-cluster/1.19.4/objectbucketclaims/helmrelease.yaml
@@ -22,14 +22,18 @@ spec:
   timeout: 20m
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: object-bucket-claims
   valuesFrom:
     - kind: ConfigMap

--- a/applications/rook-ceph/1.19.4/helmrelease/helmrelease.yaml
+++ b/applications/rook-ceph/1.19.4/helmrelease/helmrelease.yaml
@@ -22,14 +22,18 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: rook-ceph
   valuesFrom:
     - kind: ConfigMap

--- a/applications/thanos/17.3.1/helmrelease/thanos.yaml
+++ b/applications/thanos/17.3.1/helmrelease/thanos.yaml
@@ -21,13 +21,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: thanos
   valuesFrom:
     - kind: ConfigMap

--- a/applications/traefik-forward-auth-mgmt/0.3.17/helmrelease/traefik-forward-auth-mgmt.yaml
+++ b/applications/traefik-forward-auth-mgmt/0.3.17/helmrelease/traefik-forward-auth-mgmt.yaml
@@ -28,13 +28,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: traefik-forward-auth-mgmt
   valuesFrom:
     - kind: ConfigMap

--- a/applications/traefik-forward-auth/0.3.17/helmrelease/traefik-forward-auth.yaml
+++ b/applications/traefik-forward-auth/0.3.17/helmrelease/traefik-forward-auth.yaml
@@ -24,13 +24,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: traefik-forward-auth
   valuesFrom:
     - kind: ConfigMap

--- a/applications/traefik/39.0.7/traefik/traefik.yaml
+++ b/applications/traefik/39.0.7/traefik/traefik.yaml
@@ -27,13 +27,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: Skip
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: Skip
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   timeout: 5m0s
   releaseName: kommander-traefik
   valuesFrom:

--- a/applications/velero/12.0.0/helmrelease/helmrelease.yaml
+++ b/applications/velero/12.0.0/helmrelease/helmrelease.yaml
@@ -23,11 +23,15 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
+  rollback:
+    serverSideApply: enabled
   releaseName: velero
   valuesFrom:
     - kind: ConfigMap

--- a/applications/vgpu-token-operator/1.0.8/helmrelease/vgpu.yaml
+++ b/applications/vgpu-token-operator/1.0.8/helmrelease/vgpu.yaml
@@ -22,13 +22,17 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: vgpu-token-operator
   valuesFrom:
     - kind: ConfigMap

--- a/apptests/appscenarios/certmanager_test.go
+++ b/apptests/appscenarios/certmanager_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	fluxhelmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	fluxhelmv2 "github.com/fluxcd/helm-controller/api/v2"
 	apimeta "github.com/fluxcd/pkg/apis/meta"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -43,7 +43,7 @@ var _ = Describe("Cert-manager Tests", Ordered, Label("cert-manager"), func() {
 
 		var (
 			cm             certManager
-			hr, hrCrds     *fluxhelmv2beta2.HelmRelease
+			hr, hrCrds     *fluxhelmv2.HelmRelease
 			ns             *corev1.Namespace
 			rq             *corev1.ResourceQuota
 			deploymentList *appsv1.DeploymentList
@@ -56,10 +56,10 @@ var _ = Describe("Cert-manager Tests", Ordered, Label("cert-manager"), func() {
 			err := cm.Install(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      cm.Name(),
@@ -85,10 +85,10 @@ var _ = Describe("Cert-manager Tests", Ordered, Label("cert-manager"), func() {
 		})
 
 		It("should install crds successfully", func() {
-			hrCrds = &fluxhelmv2beta2.HelmRelease{
+			hrCrds = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cert-manager-crds",
@@ -234,10 +234,10 @@ var _ = Describe("Cert-manager Tests", Ordered, Label("cert-manager"), func() {
 			err := cm.InstallStepCertificates(ctx, env)
 			Expect(err).To(BeNil())
 
-			hrCrds = &fluxhelmv2beta2.HelmRelease{
+			hrCrds = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "step-certificates",
@@ -379,7 +379,7 @@ var _ = Describe("Cert-manager Tests", Ordered, Label("cert-manager"), func() {
 	Describe("Upgrading cert-manager", Ordered, Label("cert-manager", "upgrade"), func() {
 		var (
 			cm certManager
-			hr *fluxhelmv2beta2.HelmRelease
+			hr *fluxhelmv2.HelmRelease
 		)
 
 		It("should install the previous version successfully", func() {
@@ -387,10 +387,10 @@ var _ = Describe("Cert-manager Tests", Ordered, Label("cert-manager"), func() {
 			err := cm.InstallPreviousVersion(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      cm.Name(),
@@ -450,10 +450,10 @@ var _ = Describe("Cert-manager Tests", Ordered, Label("cert-manager"), func() {
 			err := cm.Upgrade(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      cm.Name(),

--- a/apptests/appscenarios/ciliumhubblerelaytraefik_test.go
+++ b/apptests/appscenarios/ciliumhubblerelaytraefik_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	fluxhelmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	fluxhelmv2 "github.com/fluxcd/helm-controller/api/v2"
 	apimeta "github.com/fluxcd/pkg/apis/meta"
 	"github.com/mesosphere/kommander-applications/apptests/constants"
 	corev1 "k8s.io/api/core/v1"
@@ -49,7 +49,7 @@ var _ = Describe("Cilium Hubble Relay Traefik Tests", Label(constants.CiliumHubb
 	})
 
 	Describe("Cilium Hubble Relay Traefik Install Test", Ordered, Label("install"), func() {
-		var ciliumHubbleRelayHR *fluxhelmv2beta2.HelmRelease
+		var ciliumHubbleRelayHR *fluxhelmv2.HelmRelease
 
 		It("should install Cilium Hubble Relay Traefik dependencies", func() {
 			installCiliumHubbleRelayTraefikDependencies()
@@ -59,10 +59,10 @@ var _ = Describe("Cilium Hubble Relay Traefik Tests", Label(constants.CiliumHubb
 			err := c.Install(ctx, env)
 			Expect(err).To(BeNil())
 
-			ciliumHubbleRelayHR = &fluxhelmv2beta2.HelmRelease{
+			ciliumHubbleRelayHR = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      c.Name(),
@@ -92,7 +92,7 @@ var _ = Describe("Cilium Hubble Relay Traefik Tests", Label(constants.CiliumHubb
 	})
 
 	PDescribe("Cilium Hubble Relay Traefik Upgrade Test", Ordered, Label("upgrade"), func() {
-		var ciliumHubbleRelayHR *fluxhelmv2beta2.HelmRelease
+		var ciliumHubbleRelayHR *fluxhelmv2.HelmRelease
 
 		It("should install Cilium Hubble Relay Traefik dependencies", func() {
 			installCiliumHubbleRelayTraefikDependencies()
@@ -102,10 +102,10 @@ var _ = Describe("Cilium Hubble Relay Traefik Tests", Label(constants.CiliumHubb
 			err := c.InstallPreviousVersion(ctx, env)
 			Expect(err).To(BeNil())
 
-			ciliumHubbleRelayHR = &fluxhelmv2beta2.HelmRelease{
+			ciliumHubbleRelayHR = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      c.Name(),
@@ -165,10 +165,10 @@ func installCiliumHubbleRelayTraefikDependencies() {
 	err := cm.Install(ctx, env)
 	Expect(err).To(BeNil())
 
-	hr := &fluxhelmv2beta2.HelmRelease{
+	hr := &fluxhelmv2.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       fluxhelmv2beta2.HelmReleaseKind,
-			APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+			Kind:       fluxhelmv2.HelmReleaseKind,
+			APIVersion: fluxhelmv2.GroupVersion.Version,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.CertManager,
@@ -192,10 +192,10 @@ func installCiliumHubbleRelayTraefikDependencies() {
 	}).WithPolling(pollInterval).WithTimeout(5 * time.Minute).Should(Succeed())
 
 	By("Verifying that cert-manager CRDs are installed")
-	certManagerCrds := &fluxhelmv2beta2.HelmRelease{
+	certManagerCrds := &fluxhelmv2.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       fluxhelmv2beta2.HelmReleaseKind,
-			APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+			Kind:       fluxhelmv2.HelmReleaseKind,
+			APIVersion: fluxhelmv2.GroupVersion.Version,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cert-manager-crds",
@@ -229,10 +229,10 @@ func installCiliumHubbleRelayTraefikDependencies() {
 	err = tfk.Install(ctx, env)
 	Expect(err).To(BeNil())
 
-	hr = &fluxhelmv2beta2.HelmRelease{
+	hr = &fluxhelmv2.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       fluxhelmv2beta2.HelmReleaseKind,
-			APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+			Kind:       fluxhelmv2.HelmReleaseKind,
+			APIVersion: fluxhelmv2.GroupVersion.Version,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      tfk.Name(),

--- a/apptests/appscenarios/externaldns_test.go
+++ b/apptests/appscenarios/externaldns_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	fluxhelmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	fluxhelmv2 "github.com/fluxcd/helm-controller/api/v2"
 	apimeta "github.com/fluxcd/pkg/apis/meta"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -41,7 +41,7 @@ var _ = Describe("External DNS Tests", Label("external-dns"), func() {
 
 		var (
 			ed             externalDns
-			hr             *fluxhelmv2beta2.HelmRelease
+			hr             *fluxhelmv2.HelmRelease
 			deploymentList *appsv1.DeploymentList
 		)
 
@@ -50,10 +50,10 @@ var _ = Describe("External DNS Tests", Label("external-dns"), func() {
 			err := ed.Install(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      ed.Name(),
@@ -131,7 +131,7 @@ var _ = Describe("External DNS Tests", Label("external-dns"), func() {
 	Describe("Upgrading external-dns", Ordered, Label("upgrade"), func() {
 		var (
 			ed externalDns
-			hr *fluxhelmv2beta2.HelmRelease
+			hr *fluxhelmv2.HelmRelease
 		)
 
 		It("should install the previous version successfully", func() {
@@ -141,10 +141,10 @@ var _ = Describe("External DNS Tests", Label("external-dns"), func() {
 			err := ed.InstallPreviousVersion(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      ed.Name(),
@@ -200,10 +200,10 @@ var _ = Describe("External DNS Tests", Label("external-dns"), func() {
 			err := ed.Upgrade(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      ed.Name(),

--- a/apptests/appscenarios/gatekeeper_test.go
+++ b/apptests/appscenarios/gatekeeper_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	fluxhelmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	fluxhelmv2 "github.com/fluxcd/helm-controller/api/v2"
 	apimeta "github.com/fluxcd/pkg/apis/meta"
 )
 
@@ -44,7 +44,7 @@ var _ = Describe("GateKeeper Tests", Label("gatekeeper"), func() {
 
 	Describe("GateKeeper Install Test", Ordered, Label("install"), func() {
 		var (
-			gateKeeperHr             *fluxhelmv2beta2.HelmRelease
+			gateKeeperHr             *fluxhelmv2.HelmRelease
 			gateKeeperDeploymentList *appsv1.DeploymentList
 			gateKeeperContainer      corev1.Container
 		)
@@ -53,10 +53,10 @@ var _ = Describe("GateKeeper Tests", Label("gatekeeper"), func() {
 			err := gk.Install(ctx, env)
 			Expect(err).ToNot(HaveOccurred())
 
-			gateKeeperHr = &fluxhelmv2beta2.HelmRelease{
+			gateKeeperHr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      gk.Name(),
@@ -122,7 +122,7 @@ var _ = Describe("GateKeeper Tests", Label("gatekeeper"), func() {
 
 	Describe("GateKeeper Upgrade Test", Ordered, Label("upgrade"), func() {
 		var (
-			gateKeeperHr *fluxhelmv2beta2.HelmRelease
+			gateKeeperHr *fluxhelmv2.HelmRelease
 			projectNS    *corev1.Namespace
 		)
 
@@ -130,10 +130,10 @@ var _ = Describe("GateKeeper Tests", Label("gatekeeper"), func() {
 			err := gk.InstallPreviousVersion(ctx, env)
 			Expect(err).ToNot(HaveOccurred())
 
-			gateKeeperHr = &fluxhelmv2beta2.HelmRelease{
+			gateKeeperHr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      gk.Name(),
@@ -200,17 +200,17 @@ var _ = Describe("GateKeeper Tests", Label("gatekeeper"), func() {
 
 func ensureConstraintEnforced(projectNS string) {
 	By("should require service account name defined in HelmRelease in Project")
-	hr1 := &fluxhelmv2beta2.HelmRelease{
+	hr1 := &fluxhelmv2.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       fluxhelmv2beta2.HelmReleaseKind,
-			APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+			Kind:       fluxhelmv2.HelmReleaseKind,
+			APIVersion: fluxhelmv2.GroupVersion.Version,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "hr-to-be-rejected",
 			Namespace: projectNS, // we are treating this as a project NS
 		},
-		Spec: fluxhelmv2beta2.HelmReleaseSpec{
-			ChartRef: &fluxhelmv2beta2.CrossNamespaceSourceReference{
+		Spec: fluxhelmv2.HelmReleaseSpec{
+			ChartRef: &fluxhelmv2.CrossNamespaceSourceReference{
 				Kind:      "HelmChart",
 				Name:      "external-dns",
 				Namespace: projectNS,

--- a/apptests/appscenarios/karma_test.go
+++ b/apptests/appscenarios/karma_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	fluxhelmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	fluxhelmv2 "github.com/fluxcd/helm-controller/api/v2"
 	apimeta "github.com/fluxcd/pkg/apis/meta"
 	"github.com/mesosphere/kommander-applications/apptests/constants"
 	appsv1 "k8s.io/api/apps/v1"
@@ -54,7 +54,7 @@ var _ = Describe("Karma Tests", Label("karma"), func() {
 
 	Describe("Karma Install Test", Ordered, Label("install"), func() {
 		var (
-			karmaHr             *fluxhelmv2beta2.HelmRelease
+			karmaHr             *fluxhelmv2.HelmRelease
 			karmaDeploymentList *appsv1.DeploymentList
 			karmaContainer      corev1.Container
 		)
@@ -68,10 +68,10 @@ var _ = Describe("Karma Tests", Label("karma"), func() {
 			err := k.Install(ctx, env)
 			Expect(err).To(BeNil())
 
-			karmaHr = &fluxhelmv2beta2.HelmRelease{
+			karmaHr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      k.Name(),
@@ -215,7 +215,7 @@ var _ = Describe("Karma Tests", Label("karma"), func() {
 
 	Describe("Karma Upgrade Test", Ordered, Label("upgrade"), func() {
 		var (
-			karmaHr *fluxhelmv2beta2.HelmRelease
+			karmaHr *fluxhelmv2.HelmRelease
 		)
 
 		It("should install karma dependencies successfully", func() {
@@ -226,10 +226,10 @@ var _ = Describe("Karma Tests", Label("karma"), func() {
 			err := k.InstallPreviousVersion(ctx, env)
 			Expect(err).To(BeNil())
 
-			karmaHr = &fluxhelmv2beta2.HelmRelease{
+			karmaHr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      k.Name(),
@@ -327,10 +327,10 @@ func installKarmaDependencies(k *karma) {
 	err := cm.Install(ctx, env)
 	Expect(err).To(BeNil())
 
-	hr := &fluxhelmv2beta2.HelmRelease{
+	hr := &fluxhelmv2.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       fluxhelmv2beta2.HelmReleaseKind,
-			APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+			Kind:       fluxhelmv2.HelmReleaseKind,
+			APIVersion: fluxhelmv2.GroupVersion.Version,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.CertManager,
@@ -354,10 +354,10 @@ func installKarmaDependencies(k *karma) {
 	}).WithPolling(pollInterval).WithTimeout(5 * time.Minute).Should(Succeed())
 
 	By("Installing cert-manager crds successfully")
-	certManagerCrds := &fluxhelmv2beta2.HelmRelease{
+	certManagerCrds := &fluxhelmv2.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       fluxhelmv2beta2.HelmReleaseKind,
-			APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+			Kind:       fluxhelmv2.HelmReleaseKind,
+			APIVersion: fluxhelmv2.GroupVersion.Version,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cert-manager-crds",
@@ -391,10 +391,10 @@ func installKarmaDependencies(k *karma) {
 	err = tfk.Install(ctx, env)
 	Expect(err).To(BeNil())
 
-	hr = &fluxhelmv2beta2.HelmRelease{
+	hr = &fluxhelmv2.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       fluxhelmv2beta2.HelmReleaseKind,
-			APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+			Kind:       fluxhelmv2.HelmReleaseKind,
+			APIVersion: fluxhelmv2.GroupVersion.Version,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      tfk.Name(),
@@ -421,10 +421,10 @@ func installKarmaDependencies(k *karma) {
 	err = k.InstallDependency(ctx, env, constants.KarmaTraefik)
 	Expect(err).To(BeNil())
 
-	hr = &fluxhelmv2beta2.HelmRelease{
+	hr = &fluxhelmv2.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       fluxhelmv2beta2.HelmReleaseKind,
-			APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+			Kind:       fluxhelmv2.HelmReleaseKind,
+			APIVersion: fluxhelmv2.GroupVersion.Version,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.KarmaTraefik,

--- a/apptests/appscenarios/kubecost_test.go
+++ b/apptests/appscenarios/kubecost_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	fluxhelmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	fluxhelmv2 "github.com/fluxcd/helm-controller/api/v2"
 	apimeta "github.com/fluxcd/pkg/apis/meta"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -45,7 +45,7 @@ var _ = Describe("Kubecost Tests", Label("kubecost"), func() {
 
 		var (
 			kc             kubeCost
-			hr             *fluxhelmv2beta2.HelmRelease
+			hr             *fluxhelmv2.HelmRelease
 			deploymentList *appsv1.DeploymentList
 		)
 
@@ -54,10 +54,10 @@ var _ = Describe("Kubecost Tests", Label("kubecost"), func() {
 			err := kc.Install(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      kc.Name(),
@@ -140,7 +140,7 @@ var _ = Describe("Kubecost Tests", Label("kubecost"), func() {
 	Describe("Upgrading kubecost", Ordered, Label("upgrade"), func() {
 		var (
 			kc kubeCost
-			hr *fluxhelmv2beta2.HelmRelease
+			hr *fluxhelmv2.HelmRelease
 		)
 
 		It("should install the previous version successfully", func() {
@@ -148,10 +148,10 @@ var _ = Describe("Kubecost Tests", Label("kubecost"), func() {
 			err := kc.InstallPreviousVersion(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      kc.Name(),
@@ -207,10 +207,10 @@ var _ = Describe("Kubecost Tests", Label("kubecost"), func() {
 			err := kc.Upgrade(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      kc.Name(),

--- a/apptests/appscenarios/rookceph.go
+++ b/apptests/appscenarios/rookceph.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	fluxhelmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	fluxhelmv2 "github.com/fluxcd/helm-controller/api/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -211,10 +211,10 @@ func (r rookCeph) install(ctx context.Context, env *environment.Env, appPath str
 // applyRookCephOverrideCM applies the overrides configmap to the rook-ceph-cluster HelmRelease. This provides smaller
 // sized buckets and single replicas for the test environment.
 func (r rookCeph) applyRookCephOverrideCM(ctx context.Context, env *environment.Env, cmName string) error {
-	hr := &fluxhelmv2beta2.HelmRelease{
+	hr := &fluxhelmv2.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       fluxhelmv2beta2.HelmReleaseKind,
-			APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+			Kind:       fluxhelmv2.HelmReleaseKind,
+			APIVersion: fluxhelmv2.GroupVersion.Version,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "rook-ceph-cluster",
@@ -234,7 +234,7 @@ func (r rookCeph) applyRookCephOverrideCM(ctx context.Context, env *environment.
 		return fmt.Errorf("could not get the HelmRelease: %w", err)
 	}
 
-	hr.Spec.ValuesFrom = append(hr.Spec.ValuesFrom, fluxhelmv2beta2.ValuesReference{
+	hr.Spec.ValuesFrom = append(hr.Spec.ValuesFrom, fluxhelmv2.ValuesReference{
 		Kind: "ConfigMap",
 		Name: "rook-ceph-cluster-overrides",
 	})

--- a/apptests/appscenarios/rookceph_test.go
+++ b/apptests/appscenarios/rookceph_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	fluxhelmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	fluxhelmv2 "github.com/fluxcd/helm-controller/api/v2"
 	apimeta "github.com/fluxcd/pkg/apis/meta"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -54,7 +54,7 @@ var _ = Describe("Rook Ceph Tests", Label("rook-ceph", "rook-ceph-cluster"), fun
 	Describe("Installing Rook Ceph", Ordered, Label("install"), func() {
 		var (
 			rc             rookCeph
-			hr             *fluxhelmv2beta2.HelmRelease
+			hr             *fluxhelmv2.HelmRelease
 			deploymentList *appsv1.DeploymentList
 		)
 
@@ -63,10 +63,10 @@ var _ = Describe("Rook Ceph Tests", Label("rook-ceph", "rook-ceph-cluster"), fun
 			err := rc.Install(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      rc.Name(),
@@ -146,10 +146,10 @@ var _ = Describe("Rook Ceph Tests", Label("rook-ceph", "rook-ceph-cluster"), fun
 			err = rc.CreateBuckets(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "rook-ceph-cluster",
@@ -174,10 +174,10 @@ var _ = Describe("Rook Ceph Tests", Label("rook-ceph", "rook-ceph-cluster"), fun
 		})
 
 		It("should create storage buckets", func() {
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "object-bucket-claims",
@@ -234,7 +234,7 @@ var _ = Describe("Rook Ceph Tests", Label("rook-ceph", "rook-ceph-cluster"), fun
 	Describe("Upgrading Rook Ceph", Ordered, Label("upgrade"), func() {
 		var (
 			rc rookCeph
-			hr *fluxhelmv2beta2.HelmRelease
+			hr *fluxhelmv2.HelmRelease
 		)
 
 		It("should install the previous version successfully", func() {
@@ -242,10 +242,10 @@ var _ = Describe("Rook Ceph Tests", Label("rook-ceph", "rook-ceph-cluster"), fun
 			err := rc.InstallPreviousVersion(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      rc.Name(),
@@ -304,10 +304,10 @@ var _ = Describe("Rook Ceph Tests", Label("rook-ceph", "rook-ceph-cluster"), fun
 			err = rc.CreateBucketsPreviousVersion(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "rook-ceph-cluster",
@@ -332,10 +332,10 @@ var _ = Describe("Rook Ceph Tests", Label("rook-ceph", "rook-ceph-cluster"), fun
 		})
 
 		It("should create storage buckets", func() {
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "object-bucket-claims",
@@ -401,10 +401,10 @@ var _ = Describe("Rook Ceph Tests", Label("rook-ceph", "rook-ceph-cluster"), fun
 			err := rc.Upgrade(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      rc.Name(),
@@ -464,10 +464,10 @@ var _ = Describe("Rook Ceph Tests", Label("rook-ceph", "rook-ceph-cluster"), fun
 			err = rc.CreateBuckets(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "rook-ceph-cluster",
@@ -492,10 +492,10 @@ var _ = Describe("Rook Ceph Tests", Label("rook-ceph", "rook-ceph-cluster"), fun
 		})
 
 		It("should reconcile storage buckets after upgrade", func() {
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "object-bucket-claims",

--- a/apptests/appscenarios/traefik_test.go
+++ b/apptests/appscenarios/traefik_test.go
@@ -20,7 +20,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	fluxhelmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	fluxhelmv2 "github.com/fluxcd/helm-controller/api/v2"
 	apimeta "github.com/fluxcd/pkg/apis/meta"
 	traefikv1a1 "github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/traefikio/v1alpha1"
 )
@@ -52,7 +52,7 @@ var _ = Describe("Traefik Tests", Label("traefik"), func() {
 
 	Describe("Traefik Install Test", Ordered, Label("install"), func() {
 		var (
-			hr             *fluxhelmv2beta2.HelmRelease
+			hr             *fluxhelmv2.HelmRelease
 			deploymentList *appsv1.DeploymentList
 			podList        *corev1.PodList
 		)
@@ -61,10 +61,10 @@ var _ = Describe("Traefik Tests", Label("traefik"), func() {
 			err := t.Install(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      t.Name(),
@@ -139,7 +139,7 @@ var _ = Describe("Traefik Tests", Label("traefik"), func() {
 
 	Describe("Traefik Upgrade Test", Ordered, Label("upgrade"), func() {
 		var (
-			hr      *fluxhelmv2beta2.HelmRelease
+			hr      *fluxhelmv2.HelmRelease
 			podList *corev1.PodList
 		)
 
@@ -147,10 +147,10 @@ var _ = Describe("Traefik Tests", Label("traefik"), func() {
 			err := t.InstallPreviousVersion(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      t.Name(),
@@ -176,10 +176,10 @@ var _ = Describe("Traefik Tests", Label("traefik"), func() {
 		})
 
 		It("should upgrade traefik successfully", func() {
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      t.Name(),
@@ -226,7 +226,7 @@ var _ = Describe("Traefik Tests", Label("traefik"), func() {
 
 			// Check the status of the HelmReleases
 			By("waiting for HR to get upgraded")
-			Eventually(func() (*fluxhelmv2beta2.HelmRelease, error) {
+			Eventually(func() (*fluxhelmv2.HelmRelease, error) {
 				err := k8sClient.Get(ctx, ctrlClient.ObjectKeyFromObject(hr), hr)
 				return hr, err
 			}, "1m", pollInterval).Should(And(

--- a/apptests/appscenarios/velero_test.go
+++ b/apptests/appscenarios/velero_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	fluxhelmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	fluxhelmv2 "github.com/fluxcd/helm-controller/api/v2"
 	apimeta "github.com/fluxcd/pkg/apis/meta"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -55,7 +55,7 @@ var _ = Describe("Velero Local Backup Tests", Label("velero"), func() {
 		var (
 			v              velero
 			rc             rookCeph
-			hr             *fluxhelmv2beta2.HelmRelease
+			hr             *fluxhelmv2.HelmRelease
 			deploymentList *appsv1.DeploymentList
 		)
 
@@ -64,10 +64,10 @@ var _ = Describe("Velero Local Backup Tests", Label("velero"), func() {
 			err := rc.Install(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      rc.Name(),
@@ -125,10 +125,10 @@ var _ = Describe("Velero Local Backup Tests", Label("velero"), func() {
 			err = rc.CreateBuckets(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "rook-ceph-cluster",
@@ -153,10 +153,10 @@ var _ = Describe("Velero Local Backup Tests", Label("velero"), func() {
 		})
 
 		It("should create storage buckets", func() {
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "object-bucket-claims",
@@ -185,10 +185,10 @@ var _ = Describe("Velero Local Backup Tests", Label("velero"), func() {
 			err := v.Install(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      v.Name(),
@@ -436,7 +436,7 @@ var _ = Describe("Velero Local Backup Tests", Label("velero"), func() {
 		var (
 			v              velero
 			rc             rookCeph
-			hr             *fluxhelmv2beta2.HelmRelease
+			hr             *fluxhelmv2.HelmRelease
 			deploymentList *appsv1.DeploymentList
 		)
 
@@ -445,10 +445,10 @@ var _ = Describe("Velero Local Backup Tests", Label("velero"), func() {
 			err := rc.Install(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      rc.Name(),
@@ -507,10 +507,10 @@ var _ = Describe("Velero Local Backup Tests", Label("velero"), func() {
 			err = rc.CreateBuckets(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "rook-ceph-cluster",
@@ -535,10 +535,10 @@ var _ = Describe("Velero Local Backup Tests", Label("velero"), func() {
 		})
 
 		It("should create storage buckets", func() {
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "object-bucket-claims",
@@ -567,10 +567,10 @@ var _ = Describe("Velero Local Backup Tests", Label("velero"), func() {
 			err := v.InstallPreviousVersion(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      v.Name(),
@@ -808,10 +808,10 @@ var _ = Describe("Velero Local Backup Tests", Label("velero"), func() {
 			err := v.Upgrade(ctx, env)
 			Expect(err).To(BeNil())
 
-			hr = &fluxhelmv2beta2.HelmRelease{
+			hr = &fluxhelmv2.HelmRelease{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       fluxhelmv2beta2.HelmReleaseKind,
-					APIVersion: fluxhelmv2beta2.GroupVersion.Version,
+					Kind:       fluxhelmv2.HelmReleaseKind,
+					APIVersion: fluxhelmv2.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      v.Name(),

--- a/apptests/environment/environment_test.go
+++ b/apptests/environment/environment_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/fluxcd/flux2/v2/pkg/manifestgen"
-	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/mesosphere/kommander-applications/apptests/flux"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,10 +76,10 @@ func TestApplyKustomizations(t *testing.T) {
 	assert.NoError(t, err)
 
 	// assert that following HelmRepository (as an example) is created
-	hr := &sourcev1beta2.HelmRepository{
+	hr := &sourcev1.HelmRepository{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "source.toolkit.fluxcd.io",
-			APIVersion: "v1beta2",
+			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "vmware-tanzu.github.io",

--- a/apptests/flux/apply.go
+++ b/apptests/flux/apply.go
@@ -27,14 +27,12 @@ import (
 	"github.com/fluxcd/cli-utils/pkg/kstatus/polling"
 	"github.com/fluxcd/flux2/v2/pkg/manifestgen/kustomization"
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
-	helmv2b2 "github.com/fluxcd/helm-controller/api/v2beta2"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	runclient "github.com/fluxcd/pkg/runtime/client"
 	"github.com/fluxcd/pkg/ssa"
 	"github.com/fluxcd/pkg/ssa/normalize"
 	ssautils "github.com/fluxcd/pkg/ssa/utils"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
 )
 
 // Apply is the equivalent of 'kubectl apply --server-side -f'.
@@ -150,10 +148,8 @@ func NewScheme() *apiruntime.Scheme {
 	_ = appsv1.AddToScheme(scheme)
 	_ = batchv1.AddToScheme(scheme)
 	_ = networkingv1.AddToScheme(scheme)
-	_ = sourcev1b2.AddToScheme(scheme)
 	_ = sourcev1.AddToScheme(scheme)
 	_ = kustomizev1.AddToScheme(scheme)
-	_ = helmv2b2.AddToScheme(scheme)
 	_ = helmv2.AddToScheme(scheme)
 	return scheme
 }

--- a/apptests/testdata/cert-manager/acme-setup/helmrelease.yaml
+++ b/apptests/testdata/cert-manager/acme-setup/helmrelease.yaml
@@ -14,14 +14,18 @@ spec:
       version: v1.26.0
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
     createNamespace: true
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   releaseName: step-certificates
   targetNamespace: ${releaseNamespace}
   valuesFrom:

--- a/common/kommander-operator/manifests/helmrelease.yaml
+++ b/common/kommander-operator/manifests/helmrelease.yaml
@@ -14,13 +14,17 @@ spec:
         namespace: kommander-flux
   interval: 15s
   install:
+    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
+    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
+  rollback:
+    serverSideApply: enabled
   valuesFrom:
     - kind: ConfigMap
       name: kommander-operator-values


### PR DESCRIPTION
**What problem does this PR solve?**:

Follow up of #4621 

Explicitly use SSA for applications during upgrades.
For fresh installs, flux already defaults to using SSA if the SSA field is omitted.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
