### PR TITLE
chore(kubefed): bump to v0.11.3 chart

### DIFF
--- a/applications/kubefed/0.11.4/release/cm.yaml
+++ b/applications/kubefed/0.11.4/release/cm.yaml
@@ -19,7 +19,6 @@ data:
       controller:
         repository: ghcr.io/mesosphere
         image: kubefed
-        tag: v0.11.2
         resources:
           limits:
             cpu: 500m
@@ -44,4 +43,3 @@ data:
           secret.reloader.stakater.com/reload: "kubefed-root-ca"
         repository: ghcr.io/mesosphere
         image: kubefed
-        tag: v0.11.2

--- a/applications/kubefed/0.11.4/release/release.yaml
+++ b/applications/kubefed/0.11.4/release/release.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 1m
   url: "oci://ghcr.io/mesosphere/charts/kubefed"
   ref:
-    tag: 0.11.2
+    tag: 0.11.3
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/artifacts_full.yaml
+++ b/artifacts_full.yaml
@@ -353,9 +353,9 @@ applications:
   - name: kubefed
     version: 0.11.4
     images:
-      - oci://ghcr.io/mesosphere/charts/kubefed:0.11.2
+      - oci://ghcr.io/mesosphere/charts/kubefed:0.11.3
       - docker.io/mesosphere/kubectl:v1.35.2-alpine
-      - ghcr.io/mesosphere/kubefed:v0.11.2
+      - ghcr.io/mesosphere/kubefed:v0.11.3
   - name: kubernetes-dashboard
     version: 7.14.1
     images:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -538,7 +538,7 @@ resources:
         ref: ${image_tag}
         url: https://github.com/kube-logging/logging-operator
         directory: /images/node-exporter
-  - container_image: ghcr.io/mesosphere/kubefed:v0.11.2
+  - container_image: ghcr.io/mesosphere/kubefed:v0.11.3
     sources:
       - license_path: LICENSE
         ref: ${image_tag}


### PR DESCRIPTION
**What problem does this PR solve?**:

Consume https://github.com/mesosphere/kubefed/pull/65

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
