### PR TITLE
build: pass --legacy-catalog flag

### DIFF
--- a/make/validate.mk
+++ b/make/validate.mk
@@ -17,7 +17,7 @@ list-airgapped-artifacts-yaml: $(NKP_CLI_BIN) $(YQ_BIN)
 
 .PHONY: generate-artifacts-yaml
 generate-artifacts-yaml: $(NKP_CLI_BIN)
-	$(NKP_CLI_BIN) validate catalog-repository --repo-dir $(REPO_ROOT) --config $(REPO_ROOT)/.bloodhound.yml --artifacts-output $(REPO_ROOT)/$(FULL_BUNDLE_FILE)
+	$(NKP_CLI_BIN) validate catalog-repository --repo-dir $(REPO_ROOT) --config $(REPO_ROOT)/.bloodhound.yml --artifacts-output $(REPO_ROOT)/$(FULL_BUNDLE_FILE) --legacy-catalog
 	@echo "Generated $(FULL_BUNDLE_FILE):"
 	@cat $(REPO_ROOT)/$(FULL_BUNDLE_FILE)
 


### PR DESCRIPTION
**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->

https://jira.nutanix.com/browse/NCN-113693

related PRs: https://github.com/mesosphere/dkp-bloodhound/pull/285 , https://github.com/nutanix-cloud-native/nkp-catalog-cli/pull/117

adds `--legacy-catalog` flag, which will swallow fs constraint errors for `cert-manager` and `gatekeeper`

# todo:
where to bump nkp CLI

