### PR TITLE
fix: Adjust Knative webhook memory default

### DIFF
--- a/applications/knative/1.20.2/helmrelease/cm.yaml
+++ b/applications/knative/1.20.2/helmrelease/cm.yaml
@@ -86,6 +86,16 @@ data:
           deployments:
             - name: eventing-webhook
               replicas: 3
+              # Upstream defaults a 200Mi memory limit which the webhook routinely
+              # exceeds, causing OOMKills/CrashLoopBackOff.
+              resources:
+                - container: eventing-webhook
+                  requests:
+                    cpu: 100m
+                    memory: 100Mi
+                  limits:
+                    cpu: 500m
+                    memory: 500Mi
               affinity:
                 podAntiAffinity:
                   preferredDuringSchedulingIgnoredDuringExecution:

--- a/apptests/appscenarios/knative_test.go
+++ b/apptests/appscenarios/knative_test.go
@@ -16,6 +16,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -201,6 +202,10 @@ var _ = Describe("Knative Tests", Label("knative"), func() {
 				}
 				return nil
 			}).WithPolling(pollInterval).WithTimeout(5 * time.Minute).Should(Succeed())
+		})
+
+		It("should override the eventing-webhook memory limit above the upstream default (NCN-115013)", func() {
+			assertEventingWebhookMemoryLimit(ctx)
 		})
 
 		It("should create the knative-ingress-gateway in knative-serving (NCN-105488)", func() {
@@ -807,6 +812,80 @@ func assertNoDigestImages(ctx context.Context, namespace string) {
 			"These images are missing registry overrides in cm.yaml and will fail in airgapped installs. "+
 			"Run hack/knative/extract-images.py to regenerate overrides.",
 			len(digestViolations), namespace))
+}
+
+// assertEventingWebhookMemoryLimit verifies that the eventing-webhook operand
+// Deployment carries the memory limit we override in cm.yaml rather than the
+// upstream Knative default. The upstream chart ships a 200Mi memory limit which
+// the webhook routinely exceeds, causing OOMKilled / CrashLoopBackOff
+// (NCN-115013). cm.yaml raises it via the KnativeEventing CR
+// (spec.deployments[].resources); this asserts the override propagates all the
+// way through the operator to the reconciled Deployment.
+func assertEventingWebhookMemoryLimit(ctx context.Context) {
+	GinkgoHelper()
+
+	// The upstream default that caused the OOMKills. The override must be
+	// strictly above this, and at least the value we configure in cm.yaml.
+	upstreamDefault := resource.MustParse("200Mi")
+	configuredFloor := resource.MustParse("500Mi")
+
+	const (
+		deploymentName = "eventing-webhook"
+		containerName  = "eventing-webhook"
+		namespace      = "knative-eventing"
+	)
+
+	webhookContainer := func(d *appsv1.Deployment) *corev1.Container {
+		for i := range d.Spec.Template.Spec.Containers {
+			if d.Spec.Template.Spec.Containers[i].Name == containerName {
+				return &d.Spec.Template.Spec.Containers[i]
+			}
+		}
+		return nil
+	}
+
+	deployment := &appsv1.Deployment{}
+	// The operator may briefly reconcile the upstream default before applying
+	// our override, so poll until the limit reflects the override.
+	Eventually(func() error {
+		if err := k8sClient.Get(ctx, ctrlClient.ObjectKey{
+			Name:      deploymentName,
+			Namespace: namespace,
+		}, deployment); err != nil {
+			return err
+		}
+
+		c := webhookContainer(deployment)
+		if c == nil {
+			return fmt.Errorf("%s container not found in %s deployment", containerName, deploymentName)
+		}
+
+		limit, ok := c.Resources.Limits[corev1.ResourceMemory]
+		if !ok {
+			return fmt.Errorf("%s has no memory limit set", deploymentName)
+		}
+		if limit.Cmp(configuredFloor) < 0 {
+			return fmt.Errorf("%s memory limit %s has not reached the configured floor %s yet",
+				deploymentName, limit.String(), configuredFloor.String())
+		}
+		return nil
+	}).WithPolling(pollInterval).WithTimeout(5 * time.Minute).Should(Succeed())
+
+	container := webhookContainer(deployment)
+	Expect(container).NotTo(BeNil(), "eventing-webhook container should exist in the deployment")
+
+	memLimit := container.Resources.Limits[corev1.ResourceMemory]
+	Expect(memLimit.Cmp(upstreamDefault)).To(BeNumerically(">", 0),
+		fmt.Sprintf("eventing-webhook memory limit (%s) must exceed the upstream %s default that causes OOMKills (NCN-115013)",
+			memLimit.String(), upstreamDefault.String()))
+	Expect(memLimit.Cmp(configuredFloor)).To(BeNumerically(">=", 0),
+		fmt.Sprintf("eventing-webhook memory limit (%s) should be at least the %s we set in cm.yaml",
+			memLimit.String(), configuredFloor.String()))
+
+	memRequest, hasRequest := container.Resources.Requests[corev1.ResourceMemory]
+	Expect(hasRequest).To(BeTrue(), "eventing-webhook should declare a memory request")
+	Expect(memRequest.Cmp(memLimit)).To(BeNumerically("<=", 0),
+		"eventing-webhook memory request should not exceed its limit")
 }
 
 // assertKnativeServiceQueueProxy deploys a minimal Knative Service and verifies


### PR DESCRIPTION
**What problem does this PR solve?**:

The Knative `eventing-webhook` pods ship with the upstream default memory limit
of `200Mi`, which the webhook routinely exceeds. On a fresh Knative install the
three `eventing-webhook` replicas get `OOMKilled` and enter `CrashLoopBackOff`,
taking turns crashing. This blocks Knative from becoming healthy.

This PR overrides the `eventing-webhook` resources via the `KnativeEventing` CR
(`spec.deployments[].resources`) in the Knative `cm.yaml`, raising the memory
limit from the upstream `200Mi` to `500Mi` (and the request from `50Mi` to
`100Mi`, cpu limit `200m` -> `500m`). The override flows through the
knative-operator onto the operand `eventing-webhook` Deployment.

It also adds an app-test spec that installs Knative and asserts the operand
`eventing-webhook` Deployment carries a memory limit above the upstream default
(>= the configured floor), so a future regression that drops the override back
to `200Mi` is caught in CI.

**Which issue(s) does this PR fix?**:

https://jira.nutanix.com/browse/NCN-115013

**Special notes for your reviewer**:

- The limit was never set by us previously; `200Mi` is the upstream Knative
  eventing default. We only ever set `replicas: 3` + anti-affinity for this
  deployment, so this is purely additive.
- `500Mi` is a conservative floor, not derived from the reporter's Grafana
  numbers in the support bundle. If you'd prefer a value right-sized to the
  observed peak, happy to adjust.
- The test lives in the existing `Knative Install Test` Ordered block
  (`apptests/appscenarios/knative_test.go`) next to the sibling specs that
  assert replicas/anti-affinity/PDB; it reuses the already-installed cluster so
  it adds negligible runtime.
- Verified locally against a kind cluster:
  `ginkgo --label-filter="knative && install"` → `7 Passed | 0 Failed`, with the
  new spec ("should override the eventing-webhook memory limit above the
  upstream default (NCN-115013)") passing.

**Does this PR introduce a user-facing change?**:

```release-note
Fix Knative `eventing-webhook` pods OOMKilling/CrashLoopBackOff on install by raising the webhook memory limit above the upstream 200Mi default. (NCN-115013)
```

**Checklist**

- [x] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA). — NA, no version bump / licensing change.
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP). — This changes the Knative app's `cm.yaml` (resource override only). Please confirm whether this warrants an app-version bump or is acceptable as an in-place fix to `1.20.2`.