### PR TITLE
fix(postrelease): Do not resolve releaseNamespace

### DIFF
--- a/hack/release/pkg/appversion/appversion.go
+++ b/hack/release/pkg/appversion/appversion.go
@@ -28,6 +28,12 @@ var (
 			constants.SemverRegexp +
 			`(?P<suffix>(-config-defaults)|(-overrides))`,
 	)
+	// applications/kommander/0.4.0/dynamic-helmreleases
+	bloodhoundPathVersion = regexp.MustCompile(
+		`(?P<prefix>applications/kommander/)` +
+			constants.SemverRegexp +
+			`(?P<suffix>/dynamic-helmreleases)`,
+	)
 )
 
 func SetKommanderAppsVersion(ctx context.Context, dir string, version string) error {
@@ -88,7 +94,7 @@ func ReplaceContent(ctx context.Context, dir, version string) (int, error) {
 			}
 		}
 
-		if !d.Type().IsRegular() || filepath.Ext(d.Name()) != ".yaml" {
+		if !d.Type().IsRegular() || !shouldProcessFile(relPath, d.Name()) {
 			return nil
 		}
 
@@ -117,14 +123,8 @@ func replaceContentInFile(ctx context.Context, file string, version string) (int
 	for fscanner.Scan() {
 		text := fscanner.Text()
 
-		newText := varNames.ReplaceAllStringFunc(text, func(match string) string {
-			newValue, ok := replaceInString(match, version)
-			if ok {
-				changes++
-				return newValue
-			}
-			return match
-		})
+		newText := replaceVersionPattern(text, varNames, version, &changes)
+		newText = replaceVersionPattern(newText, bloodhoundPathVersion, version, &changes)
 
 		_, _ = fmt.Fprintln(output, newText)
 	}
@@ -165,14 +165,33 @@ func move(ctx context.Context, dir, oldVersion, newVersion string) error {
 	return nil
 }
 
-func replaceInString(input, replace string) (string, bool) {
-	prefixIndex := varNames.SubexpIndex("prefix")
-	suffixIndex := varNames.SubexpIndex("suffix")
+func replaceVersionPattern(input string, pattern *regexp.Regexp, version string, changes *int) string {
+	return pattern.ReplaceAllStringFunc(input, func(match string) string {
+		newValue, ok := replaceInPattern(pattern, match, version)
+		if ok {
+			(*changes)++
+			return newValue
+		}
+		return match
+	})
+}
 
-	match := varNames.FindStringSubmatch(input)
-	if len(match) < suffixIndex {
+func replaceInPattern(pattern *regexp.Regexp, input, replace string) (string, bool) {
+	prefixIndex := pattern.SubexpIndex("prefix")
+	suffixIndex := pattern.SubexpIndex("suffix")
+
+	match := pattern.FindStringSubmatch(input)
+	if len(match) <= suffixIndex || prefixIndex < 0 || suffixIndex < 0 {
 		return "", false
 	}
 
 	return match[prefixIndex] + replace + match[suffixIndex], true
+}
+
+func shouldProcessFile(relPath, fileName string) bool {
+	if relPath == ".bloodhound.yml" {
+		return true
+	}
+
+	return filepath.Ext(fileName) == ".yaml"
 }

--- a/hack/release/pkg/appversion/appversion_test.go
+++ b/hack/release/pkg/appversion/appversion_test.go
@@ -26,6 +26,23 @@ func TestMove(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestReplaceContentInFile_BloodhoundPathVersion(t *testing.T) {
+	f := filepath.Join(t.TempDir(), ".bloodhound.yml")
+	content := `paths:
+  - applications/kommander/0.18.0/dynamic-helmreleases
+`
+	require.NoError(t, os.WriteFile(f, []byte(content), 0o644))
+
+	changes, err := replaceContentInFile(context.Background(), f, "0.99.99")
+	require.NoError(t, err)
+	assert.Equal(t, 1, changes)
+
+	got, err := os.ReadFile(f)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "applications/kommander/0.99.99/dynamic-helmreleases")
+	assert.NotContains(t, string(got), "applications/kommander/0.18.0/dynamic-helmreleases")
+}
+
 func fetchRepo(t *testing.T) string {
 	t.Helper()
 

--- a/hack/release/pkg/chartversion/chartversion.go
+++ b/hack/release/pkg/chartversion/chartversion.go
@@ -7,12 +7,12 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/fluxcd/pkg/envsubst"
 	"github.com/mesosphere/kommander-applications/hack/release/pkg/constants"
 )
 
 // kommanderChartVersionDefaultRegex extracts the default value from ${kommanderChartVersion:=v2.18.0-dev}.
 var kommanderChartVersionDefaultRegex = regexp.MustCompile(`\$\{kommanderChartVersion:=([^}]+)\}`)
+var kommanderChartVersionVarRegex = regexp.MustCompile(`\$\{kommanderChartVersion(?::[-=][^}]*)?\}`)
 
 const kommanderChartVersionTemplate = "${kommanderChartVersion:=%s}"
 
@@ -97,17 +97,17 @@ func UpdateChartVersions(kommanderApplicationsRepo, chartVersion string) error {
 }
 
 func replaceKommanderVersion(filePath string, subVars map[string]string) error {
-	parsedFile, err := envsubst.ParseFile(filePath)
+	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return err
 	}
-	updatedFile, err := parsedFile.Execute(func(s string) (string, bool) {
-		// Match prior drone/envsubst behavior: unset keys expand to empty string.
-		return subVars[s], true
-	})
-	if err != nil {
-		return err
+
+	newVersion, ok := subVars["kommanderChartVersion"]
+	if !ok {
+		return fmt.Errorf("kommanderChartVersion substitution variable is required")
 	}
+
+	updatedFile := kommanderChartVersionVarRegex.ReplaceAllString(string(content), newVersion)
 
 	if !strings.Contains(updatedFile, subVars["kommanderChartVersion"]) {
 		return fmt.Errorf("failed to update Kommander chart version in %s", filePath)

--- a/hack/release/pkg/chartversion/chartversion_test.go
+++ b/hack/release/pkg/chartversion/chartversion_test.go
@@ -266,3 +266,31 @@ image: mesosphere/x:` + oldVer + "\n"
 	// On-disk YAML must still have two backslashes before "d" (four in a Go "..." literal).
 	assert.Contains(t, s, "[1-9]\\\\d*", "CEL pattern must keep \\\\d, not collapse to \\d")
 }
+
+func TestReplaceKommanderVersion_PreservesReleaseNamespaceExpressions(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "flux-kustomization.yaml")
+	const (
+		oldVer = "${kommanderChartVersion:=v2.0.0-dev}"
+		newVer = "${kommanderChartVersion:=v9.9.9}"
+	)
+	content := `kind: Kustomization
+metadata:
+  labels:
+    release-namespace: "${releaseNamespace}"
+  namespace: "${releaseNamespace:-kommander}"
+  annotations:
+    managementplane.nkp.nutanix.com/version: "` + oldVer + `"
+`
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+
+	subVars := map[string]string{"kommanderChartVersion": newVer}
+	require.NoError(t, replaceKommanderVersion(p, subVars))
+
+	out, err := os.ReadFile(p)
+	require.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, newVer)
+	assert.Contains(t, s, "${releaseNamespace}")
+	assert.Contains(t, s, "${releaseNamespace:-kommander}")
+}


### PR DESCRIPTION
**What problem does this PR solve?**:
fix postrelease script (issues here https://github.com/mesosphere/kommander-applications/pull/4905)

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
