### PR TITLE
chore: add ai applications catalog for future

### DIFF
--- a/applications/kommander/0.18.0/helmrelease/cm.yaml
+++ b/applications/kommander/0.18.0/helmrelease/cm.yaml
@@ -138,3 +138,8 @@ data:
       extraLabels: {}
       tag: "" # Defaults to MAJOR.MINOR of KommanderCore when empty.
       airgappedDiscovery: true
+    - resourceURI: oci://ghcr.io/nutanix-cloud-native/nkp-ai-applications-catalog/collection
+      catalogName: nkp-ai-applications-catalog
+      extraLabels: {}
+      tag: 2.18.0
+      airgappedDiscovery: false


### PR DESCRIPTION
Reverts mesosphere/kommander-applications#4915

[jira.nutanix.com/browse/NCN-114727](https://jira.nutanix.com/browse/NCN-114727) 

Lets reserve 2.18.0 for amd apps in 2.18.0 