### PR TITLE
fix(kommander-appmanagement): Remove SSA from HR

### DIFF
--- a/applications/kommander-appmanagement/0.18.0/helmrelease/kommander-appmanagement.yaml
+++ b/applications/kommander-appmanagement/0.18.0/helmrelease/kommander-appmanagement.yaml
@@ -24,17 +24,13 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
-    serverSideApply: true
     crds: CreateReplace
     remediation:
       retries: 30
   upgrade:
-    serverSideApply: enabled
     crds: CreateReplace
     remediation:
       retries: 30
-  rollback:
-    serverSideApply: enabled
   releaseName: kommander-appmanagement
   valuesFrom:
     - kind: ConfigMap


### PR DESCRIPTION


**What problem does this PR solve?**:
Removed serverSideApply settings from install, upgrade, and rollback sections.
Same motivations as https://github.com/mesosphere/kommander-applications/pull/4828
See https://github.com/mesosphere/kommander-cli/blob/4859d41c004a6641c5bffcd8716efe9551a5bbfd/cmd/upgrade/upgrade.go#L67-L68

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-113892

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
