### PR TITLE
chore: Update Traefik CRD urls

### DIFF
--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -35,9 +35,9 @@ additional_crds:
   - https://raw.githubusercontent.com/mesosphere/charts/refs/heads/master/stable/cosi/crds/apiextensions.k8s.io_v1_customresourcedefinition_bucketclaims.objectstorage.k8s.io.yaml
   - https://raw.githubusercontent.com/mesosphere/charts/refs/heads/master/stable/cosi/crds/apiextensions.k8s.io_v1_customresourcedefinition_bucketclasses.objectstorage.k8s.io.yaml
   - https://raw.githubusercontent.com/mesosphere/charts/refs/heads/master/stable/cosi/crds/apiextensions.k8s.io_v1_customresourcedefinition_buckets.objectstorage.k8s.io.yaml
-  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/refs/heads/master/traefik-crds/crds-files/traefik/traefik.io_ingressroutes.yaml # for nkp-pulse-management
-  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/refs/heads/master/traefik-crds/crds-files/traefik/traefik.io_ingressroutetcps.yaml # for cilium-hubble-relay-traefik
-  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/refs/heads/master/traefik-crds/crds-files/traefik/traefik.io_middlewares.yaml # for harbor
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/refs/tags/v37.1.2/traefik-crds/crds-files/traefik/traefik.io_ingressroutes.yaml # for nkp-pulse-management
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/refs/tags/v37.1.2/traefik-crds/crds-files/traefik/traefik.io_ingressroutetcps.yaml # for cilium-hubble-relay-traefik
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/refs/tags/v37.1.2/traefik-crds/crds-files/traefik/traefik.io_middlewares.yaml # for harbor
   - https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/heads/main/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml # for harbor
   - https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/heads/main/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml # for ESO and many others
   - https://raw.githubusercontent.com/traefik/traefik-helm-chart/refs/heads/master/traefik-crds/crds-files/traefik/traefik.io_tlsoptions.yaml # for karma

--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -38,9 +38,9 @@ additional_crds:
   - https://raw.githubusercontent.com/traefik/traefik-helm-chart/refs/tags/v37.1.2/traefik-crds/crds-files/traefik/traefik.io_ingressroutes.yaml # for nkp-pulse-management
   - https://raw.githubusercontent.com/traefik/traefik-helm-chart/refs/tags/v37.1.2/traefik-crds/crds-files/traefik/traefik.io_ingressroutetcps.yaml # for cilium-hubble-relay-traefik
   - https://raw.githubusercontent.com/traefik/traefik-helm-chart/refs/tags/v37.1.2/traefik-crds/crds-files/traefik/traefik.io_middlewares.yaml # for harbor
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/refs/tags/v37.1.2/traefik-crds/crds-files/traefik/traefik.io_tlsoptions.yaml # for karma
   - https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/heads/main/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml # for harbor
   - https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/heads/main/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml # for ESO and many others
-  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/refs/heads/master/traefik-crds/crds-files/traefik/traefik.io_tlsoptions.yaml # for karma
   - https://raw.githubusercontent.com/kube-logging/logging-operator/refs/heads/master/charts/logging-operator/crds/logging.banzaicloud.io_flows.yaml # for project logging
   - https://raw.githubusercontent.com/kube-logging/logging-operator/refs/heads/master/charts/logging-operator/crds/logging.banzaicloud.io_outputs.yaml # for project logging
 


### PR DESCRIPTION
**What problem does this PR solve?**:

Fix this CI issue:
```
accumulating resources: accumulation err='accumulating resources from 'https://raw.githubusercontent.com/traefik/traefik-helm-chart/refs/heads/master/traefik-crds/crds-files/traefik/traefik.io_ingressroutes.yaml': URL is a git repository': failed to run '/home/runner/_work/kommander-applications/kommander-applications/.devbox/nix/profile/default/bin/git fetch --depth=1 https://raw.githubusercontent.com/traefik/traefik-helm-chart HEAD': remote: 404: Not Found
```

Use the matching Traefik version tag to retrieve the CRDs for Bloodhound.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
