### PR TITLE
fix: remove unnecessary concurrency block

### DIFF
--- a/.github/workflows/application-test-scenario-install.yaml
+++ b/.github/workflows/application-test-scenario-install.yaml
@@ -21,11 +21,6 @@ on:
         required: true
         type: string
 
-# https://stackoverflow.com/a/72408109/3058839
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   run-test-scenario:
     runs-on:

--- a/.github/workflows/application-test-scenario-pdb-drain.yaml
+++ b/.github/workflows/application-test-scenario-pdb-drain.yaml
@@ -21,11 +21,6 @@ on:
         required: true
         type: string
 
-# https://stackoverflow.com/a/72408109/3058839
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   run-test-scenario:
     runs-on:

--- a/.github/workflows/application-test-scenario-upgrade.yaml
+++ b/.github/workflows/application-test-scenario-upgrade.yaml
@@ -31,11 +31,6 @@ on:
 env:
   UPGRADE_KAPPS_REPO_PATH: '.work/upgrade/kommander-applications'
 
-# https://stackoverflow.com/a/72408109/3058839
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
 
   run-test-scenario:


### PR DESCRIPTION
**What problem does this PR solve?**:
app specific test has been skipped due to unnecessary concurrency cancel: https://github.com/mesosphere/kommander-applications/pull/4527/changes#diff-a2a937b6d8b957a983595380918950651667ea4a905921cbfd84abcf72cb0612R24-R28

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-113788

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
