### PR TITLE
fix: remove the uiPath hack for opencost ui 1.120

### DIFF
--- a/applications/opencost/2.5.14/release/cm.yaml
+++ b/applications/opencost/2.5.14/release/cm.yaml
@@ -29,10 +29,10 @@ data:
       ui:
         image:
           registry: ghcr.io
-          repository: nutanix-cloud-native/dkp-container-images/opencost/opencost-ui
+          repository: opencost/opencost
           # to avoid upstream default tag that comes with a SHA
           tag: "1.120.0"
-        uiPath: /dkp/opencost/frontend
+        uiPath: /
         useIPv6: false
         enabled: true
         ingress:
@@ -40,7 +40,7 @@ data:
           ingressClassName: "kommander-traefik"
           annotations:
             traefik.ingress.kubernetes.io/router.tls: "true"
-            traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-forwardauth@kubernetescrd"
+            traefik.ingress.kubernetes.io/router.middlewares: "${workspaceNamespace}-stripprefixes@kubernetescrd,${workspaceNamespace}-forwardauth@kubernetescrd"
           hosts:
             - host: ""
               paths:

--- a/applications/traefik/39.0.7/traefik/cm.yaml
+++ b/applications/traefik/39.0.7/traefik/cm.yaml
@@ -71,6 +71,7 @@ data:
               - /dkp/kommander/monitoring/query
               - /dkp/kubernetes
               - /dkp/prometheus
+              - /dkp/opencost/frontend
       - # Create stripprefix middleware for kubetunnel exposed services.
         # This expects that every TunnelGateway will be launched with
         # `urlPathPrefix: /dkp/tunnel` configuration.

--- a/artifacts_full.yaml
+++ b/artifacts_full.yaml
@@ -466,7 +466,6 @@ applications:
     images:
       - oci://ghcr.io/opencost/charts/opencost:2.5.14
       - docker.io/mesosphere/kubectl:v1.35.2-alpine
-      - ghcr.io/nutanix-cloud-native/dkp-container-images/opencost/opencost-ui:1.120.0
       - ghcr.io/opencost/opencost:1.120.0
   - name: project-grafana-logging
     version: 11.3.3


### PR DESCRIPTION
**What problem does this PR solve?**:
https://github.com/opencost/opencost-ui/pull/215 changed how opencost ui is built and now we dont need to custom build the image and can use our existing stripprefix middleware pattern

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-113307

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
