### PR TITLE
chore: Add backport configuration file (.backportrc.json)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,3 @@
+{
+  "prTitle": "{{{commitMessages}}} (backport to {{targetBranch}})"
+}


### PR DESCRIPTION
**What problem does this PR solve?**:

Backport PRs generated by the `sorenlouv/backport-github-action` use the action's
default title template, `[{{targetBranch}}] {{commitMessages}}`. The leading
`[release-x.y]` prefix means the conventional-commit type (`fix:`, `feat:`, etc.)
is no longer at the start of the title, so the `Lint PR` workflow
(`amannn/action-semantic-pull-request`) fails on every backport with
"No release type found in pull request title".

Until now this has required manually editing each backport PR title to move the
release marker after the type. This PR adds a `.backportrc.json` with a custom
`prTitle` so backport titles keep the conventional type first
(e.g. `fix: Adjust Knative webhook memory (#4970) (backport to release-2.18)`),
passing both the conventional-commit check and the 72-char title length check
automatically.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
- Uses `{{{commitMessages}}}` (triple braces) to avoid the Handlebars HTML-escaping
  issue documented for this action.
- Uses `commitMessages` rather than `sourcePullRequest.title` so the original
  `(#xxxx)` reference is preserved, matching the content of the action's previous
  default — just reordered.
- Only `prTitle` is overridden; all other action defaults still apply, and
  `repoOwner`/`repoName` come from the workflow context so they're not needed here.
- This applies to future backports only; existing open backport PRs still need
  their titles edited manually.

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
NONE
```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [x] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [x] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).