### PR TITLE
fix: discover catalog in airgapped

### DIFF
--- a/applications/kommander/0.18.0/helmrelease/cm.yaml
+++ b/applications/kommander/0.18.0/helmrelease/cm.yaml
@@ -137,3 +137,4 @@ data:
       catalogName: nkp-nutanix-product-catalog
       extraLabels: {}
       tag: "" # Defaults to MAJOR.MINOR of KommanderCore when empty.
+      airgappedDiscovery: true


### PR DESCRIPTION
**What problem does this PR solve?**:

Follow up of https://github.com/mesosphere/kommander/pull/7190

Discover catalogs in airgapped mode. Validated this on a real airgapped cluster with @msdolbey 

https://jira.nutanix.com/browse/NCN-113909

