### PR TITLE
fix: add dependsOn to opencost apps

### DIFF
--- a/applications/centralized-opencost/2.5.14/helmrelease.yaml
+++ b/applications/centralized-opencost/2.5.14/helmrelease.yaml
@@ -4,6 +4,9 @@ metadata:
   name: centralized-opencost-release
   namespace: ${releaseNamespace}
 spec:
+  dependsOn:
+    - name: thanos
+      namespace: ${releaseNamespace}
   force: false
   prune: true
   wait: true

--- a/applications/opencost/2.5.14/helmrelease.yaml
+++ b/applications/opencost/2.5.14/helmrelease.yaml
@@ -10,6 +10,8 @@ spec:
   interval: 6h
   retryInterval: 1m
   dependsOn:
+    - name: kube-prometheus-stack
+      namespace: ${releaseNamespace}
     - name: opencost-pre-install
       namespace: ${releaseNamespace}
   path: ./applications/opencost/2.5.14/release


### PR DESCRIPTION
**What problem does this PR solve?**:
currently opencost pods can restart couple time because waiting for prometheus pod. add an explicit dependson so that HR of opencost won't even try to spin up if KPS is not ready

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-113306

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
