### PR TITLE
feat(gatekeeper): enable mutation, RuntimeDefault seccomp Assign

### DIFF
--- a/applications/gatekeeper/3.22.0/release/cm.yaml
+++ b/applications/gatekeeper/3.22.0/release/cm.yaml
@@ -23,10 +23,12 @@ data:
       excludeNamespacesFromProxy: []
       namespaceSelectorForProxy: {}
       sideEffects: "None"
-      # Default RuntimeDefault seccomp Assign shipped by the
-      # gatekeeper-proxy-mutations chart. A MustNotExist pathTest preserves any
-      # explicit Unconfined / Localhost choice. Opt out per-namespace or
-      # per-pod by setting the optOutLabel to "true".
+      # Opt Kommander into the default RuntimeDefault seccomp Assign shipped
+      # by the gatekeeper-proxy-mutations chart (chart default is
+      # enabled: false so standalone consumers see no behaviour change). A
+      # MustNotExist pathTest preserves any explicit Unconfined / Localhost
+      # choice. Opt out per-namespace or per-pod by setting the optOutLabel
+      # to "true".
       defaultSeccompProfile:
         enabled: true
         optOutLabel: kommander.d2iq.io/disable-default-seccomp

--- a/applications/gatekeeper/3.22.0/release/cm.yaml
+++ b/applications/gatekeeper/3.22.0/release/cm.yaml
@@ -13,6 +13,10 @@ data:
     # Mitigates the DirtyFrag CVE family (CVE-2026-43284, CVE-2026-43500) and
     # unblocks customer-defined Assign/AssignMetadata/AssignImage/ModifySet.
     disableMutation: false
+    # Pin failurePolicy to Ignore (matches the upstream chart default) so a
+    # gatekeeper outage cannot block pod admission cluster-wide, and so the
+    # behaviour cannot silently drift if upstream defaults change.
+    mutatingWebhookFailurePolicy: Ignore
 
     mutations:
       enablePodProxy: false

--- a/applications/gatekeeper/3.22.0/release/cm.yaml
+++ b/applications/gatekeeper/3.22.0/release/cm.yaml
@@ -8,7 +8,11 @@ data:
     ---
     replicas: 2
     disableValidatingWebhook: false
-    disableMutation: true
+    # Mutating webhook is enabled by default so the gatekeeper-proxy-mutations
+    # chart can apply the RuntimeDefault seccomp profile to all pods.
+    # Mitigates the DirtyFrag CVE family (CVE-2026-43284, CVE-2026-43500) and
+    # unblocks customer-defined Assign/AssignMetadata/AssignImage/ModifySet.
+    disableMutation: false
 
     mutations:
       enablePodProxy: false
@@ -19,6 +23,13 @@ data:
       excludeNamespacesFromProxy: []
       namespaceSelectorForProxy: {}
       sideEffects: "None"
+      # Default RuntimeDefault seccomp Assign shipped by the
+      # gatekeeper-proxy-mutations chart. A MustNotExist pathTest preserves any
+      # explicit Unconfined / Localhost choice. Opt out per-namespace or
+      # per-pod by setting the optOutLabel to "true".
+      defaultSeccompProfile:
+        enabled: true
+        optOutLabel: kommander.d2iq.io/disable-default-seccomp
     postInstall:
       labelNamespace:
         enabled: false

--- a/applications/gatekeeper/3.22.0/release/release.yaml
+++ b/applications/gatekeeper/3.22.0/release/release.yaml
@@ -18,7 +18,7 @@ spec:
   interval: 1m
   url: "oci://ghcr.io/mesosphere/charts/gatekeeper-proxy-mutations"
   ref:
-    tag: v0.0.1
+    tag: v0.1.0
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/apptests/appscenarios/gatekeeper_test.go
+++ b/apptests/appscenarios/gatekeeper_test.go
@@ -10,11 +10,21 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	fluxhelmv2 "github.com/fluxcd/helm-controller/api/v2"
 	apimeta "github.com/fluxcd/pkg/apis/meta"
+)
+
+const (
+	gatekeeperProxyMutationsHRName = "gatekeeper-proxy-mutations"
+	mutatingWebhookConfigName      = "gatekeeper-mutating-webhook-configuration"
+	defaultSeccompAssignName       = "pod-seccomp-runtime-default"
+	defaultSeccompOptOutLabel      = "kommander.d2iq.io/disable-default-seccomp"
 )
 
 var _ = Describe("GateKeeper Tests", Label("gatekeeper"), func() {
@@ -118,6 +128,48 @@ var _ = Describe("GateKeeper Tests", Label("gatekeeper"), func() {
 			Expect(err).ToNot(HaveOccurred())
 			ensureConstraintEnforced(projectNS.Name)
 		})
+
+		It("should install the mutating webhook configuration", func() {
+			ensureMutatingWebhookConfiguration()
+		})
+
+		It("should mutate pods without a seccomp profile to RuntimeDefault", func() {
+			By("waiting for the gatekeeper-proxy-mutations HelmRelease to be ready")
+			waitForHelmReleaseReady(gatekeeperProxyMutationsHRName)
+
+			By("waiting for the default seccomp Assign to be created by the chart")
+			waitForDefaultSeccompAssign()
+
+			ns := createNamespace("seccomp-default-test", nil)
+			DeferCleanup(deleteNamespace, ns)
+
+			pod := newPauseSeccompTestPod(ns.Name, "seccomp-default-pod")
+			admittedPod := createPodAndRefetch(pod)
+
+			Expect(admittedPod.Spec.SecurityContext).ToNot(BeNil(),
+				"expected pod-level securityContext to be added by the Assign mutation")
+			Expect(admittedPod.Spec.SecurityContext.SeccompProfile).ToNot(BeNil(),
+				"expected seccompProfile to be set by the Assign mutation")
+			Expect(admittedPod.Spec.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+		})
+
+		It("should not mutate pods in namespaces labeled with the opt-out label", func() {
+			By("waiting for the default seccomp Assign to be created by the chart")
+			waitForDefaultSeccompAssign()
+
+			ns := createNamespace("seccomp-default-test-optout", map[string]string{
+				defaultSeccompOptOutLabel: "true",
+			})
+			DeferCleanup(deleteNamespace, ns)
+
+			pod := newPauseSeccompTestPod(ns.Name, "seccomp-default-pod-optout")
+			admittedPod := createPodAndRefetch(pod)
+
+			if admittedPod.Spec.SecurityContext != nil {
+				Expect(admittedPod.Spec.SecurityContext.SeccompProfile).To(BeNil(),
+					"expected Assign mutation to be skipped in opt-out namespace")
+			}
+		})
 	})
 
 	Describe("GateKeeper Upgrade Test", Ordered, Label("upgrade"), func() {
@@ -195,8 +247,110 @@ var _ = Describe("GateKeeper Tests", Label("gatekeeper"), func() {
 		It("should enforce the default constraints after upgrade", func() {
 			ensureConstraintEnforced(projectNS.Name)
 		})
+
+		It("should have the mutating webhook configuration after upgrade", func() {
+			ensureMutatingWebhookConfiguration()
+		})
 	})
 })
+
+func ensureMutatingWebhookConfiguration() {
+	mwc := &unstructured.Unstructured{}
+	mwc.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "admissionregistration.k8s.io",
+		Version: "v1",
+		Kind:    "MutatingWebhookConfiguration",
+	})
+
+	Eventually(func() error {
+		return k8sClient.Get(ctx, ctrlClient.ObjectKey{Name: mutatingWebhookConfigName}, mwc)
+	}).WithPolling(pollInterval).WithTimeout(2 * time.Minute).Should(Succeed(),
+		"expected MutatingWebhookConfiguration %q to exist after install", mutatingWebhookConfigName)
+
+	webhooks, found, err := unstructured.NestedSlice(mwc.Object, "webhooks")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(found).To(BeTrue(), "expected MutatingWebhookConfiguration to expose webhooks")
+	Expect(webhooks).ToNot(BeEmpty(), "expected at least one webhook entry")
+}
+
+func waitForHelmReleaseReady(name string) {
+	hr := &fluxhelmv2.HelmRelease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       fluxhelmv2.HelmReleaseKind,
+			APIVersion: fluxhelmv2.GroupVersion.Version,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: kommanderNamespace,
+		},
+	}
+	Eventually(func() error {
+		if err := k8sClient.Get(ctx, ctrlClient.ObjectKeyFromObject(hr), hr); err != nil {
+			return err
+		}
+		for _, cond := range hr.Status.Conditions {
+			if cond.Status == metav1.ConditionTrue && cond.Type == apimeta.ReadyCondition {
+				return nil
+			}
+		}
+		return fmt.Errorf("HelmRelease %q not ready yet", name)
+	}).WithPolling(pollInterval).WithTimeout(5 * time.Minute).Should(Succeed())
+}
+
+func waitForDefaultSeccompAssign() {
+	assign := &unstructured.Unstructured{}
+	assign.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "mutations.gatekeeper.sh",
+		Version: "v1",
+		Kind:    "Assign",
+	})
+	Eventually(func() error {
+		return k8sClient.Get(ctx, ctrlClient.ObjectKey{Name: defaultSeccompAssignName}, assign)
+	}).WithPolling(pollInterval).WithTimeout(2 * time.Minute).Should(Succeed(),
+		"expected default seccomp Assign %q to be created by the gatekeeper-proxy-mutations chart", defaultSeccompAssignName)
+}
+
+func createNamespace(name string, labels map[string]string) *corev1.Namespace {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+	Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+	return ns
+}
+
+func deleteNamespace(ns *corev1.Namespace) {
+	if err := k8sClient.Delete(ctx, ns); err != nil && !apierrors.IsNotFound(err) {
+		Expect(err).ToNot(HaveOccurred())
+	}
+}
+
+func newPauseSeccompTestPod(namespace, name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "pause",
+				Image: "registry.k8s.io/pause:3.9",
+			}},
+			TerminationGracePeriodSeconds: ptrInt64(0),
+		},
+	}
+}
+
+func createPodAndRefetch(pod *corev1.Pod) *corev1.Pod {
+	Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+	out := &corev1.Pod{}
+	Expect(k8sClient.Get(ctx, ctrlClient.ObjectKeyFromObject(pod), out)).To(Succeed())
+	return out
+}
+
+func ptrInt64(v int64) *int64 { return &v }
 
 func ensureConstraintEnforced(projectNS string) {
 	By("should require service account name defined in HelmRelease in Project")

--- a/artifacts_full.yaml
+++ b/artifacts_full.yaml
@@ -141,7 +141,7 @@ applications:
   - name: gatekeeper
     version: 3.22.0
     images:
-      - oci://ghcr.io/mesosphere/charts/gatekeeper-proxy-mutations:v0.0.1
+      - oci://ghcr.io/mesosphere/charts/gatekeeper-proxy-mutations:v0.1.0
       - oci://ghcr.io/mesosphere/charts/gatekeeper:3.22.0
       - docker.io/curlimages/curl:8.19.0
       - docker.io/openpolicyagent/gatekeeper-crds:v3.22.0


### PR DESCRIPTION
## Summary

- Enables the Gatekeeper mutating webhook by default (`disableMutation: false`) and ships a default `Assign` mutation that sets `securityContext.seccompProfile` to `RuntimeDefault` on any pod that does not already specify one. Mitigates the DirtyFrag CVE family (CVE-2026-43284 in xfrm-ESP, CVE-2026-43500 in RxRPC), where independent testing on EKS and GKE has shown that pods without a seccomp profile, or with `Unconfined`, can be used to achieve container root.
- Bumps the `gatekeeper-proxy-mutations` OCIRepository tag from `v0.0.1` to `v0.1.0` to pull in the new Assign template, and pins `mutations.defaultSeccompProfile.{enabled, optOutLabel}` explicitly in `cm.yaml`.
- Adds apptest coverage: `MutatingWebhookConfiguration` smoke check, functional pod-mutation test, namespace-label opt-out test, and a post-upgrade smoke check.

The default Assign uses a `MustNotExist` pathTest so explicit `Unconfined`/`Localhost` choices are preserved. Customers (and namespaces) can opt out with the `kommander.d2iq.io/disable-default-seccomp: "true"` label. Side benefit: customers can now ship their own `Assign`/`AssignMetadata`/`AssignImage`/`ModifySet` resources without first having to override the default ConfigMap.

Refs [NCN-114260](https://jira.nutanix.com/browse/NCN-114260).

## Dependency

> [!IMPORTANT]
> This PR cannot merge until [mesosphere/charts#1655](https://github.com/mesosphere/charts/pull/1655) merges **and** chart `gatekeeper-proxy-mutations` `v0.1.0` is published to `oci://ghcr.io/mesosphere/charts/gatekeeper-proxy-mutations`. Until then, the apptests will fail at the `gatekeeper-proxy-mutations` HelmRelease readiness check (and the functional/opt-out tests by extension).

## Test plan

- [ ] Wait for mesosphere/charts#1655 to merge and `gatekeeper-proxy-mutations:v0.1.0` to be published to OCI.
- [ ] CI green on this PR (apptests `gatekeeper` label).
- [ ] Manual sanity check on a kind cluster:
  - [ ] `kubectl get mutatingwebhookconfigurations gatekeeper-mutating-webhook-configuration` exists.
  - [ ] `kubectl get assign pod-seccomp-runtime-default` exists.
  - [ ] `kubectl run --image=registry.k8s.io/pause:3.9 sec-test --restart=Never -n default && kubectl get pod sec-test -o jsonpath='{.spec.securityContext.seccompProfile.type}'` returns `RuntimeDefault`.
  - [ ] Same in a namespace labeled `kommander.d2iq.io/disable-default-seccomp=true` returns empty.
  - [ ] Existing `RequiredServiceAccountName` constraint still rejects `HelmRelease` without a `serviceAccountName` in a project namespace (no regression).
- [ ] Verify the existing postRenderer patch on `MutatingWebhookConfiguration` (D2IQ-92439 workaround) still applies cleanly with mutations enabled and against the gatekeeper 3.22.0 chart's actual rendering.

## Risks

- **Workload regression under `RuntimeDefault`** — containers that need syscalls blocked by the runtime default profile (older JVMs, eBPF/tracing, container builders, etc.) will fail to start after their next pod creation. Mitigated by `MustNotExist` pathTest and the opt-out label. Worth calling out in release notes.
- **Roll-back doesn't strip seccomp from already-running pods** — mutations are admission-time only.
- **Self-managed control-plane static pods bypass the webhook** (Kubernetes property, not a bug).
- **Audit/compliance** — applied manifests will differ from stored manifests; Gatekeeper annotates mutated objects.