### PR TITLE
chore: Revert #4912 - add ai applications catalog for future

### DIFF
--- a/applications/kommander/0.18.0/helmrelease/cm.yaml
+++ b/applications/kommander/0.18.0/helmrelease/cm.yaml
@@ -138,8 +138,3 @@ data:
       extraLabels: {}
       tag: "" # Defaults to MAJOR.MINOR of KommanderCore when empty.
       airgappedDiscovery: true
-    - resourceURI: oci://ghcr.io/nutanix-cloud-native/nkp-ai-applications-catalog/collection
-      catalogName: nkp-ai-applications-catalog
-      extraLabels: {}
-      tag: 2.18.0
-      airgappedDiscovery: false


### PR DESCRIPTION
**What problem does this PR solve?**:

This reverts #4912
The target catalog: https://github.com/nutanix-cloud-native/nkp-ai-applications-catalog needs to be public for this, and its private right now. 

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-114727

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
