### PR TITLE
fix: revert Nvidia doca drivers

### DIFF
--- a/applications/nvidia-network-operator/26.1.0/helmrelease/extra-images.txt
+++ b/applications/nvidia-network-operator/26.1.0/helmrelease/extra-images.txt
@@ -8,7 +8,7 @@ nvcr.io/nvidia/mellanox/k8s-rdma-shared-dev-plugin:network-operator-v{{ .Chart.V
 nvcr.io/nvidia/mellanox/ib-kubernetes:network-operator-v{{ .Chart.Version }}
 nvcr.io/nvidia/mellanox/ipoib-cni:network-operator-v{{ .Chart.Version }}
 nvcr.io/nvidia/doca/doca_telemetry:1.22.5-doca3.1.0-host
-nvcr.io/nvidia/mellanox/doca-driver:doca3.3.0-26.01-1.0.0.0-0-5.15.0-176-generic-ubuntu22.04-amd64
+nvcr.io/nvidia/mellanox/doca-driver:doca3.3.0-26.01-1.0.0.0-0-5.15.0-170-generic-ubuntu22.04-amd64
 nvcr.io/nvidia/mellanox/spectrum-x-operator:network-operator-v{{ .Chart.Version }}
 nvcr.io/nvidia/mellanox/sriov-network-operator:network-operator-v{{ .Chart.Version }}
 nvcr.io/nvidia/mellanox/sriov-network-operator-config-daemon:network-operator-v{{ .Chart.Version }}

--- a/artifacts_full.yaml
+++ b/artifacts_full.yaml
@@ -441,7 +441,7 @@ applications:
       - ghcr.io/k8snetworkplumbingwg/network-resources-injector:v1.8.0
       - nvcr.io/nvidia/cloud-native/network-operator:v26.1.0
       - nvcr.io/nvidia/doca/doca_telemetry:1.22.5-doca3.1.0-host
-      - nvcr.io/nvidia/mellanox/doca-driver:doca3.3.0-26.01-1.0.0.0-0-5.15.0-176-generic-ubuntu22.04-amd64
+      - nvcr.io/nvidia/mellanox/doca-driver:doca3.3.0-26.01-1.0.0.0-0-5.15.0-170-generic-ubuntu22.04-amd64
       - nvcr.io/nvidia/mellanox/ib-kubernetes:network-operator-v26.1.0
       - nvcr.io/nvidia/mellanox/ib-sriov-cni:network-operator-v26.1.0
       - nvcr.io/nvidia/mellanox/ipoib-cni:network-operator-v26.1.0

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -970,8 +970,8 @@ resources:
       - url: nvcr.io/nvidia/doca/doca_telemetry:1.21.4-doca3.0.0-host
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: nvcr.io/nvidia/mellanox/doca-driver:doca3.3.0-26.01-1.0.0.0-0-5.15.0-176-generic-ubuntu22.04-amd64
+  - container_image: nvcr.io/nvidia/mellanox/doca-driver:doca3.3.0-26.01-1.0.0.0-0-5.15.0-170-generic-ubuntu22.04-amd64
     sources:
-      - url: nvcr.io/nvidia/mellanox/doca-driver:doca3.3.0-26.01-1.0.0.0-0-5.15.0-176-generic-ubuntu22.04-amd64
+      - url: nvcr.io/nvidia/mellanox/doca-driver:doca3.3.0-26.01-1.0.0.0-0-5.15.0-170-generic-ubuntu22.04-amd64
         ref: ${image_tag}
         license_path: LICENSE


### PR DESCRIPTION
**What problem does this PR solve?**:
revert the doca driver image, since the new version is not currently available

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
