### PR TITLE
chore(kubefed): bump to latest kubefed chart 0.11.2

### DIFF
--- a/applications/kubefed/0.11.4/release/release.yaml
+++ b/applications/kubefed/0.11.4/release/release.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 1m
   url: "oci://ghcr.io/mesosphere/charts/kubefed"
   ref:
-    tag: 0.11.1
+    tag: 0.11.2
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -28,12 +28,10 @@ spec:
       retries: 30
   targetNamespace: kube-federation-system
   upgrade:
-    serverSideApply: enabled
+    serverSideApply: auto
     crds: CreateReplace
     remediation:
       retries: 30
-  rollback:
-    serverSideApply: enabled
   releaseName: kubefed
   valuesFrom:
     - kind: ConfigMap
@@ -41,32 +39,3 @@ spec:
     - kind: ConfigMap
       name: kubefed-overrides
       optional: true
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: ValidatingWebhookConfiguration
-              name: validations.core.kubefed.io
-            patch: |
-              apiVersion: admissionregistration.k8s.io/v1
-              kind: ValidatingWebhookConfiguration
-              metadata:
-                name: validations.core.kubefed.io
-              webhooks:
-                - name: federatedtypeconfigs.core.kubefed.io
-                  failurePolicy: Ignore
-                - name: kubefedclusters.core.kubefed.io
-                  failurePolicy: Ignore
-                - name: kubefedconfigs.core.kubefed.io
-                  failurePolicy: Ignore
-          - target:
-              kind: MutatingWebhookConfiguration
-              name: mutation.core.kubefed.io
-            patch: |
-              apiVersion: admissionregistration.k8s.io/v1
-              kind: MutatingWebhookConfiguration
-              metadata:
-                name: mutation.core.kubefed.io
-              webhooks:
-                - name: kubefedconfigs.core.kubefed.io
-                  failurePolicy: Ignore

--- a/artifacts_full.yaml
+++ b/artifacts_full.yaml
@@ -353,7 +353,7 @@ applications:
   - name: kubefed
     version: 0.11.4
     images:
-      - oci://ghcr.io/mesosphere/charts/kubefed:0.11.1
+      - oci://ghcr.io/mesosphere/charts/kubefed:0.11.2
       - docker.io/mesosphere/kubectl:v1.35.2-alpine
       - ghcr.io/mesosphere/kubefed:v0.11.2
   - name: kubernetes-dashboard


### PR DESCRIPTION
**What problem does this PR solve?**:

Consume https://github.com/mesosphere/kommander-applications/pkgs/container/charts%2Fkubefed/869547313?tag=0.11.2 from https://github.com/mesosphere/kommander-applications/actions/runs/25969431046

- using `serverSideApply: auto` for upgrade for a more conservative upgrades
- fresh installs continue to have ssa to true
- reverted postRenderers as these are built into helm chart itself now - see https://github.com/mesosphere/kubefed/blob/v0.11.2/charts/kubefed/charts/controllermanager/templates/webhook.yaml#L43 for `failurePolicy`

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
