### PR TITLE
chore: downgrade opencost-ui to 1.119.2

### DIFF
--- a/applications/opencost/2.5.14/release/cm.yaml
+++ b/applications/opencost/2.5.14/release/cm.yaml
@@ -31,7 +31,8 @@ data:
           registry: ghcr.io
           repository: nutanix-cloud-native/dkp-container-images/opencost/opencost-ui
           # to avoid upstream default tag that comes with a SHA
-          tag: "1.120.0"
+          # TODO: use 1.120+ once we know how to integrate the updated frontend build from upstream PR: https://github.com/opencost/opencost-ui/pull/215
+          tag: "1.119.2"
         uiPath: /dkp/opencost/frontend
         useIPv6: false
         enabled: true

--- a/artifacts_full.yaml
+++ b/artifacts_full.yaml
@@ -466,7 +466,7 @@ applications:
     images:
       - oci://ghcr.io/opencost/charts/opencost:2.5.14
       - docker.io/mesosphere/kubectl:v1.35.2-alpine
-      - ghcr.io/nutanix-cloud-native/dkp-container-images/opencost/opencost-ui:1.120.0
+      - ghcr.io/nutanix-cloud-native/dkp-container-images/opencost/opencost-ui:1.119.2
       - ghcr.io/opencost/opencost:1.120.0
   - name: project-grafana-logging
     version: 11.3.3

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -845,7 +845,7 @@ resources:
       - url: https://github.com/opencost/opencost
         ref: v${image_tag}
         license_path: LICENSE
-  - container_image: ghcr.io/nutanix-cloud-native/dkp-container-images/opencost/opencost-ui:1.120.0
+  - container_image: ghcr.io/nutanix-cloud-native/dkp-container-images/opencost/opencost-ui:1.119.2
     sources:
       - url: https://github.com/opencost/opencost-ui
         ref: v${image_tag}


### PR DESCRIPTION
**What problem does this PR solve?**:
currently opencost UI returns empty page on browser

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-113307

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
for now, let's revert the UI only.

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
