### PR TITLE
fix(kubefed): disable SSA on kubefed install 

### DIFF
--- a/applications/kubefed/0.11.4/release/release.yaml
+++ b/applications/kubefed/0.11.4/release/release.yaml
@@ -22,7 +22,7 @@ spec:
     namespace: ${releaseNamespace}
   interval: 15s
   install:
-    disableTakeOwnership: true # This is needed cuz kubefed controller-manager races with helm-controller for ownership of a KubefedConfig resource created from helm chart.
+    serverSideApply: false
     crds: CreateReplace
     remediation:
       retries: 30


### PR DESCRIPTION
**What problem does this PR solve?**:

The kubefed controller-manager creates/patches KubeFedConfig.spec.scope via SSA with field manager "controller-manager" within ~2 seconds of starting. When Helm also applies the KubeFedConfig via SSA (field manager "helm-controller"), a conflict occurs on .spec.scope because two different field managers claim the same field.

disableTakeOwnership: true does not fix this — it only controls whether Helm force-takes fields from other managers. With it set to true, Helm still attempts the SSA apply but fails with a 409 Conflict instead of silently stealing the field. The install then enters a permanent
retry loop: install -> conflict -> uninstall remediation -> reinstall ->
controller-manager races again -> conflict.

Setting install.serverSideApply: false falls back to client-side apply, which has no field ownership model and bypasses the race entirely.

Upgrade retains SSA (the default) with disableTakeOwnership: true as a safety net — by upgrade time the KubeFedConfig already exists and controller-manager already owns .spec.scope, so Helm should not force-steal it.




**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-113741

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
