### PR TITLE
fix: bump flux oci mirror 0.3.1 & remove secret stub

### DIFF
--- a/applications/kommander-flux/2.8.5/mirror/flux-oci-mirror.yaml
+++ b/applications/kommander-flux/2.8.5/mirror/flux-oci-mirror.yaml
@@ -1,15 +1,4 @@
 apiVersion: v1
-data:
-  ca.crt: ""
-kind: Secret
-metadata:
-  name: flux-oci-mirror-config
-stringData:
-  config.yaml: |
-    listen_addr: ":8443"
-type: Opaque
----
-apiVersion: v1
 kind: Service
 metadata:
   name: flux-oci-mirror
@@ -48,7 +37,7 @@ spec:
         - args:
             - -config-dir
             - /config
-          image: mesosphere/flux-oci-mirror:v0.3.0
+          image: mesosphere/flux-oci-mirror:v0.3.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -81,6 +70,7 @@ spec:
         - name: flux-oci-mirror-config
           secret:
             secretName: flux-oci-mirror-config
+            optional: true
         - name: proxy-ca
           secret:
             secretName: flux-oci-mirror-ca-secret

--- a/artifacts_full.yaml
+++ b/artifacts_full.yaml
@@ -314,7 +314,7 @@ applications:
     version: 2.8.5
     images:
       - oci://ghcr.io/fluxcd-community/charts/flux2:2.18.3
-      - docker.io/mesosphere/flux-oci-mirror:v0.3.0
+      - docker.io/mesosphere/flux-oci-mirror:v0.3.1
       - ghcr.io/fluxcd/flux-cli:v2.8.5
       - ghcr.io/fluxcd/helm-controller:v1.5.4
       - ghcr.io/fluxcd/image-automation-controller:v1.1.1

--- a/hack/flux/update-flux-oci-mirror.sh
+++ b/hack/flux/update-flux-oci-mirror.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="v0.3.0"
+VERSION="v0.3.1"
 
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -4,7 +4,7 @@ ignore:
   #   sources:
   #     - url: https://github.com/nutanix-cloud-native/flux-oci-mirror
   #       ref: ${image_tag}
-  - docker.io/mesosphere/flux-oci-mirror:v0.3.0
+  - docker.io/mesosphere/flux-oci-mirror:v0.3.1
   - pullthrough.infra.nkp.sh/mesosphere/nkp-mcp:0.0.0-dev.0
 
 resources:


### PR DESCRIPTION
**What problem does this PR solve?**:
flux oci mirror currently lost credential upon re-install due to the empty secret stub

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-112985

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
