### PR TITLE
ci: publish using catalog cli

### DIFF
--- a/just/release.just
+++ b/just/release.just
@@ -47,10 +47,10 @@ release-oci publish="true" tmp_dir=`mktemp --directory`: (_prepare-files-for-a-b
 release-platform-collection-artifact publish="true": install-tools
   export git_tag="{{ git_tag }}" filename="{{ justfile_directory() }}/kommander-applications-platform-collection-{{ git_tag }}.tar"
   envsubst -i "{{ justfile_directory() }}/releases/release-spec.yaml.tmpl" -o "{{ justfile_directory() }}/releases/release-spec.yaml"
-  {{nkp_cli_bin}} experimental catalog release --release-spec "{{ justfile_directory() }}/releases/release-spec.yaml" --repo-dir {{ justfile_directory() }}
   if {{ publish }}; then
-    {{nkp_cli_bin}} push bundle --bundle {{ justfile_directory() }}/kommander-applications-platform-collection-{{ git_tag }}.tar --to-registry {{ registry }}/{{ org_name }}
+    {{nkp_cli_bin}} experimental catalog release --release-spec "{{ justfile_directory() }}/releases/release-spec.yaml" --repo-dir {{ justfile_directory() }} --push-to-registry {{ registry }}/{{ org_name }}
   else
+    {{nkp_cli_bin}} experimental catalog release --release-spec "{{ justfile_directory() }}/releases/release-spec.yaml" --repo-dir {{ justfile_directory() }}
     echo "Skipping publish"
   fi
 


### PR DESCRIPTION
**What problem does this PR solve?**:

Unblocking dev.40 to workaround strictness of layout introduced in https://github.com/mesosphere/mindthegap/releases/tag/v1.26.0 
We should fix the fundamental issue in nkp-catalog-cli and then we can revert this PR if we want.
