### PR TITLE
test: knative minor version check

### DIFF
--- a/apptests/appscenarios/knative.go
+++ b/apptests/appscenarios/knative.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	fluxhelmv2 "github.com/fluxcd/helm-controller/api/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -52,6 +54,69 @@ func (k knative) InstallPreviousVersion(ctx context.Context, env *environment.En
 func (k knative) Upgrade(ctx context.Context, env *environment.Env) error {
 	err := k.install(ctx, env, k.appPathCurrentVersion)
 	return err
+}
+
+func (k knative) ValidateUpgradeVersionStep() error {
+	previous, err := parseKnativeVersionFromPath(k.appPathPreviousVersion)
+	if err != nil {
+		return fmt.Errorf("parse previous Knative version: %w", err)
+	}
+
+	current, err := parseKnativeVersionFromPath(k.appPathCurrentVersion)
+	if err != nil {
+		return fmt.Errorf("parse current Knative version: %w", err)
+	}
+
+	if current.major != previous.major {
+		return fmt.Errorf("unsupported Knative upgrade from %s to %s: major version changes are not allowed", previous, current)
+	}
+	if current.minor < previous.minor {
+		return fmt.Errorf("unsupported Knative upgrade from %s to %s: downgrade is not allowed", previous, current)
+	}
+	if current.minor-previous.minor > 1 {
+		return fmt.Errorf("unsupported Knative upgrade from %s to %s: Knative only supports one minor version upgrade at a time", previous, current)
+	}
+
+	return nil
+}
+
+type knativeVersion struct {
+	major int
+	minor int
+	patch int
+	raw   string
+}
+
+func (v knativeVersion) String() string {
+	return v.raw
+}
+
+func parseKnativeVersionFromPath(path string) (knativeVersion, error) {
+	version := strings.TrimPrefix(filepath.Base(filepath.Clean(path)), "v")
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return knativeVersion{}, fmt.Errorf("expected semantic version directory, got %q", filepath.Base(path))
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return knativeVersion{}, fmt.Errorf("parse major version %q: %w", parts[0], err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return knativeVersion{}, fmt.Errorf("parse minor version %q: %w", parts[1], err)
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return knativeVersion{}, fmt.Errorf("parse patch version %q: %w", parts[2], err)
+	}
+
+	return knativeVersion{
+		major: major,
+		minor: minor,
+		patch: patch,
+		raw:   version,
+	}, nil
 }
 
 func (k knative) install(ctx context.Context, env *environment.Env, appPath string) error {

--- a/apptests/appscenarios/knative_test.go
+++ b/apptests/appscenarios/knative_test.go
@@ -50,8 +50,8 @@ var _ = Describe("Knative Tests", Label("knative"), func() {
 
 	Describe("Knative Install Test", Ordered, Label("install"), func() {
 		var (
-			operatorHr    *fluxhelmv2.HelmRelease
-			deploymentHr  *fluxhelmv2.HelmRelease
+			operatorHr     *fluxhelmv2.HelmRelease
+			deploymentHr   *fluxhelmv2.HelmRelease
 			deploymentList *appsv1.DeploymentList
 		)
 
@@ -152,7 +152,7 @@ var _ = Describe("Knative Tests", Label("knative"), func() {
 						return 0
 					}
 					return len(jobList.Items)
-				}).WithPolling(pollInterval).WithTimeout(3 * time.Minute).Should(
+				}).WithPolling(pollInterval).WithTimeout(3*time.Minute).Should(
 					BeNumerically(">", 0),
 					fmt.Sprintf("expected at least 1 job in namespace %s", ns),
 				)
@@ -223,7 +223,7 @@ var _ = Describe("Knative Tests", Label("knative"), func() {
 					Name:      "knative-ingress-gateway",
 					Namespace: "knative-serving",
 				}, gw)
-			}).WithPolling(pollInterval).WithTimeout(3 * time.Minute).Should(Succeed(),
+			}).WithPolling(pollInterval).WithTimeout(3*time.Minute).Should(Succeed(),
 				"knative-ingress-gateway Gateway must exist in knative-serving after install (regression: NCN-105488)")
 
 			// Verify the gateway has the expected server ports configured
@@ -243,6 +243,10 @@ var _ = Describe("Knative Tests", Label("knative"), func() {
 			operatorHr   *fluxhelmv2.HelmRelease
 			deploymentHr *fluxhelmv2.HelmRelease
 		)
+
+		It("should only upgrade by one Knative minor version", func() {
+			Expect(k.ValidateUpgradeVersionStep()).To(Succeed())
+		})
 
 		It("should install istio-helm as a prerequisite", func() {
 			err := k.InstallIstioHelmDependency(ctx, env)
@@ -369,10 +373,10 @@ var _ = Describe("Knative Tests", Label("knative"), func() {
 
 	Describe("Knative PDB Drain Resilience Test", Ordered, Label("pdb-drain"), func() {
 		var (
-			clientset     *kubernetes.Clientset
-			workerNode    string
-			pdb           *policyv1.PodDisruptionBudget
-			webhookPods   *corev1.PodList
+			clientset   *kubernetes.Clientset
+			workerNode  string
+			pdb         *policyv1.PodDisruptionBudget
+			webhookPods *corev1.PodList
 		)
 
 		It("should install istio-helm as a prerequisite", func() {

--- a/apptests/appscenarios/knative_version_test.go
+++ b/apptests/appscenarios/knative_version_test.go
@@ -1,0 +1,63 @@
+package appscenarios
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKnativeValidateUpgradeVersionStep(t *testing.T) {
+	tests := []struct {
+		name        string
+		previous    string
+		current     string
+		expectedErr string
+	}{
+		{
+			name:     "allows patch upgrade",
+			previous: "1.20.0",
+			current:  "1.20.1",
+		},
+		{
+			name:     "allows one minor upgrade",
+			previous: "1.20.1",
+			current:  "1.21.0",
+		},
+		{
+			name:        "rejects skipped minor upgrade",
+			previous:    "1.19.5",
+			current:     "1.21.0",
+			expectedErr: "only supports one minor version upgrade at a time",
+		},
+		{
+			name:        "rejects downgrade",
+			previous:    "1.21.0",
+			current:     "1.20.1",
+			expectedErr: "downgrade is not allowed",
+		},
+		{
+			name:        "rejects major upgrade",
+			previous:    "1.21.0",
+			current:     "2.0.0",
+			expectedErr: "major version changes are not allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := knative{
+				appPathPreviousVersion: filepath.Join("applications", "knative", tt.previous),
+				appPathCurrentVersion:  filepath.Join("applications", "knative", tt.current),
+			}
+
+			err := k.ValidateUpgradeVersionStep()
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorContains(t, err, tt.expectedErr)
+		})
+	}
+}


### PR DESCRIPTION
**What problem does this PR solve?**:

Adds a Knative-specific upgrade guard to the app scenario tests so unsupported multi-minor Knative upgrades fail fast. Knative operator does not allow upgrades across more than one minor version, and this catches cases like `1.19.x -> 1.21.x` before the test spends time waiting on a Helm upgrade that will never become ready.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://jira.nutanix.com/browse/NCN-114115

**Special notes for your reviewer**:

The guard runs at the start of the `knative && upgrade` app scenario and compares the previous k-apps checkout’s Knative app directory version with the current one.

Validation:
- `go test -run TestKnativeValidateUpgradeVersionStep`
- Full app scenario execution still requires Docker/kind locally:
  `ginkgo --label-filter="knative && upgrade" appscenarios`

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
NONE