### PR TITLE
fix: fixing chart version for rook-ceph and rook-ceph cluster

### DIFF
--- a/applications/rook-ceph-cluster/1.19.5/helmrelease/dashboard-cm.yaml
+++ b/applications/rook-ceph-cluster/1.19.5/helmrelease/dashboard-cm.yaml
@@ -9,5 +9,5 @@ data:
   name: "Rook Ceph Cluster"
   dashboardLink: "/dkp/kommander/ceph-dashboard/"
   docsLink: "https://docs.ceph.com/en/latest/mgr/dashboard/"
-  # Rook Ceph Version can be found at https://github.com/rook/rook/blob/v1.19.4/deploy/charts/rook-ceph-cluster/values.yaml#L97
+  # Rook Ceph Version can be found at https://github.com/rook/rook/blob/v1.19.5/deploy/charts/rook-ceph-cluster/values.yaml#L97
   version: "v19.2.3"

--- a/applications/rook-ceph-cluster/1.19.5/helmrelease/helmrelease.yaml
+++ b/applications/rook-ceph-cluster/1.19.5/helmrelease/helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 1m
   url: "oci://ghcr.io/mesosphere/charts/rook-ceph-cluster"
   ref:
-    tag: v1.19.4
+    tag: v1.19.5
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/applications/rook-ceph/1.19.5/helmrelease/helmrelease.yaml
+++ b/applications/rook-ceph/1.19.5/helmrelease/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 1m
   url: "oci://ghcr.io/mesosphere/charts/rook-ceph"
   ref:
-    tag: v1.19.4
+    tag: v1.19.5
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/artifacts_full.yaml
+++ b/artifacts_full.yaml
@@ -507,14 +507,14 @@ applications:
   - name: rook-ceph
     version: 1.19.5
     images:
-      - oci://ghcr.io/mesosphere/charts/rook-ceph:v1.19.4
-      - docker.io/rook/ceph:v1.19.4
+      - oci://ghcr.io/mesosphere/charts/rook-ceph:v1.19.5
+      - docker.io/rook/ceph:v1.19.5
   - name: rook-ceph-cluster
     version: 1.19.5
     images:
       - oci://ghcr.io/mesosphere/charts/cosi-bucket-kit:0.0.5
       - oci://ghcr.io/mesosphere/charts/object-bucket-claim:0.1.11
-      - oci://ghcr.io/mesosphere/charts/rook-ceph-cluster:v1.19.4
+      - oci://ghcr.io/mesosphere/charts/rook-ceph-cluster:v1.19.5
       - docker.io/mesosphere/kubectl:v1.35.2-alpine
       - quay.io/ceph/ceph:v19.2.3
       - quay.io/ceph/cosi:v0.1.4

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -271,7 +271,7 @@ resources:
         notice_path: NOTICE
         ref: ${image_tag}
         url: https://github.com/open-policy-agent/gatekeeper
-  - container_image: docker.io/rook/ceph:v1.19.4
+  - container_image: docker.io/rook/ceph:v1.19.5
     sources:
       - license_path: LICENSE
         ref: ${image_tag}


### PR DESCRIPTION
**What problem does this PR solve?**:
 - fixing chart version for rook-ceph and rook-ceph cluster, pointing to v1.19.5 tag

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-114203


**Screenshots**
 - Pre-req job was failing before
 
<img width="996" height="199" alt="Screenshot 2026-05-11 at 9 53 27 PM" src="https://github.com/user-attachments/assets/3f811063-8586-42d3-812b-74c7de2ae670" />

