### PR TITLE
feat: Nvidia drivers for 2.18

### DIFF
--- a/applications/nvidia-gpu-operator/26.3.0/helmrelease/extra-images.txt
+++ b/applications/nvidia-gpu-operator/26.3.0/helmrelease/extra-images.txt
@@ -5,8 +5,8 @@ nvcr.io/nvidia/k8s-device-plugin:{{ .Values.devicePlugin.version }}
 nvcr.io/nvidia/cloud-native/k8s-mig-manager:{{ .Values.migManager.version }}
 # This corresponds to the kernel version 5.15.0-170-generic that the ubuntu pro images that we ship.
 # When the kernel changes this should change too.
-nvcr.io/nvidia/driver:580-5.15.0-176-generic-ubuntu22.04
+nvcr.io/nvidia/driver:580-5.15.0-174-generic-ubuntu22.04
 # precompiled driver for ubuntu 24.04
-nvcr.io/nvidia/driver:580-6.8.0-111-generic-ubuntu24.04
+nvcr.io/nvidia/driver:580-6.8.0-107-generic-ubuntu24.04
 nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0
 nvcr.io/nvidia/cloud-native/k8s-driver-manager:{{ .Values.driver.manager.version }}

--- a/applications/nvidia-network-operator/26.1.0/helmrelease/extra-images.txt
+++ b/applications/nvidia-network-operator/26.1.0/helmrelease/extra-images.txt
@@ -8,7 +8,8 @@ nvcr.io/nvidia/mellanox/k8s-rdma-shared-dev-plugin:network-operator-v{{ .Chart.V
 nvcr.io/nvidia/mellanox/ib-kubernetes:network-operator-v{{ .Chart.Version }}
 nvcr.io/nvidia/mellanox/ipoib-cni:network-operator-v{{ .Chart.Version }}
 nvcr.io/nvidia/doca/doca_telemetry:1.22.5-doca3.1.0-host
-nvcr.io/nvidia/mellanox/doca-driver:doca3.3.0-26.01-1.0.0.0-0-5.15.0-170-generic-ubuntu22.04-amd64
+nvcr.io/nvidia/mellanox/doca-driver:doca3.2.2-25.10-2.4.1.0-4-5.15.0-174-generic-ubuntu22.04-amd64
+nvcr.io/nvidia/mellanox/doca-driver:doca3.2.2-25.10-2.4.1.0-4-6.8.0-107-generic-ubuntu24.04-amd64
 nvcr.io/nvidia/mellanox/spectrum-x-operator:network-operator-v{{ .Chart.Version }}
 nvcr.io/nvidia/mellanox/sriov-network-operator:network-operator-v{{ .Chart.Version }}
 nvcr.io/nvidia/mellanox/sriov-network-operator-config-daemon:network-operator-v{{ .Chart.Version }}

--- a/artifacts_full.yaml
+++ b/artifacts_full.yaml
@@ -441,7 +441,8 @@ applications:
       - ghcr.io/k8snetworkplumbingwg/network-resources-injector:v1.8.0
       - nvcr.io/nvidia/cloud-native/network-operator:v26.1.0
       - nvcr.io/nvidia/doca/doca_telemetry:1.22.5-doca3.1.0-host
-      - nvcr.io/nvidia/mellanox/doca-driver:doca3.3.0-26.01-1.0.0.0-0-5.15.0-170-generic-ubuntu22.04-amd64
+      - nvcr.io/nvidia/mellanox/doca-driver:doca3.2.2-25.10-2.4.1.0-4-5.15.0-174-generic-ubuntu22.04-amd64
+      - nvcr.io/nvidia/mellanox/doca-driver:doca3.2.2-25.10-2.4.1.0-4-6.8.0-107-generic-ubuntu24.04-amd64
       - nvcr.io/nvidia/mellanox/ib-kubernetes:network-operator-v26.1.0
       - nvcr.io/nvidia/mellanox/ib-sriov-cni:network-operator-v26.1.0
       - nvcr.io/nvidia/mellanox/ipoib-cni:network-operator-v26.1.0

--- a/artifacts_full.yaml
+++ b/artifacts_full.yaml
@@ -427,8 +427,8 @@ applications:
       - nvcr.io/nvidia/cloud-native/dcgm:4.5.2-1-ubuntu22.04
       - nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.10.0
       - nvcr.io/nvidia/cloud-native/k8s-mig-manager:v0.14.0
-      - nvcr.io/nvidia/driver:580-5.15.0-176-generic-ubuntu22.04
-      - nvcr.io/nvidia/driver:580-6.8.0-111-generic-ubuntu24.04
+      - nvcr.io/nvidia/driver:580-5.15.0-174-generic-ubuntu22.04
+      - nvcr.io/nvidia/driver:580-6.8.0-107-generic-ubuntu24.04
       - nvcr.io/nvidia/gpu-operator:v26.3.0
       - nvcr.io/nvidia/k8s-device-plugin:v0.19.0
       - nvcr.io/nvidia/k8s/container-toolkit:v1.19.0

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -588,13 +588,13 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag%-ubuntu20.04}
         url: https://github.com/NVIDIA/mig-parted
-  - container_image: nvcr.io/nvidia/driver:580-5.15.0-176-generic-ubuntu22.04
+  - container_image: nvcr.io/nvidia/driver:580-5.15.0-174-generic-ubuntu22.04
     sources:
       - license_path: LICENSE
         ref: main
         directory: /ubuntu22.04/precompiled
         url: https://github.com/NVIDIA/gpu-driver-container
-  - container_image: nvcr.io/nvidia/driver:580-6.8.0-111-generic-ubuntu24.04
+  - container_image: nvcr.io/nvidia/driver:580-6.8.0-107-generic-ubuntu24.04
     sources:
       - license_path: LICENSE
         ref: main

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -985,8 +985,13 @@ resources:
       - url: nvcr.io/nvidia/doca/doca_telemetry:1.21.4-doca3.0.0-host
         ref: ${image_tag}
         license_path: LICENSE
-  - container_image: nvcr.io/nvidia/mellanox/doca-driver:doca3.3.0-26.01-1.0.0.0-0-5.15.0-170-generic-ubuntu22.04-amd64
+  - container_image: nvcr.io/nvidia/mellanox/doca-driver:doca3.2.2-25.10-2.4.1.0-4-5.15.0-174-generic-ubuntu22.04-amd64
     sources:
-      - url: nvcr.io/nvidia/mellanox/doca-driver:doca3.3.0-26.01-1.0.0.0-0-5.15.0-170-generic-ubuntu22.04-amd64
+      - url: nvcr.io/nvidia/mellanox/doca-driver:doca3.2.2-25.10-2.4.1.0-4-5.15.0-174-generic-ubuntu22.04-amd64
+        ref: ${image_tag}
+        license_path: LICENSE
+  - container_image: nvcr.io/nvidia/mellanox/doca-driver:doca3.2.2-25.10-2.4.1.0-4-6.8.0-107-generic-ubuntu24.04-amd64
+    sources:
+      - url: nvcr.io/nvidia/mellanox/doca-driver:doca3.2.2-25.10-2.4.1.0-4-6.8.0-107-generic-ubuntu24.04-amd64
         ref: ${image_tag}
         license_path: LICENSE


### PR DESCRIPTION
**What problem does this PR solve?**:
for nkp 2.18, the OOTB Ubuntu image kernel version are fixed as below
```
Ubuntu22.04: 5.15.0-174 
Ubntu24.04: 6.8.0-107
```

ref: https://nutanix.slack.com/archives/C069QMDB2QM/p1779294735109589?thread_ts=1776916597.660739&cid=C069QMDB2QM

so respective precompiled driver images are bundled for gpu and network operator

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-114777

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
