### PR TITLE
fix: preserve project-level OBC during Loki v2 to v3 migration

### DIFF
--- a/applications/project-grafana-loki/0.80.6/helmrelease/object-bucket-claims.yaml
+++ b/applications/project-grafana-loki/0.80.6/helmrelease/object-bucket-claims.yaml
@@ -41,3 +41,18 @@ spec:
       name: project-grafana-loki-overrides
       optional: true
   targetNamespace: ${releaseNamespace}
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: objectbucket.io
+              version: v1alpha1
+              kind: ObjectBucketClaim
+              name: proj-loki-${releaseNamespace}
+            patch: |
+              apiVersion: objectbucket.io/v1alpha1
+              kind: ObjectBucketClaim
+              metadata:
+                name: proj-loki-${releaseNamespace}
+                annotations:
+                  helm.sh/resource-policy: keep


### PR DESCRIPTION
## Summary
Adds a Flux postRenderers patch to the project-loki-object-bucket-claims HelmRelease that injects helm.sh/resource-policy: keep annotation on the project-level ObjectBucketClaim (proj-loki-<project-namespace>)
This prevents the OBC (and its associated S3 bucket, Secret, ConfigMap, and ObjectBucket) from being deleted when project-grafana-loki is uninstalled during migration to project-grafana-loki-v3

## Problem
During migration from project-grafana-loki (v2) to project-grafana-loki-v3, the v2 app is deleted after v3 is deployed and running. When the v2 project-loki-object-bucket-claims HelmRelease is deleted, Flux triggers helm uninstall, which deletes the ObjectBucketClaim proj-loki-<namespace>. Since the dkp-object-store StorageClass has reclaimPolicy: Delete, the Rook OBC provisioner then:

Deletes the S3 bucket in Ceph (purging all stored log data)
Deletes the Secret containing S3 credentials
Deletes the ConfigMap containing bucket endpoint info
Deletes the cluster-scoped ObjectBucket
This causes:

Data loss: All historical logs stored by Loki are permanently destroyed
v3 pod failures: Loki v3 pods enter CreateContainerConfigError because the Secret they reference via extraEnvFrom no longer exists


## Solution
A Flux postRenderers Kustomize patch is added to the v2 OBC HelmRelease. The post-renderer injects helm.sh/resource-policy: keep directly into the chart's rendered output before Helm stores it in the release manifest. This is critical because:

helm uninstall only reads the resource-policy annotation from its stored manifest, not from the live resource ([helm/helm#10890](https://github.com/helm/helm/issues/10890), [helm/helm#8132](https://github.com/helm/helm/issues/8132))
Adding the annotation via kubectl annotate does not work for helm uninstall — this is a known, long-standing Helm bug (unfixed as of Helm v4.2.0)
The postRenderers approach ensures the annotation is part of the stored manifest after the next Flux reconciliation/Helm upgrade


The patch is scoped to only the project-level Loki OBC (proj-loki-<namespace>), not all ObjectBucketClaims.

### Migration workflow with this fix
1. v3 deployed alongside v2 (old version)
2. v2 upgraded (this change) → Flux reconciles → keep annotation stored in Helm manifest
3. v2 deleted → helm uninstall skips OBC → OBC, Secret, data all survive
4. v3 takes over OBC ownership via SSA

## Related ticket
https://jira.nutanix.com/browse/NCN-115114