### PR TITLE
fix(apptests): fix version discovery and upgrade teardown

### DIFF
--- a/apptests/catalog/app.go
+++ b/apptests/catalog/app.go
@@ -82,6 +82,24 @@ func (a *App) Upgrade(ctx context.Context, env *environment.Env) error {
 	return a.install(ctx, env, appPath)
 }
 
+// versionDirs returns all subdirectories of dir, sorted lexicographically.
+// os.ReadDir guarantees lexicographic ordering, so no explicit sort is needed.
+// Only directories are returned; non-directory entries such as .catalog-source.yaml
+// or README.md are skipped to avoid being mistaken for version directories.
+func versionDirs(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var dirs []string
+	for _, e := range entries {
+		if e.IsDir() {
+			dirs = append(dirs, filepath.Join(dir, e.Name()))
+		}
+	}
+	return dirs, nil
+}
+
 // HasPreviousVersion reports whether the app has a version directory that
 // sorts before the configured version, making an upgrade test meaningful.
 func (a *App) HasPreviousVersion() bool {
@@ -89,7 +107,7 @@ func (a *App) HasPreviousVersion() bool {
 	if err != nil {
 		return false
 	}
-	matches, err := filepath.Glob(filepath.Join(dir, "*"))
+	matches, err := versionDirs(dir)
 	if err != nil {
 		return false
 	}
@@ -120,7 +138,7 @@ func absolutePathTo(application, appVersion string) (string, error) {
 		return pathToApp, nil
 	}
 
-	matches, err := filepath.Glob(filepath.Join(dir, "*"))
+	matches, err := versionDirs(dir)
 	if err != nil {
 		return "", err
 	}
@@ -138,7 +156,7 @@ func getPrevVersionPath(application string) (string, error) {
 		return "", err
 	}
 
-	matches, err := filepath.Glob(filepath.Join(dir, "*"))
+	matches, err := versionDirs(dir)
 	if err != nil {
 		return "", err
 	}

--- a/apptests/catalog/template.go
+++ b/apptests/catalog/template.go
@@ -89,13 +89,15 @@ func RegisterDefaultTests(appName string) {
 
 		Describe("Upgrading "+appName, Ordered, Label("upgrade"), func() {
 			var (
-				app *App
-				hr  *fluxhelmv2.HelmRelease
+				app     *App
+				hr      *fluxhelmv2.HelmRelease
+				skipped bool
 			)
 
 			BeforeAll(func() {
 				app = NewAppScenario(appName, *AppVersion).(*App)
 				if !app.HasPreviousVersion() {
+					skipped = true
 					Skip("skipping upgrade test: no previous version available")
 				}
 
@@ -110,6 +112,9 @@ func RegisterDefaultTests(appName string) {
 			})
 
 			AfterAll(func() {
+				if skipped {
+					return
+				}
 				Expect(TeardownCluster()).To(Succeed())
 			})
 

--- a/artifacts_full.yaml
+++ b/artifacts_full.yaml
@@ -302,7 +302,6 @@ applications:
       - docker.io/mesosphere/kommander2-licensing-controller-manager:v2.19.0-dev
       - docker.io/mesosphere/kommander2-licensing-webhook:v2.19.0-dev
       - ghcr.io/mesosphere/kommander-applications-server:v2.19.0-dev
-      - quay.io/brancz/kube-rbac-proxy:v0.21.1
   - name: kommander-appmanagement
     version: 0.19.0
     images:
@@ -310,7 +309,6 @@ applications:
       - docker.io/mesosphere/kommander2-appmanagement-webhook:v2.19.0-dev
       - docker.io/mesosphere/kommander2-appmanagement:v2.19.0-dev
       - docker.io/mesosphere/kommander2-kubetools:v2.19.0-dev
-      - quay.io/brancz/kube-rbac-proxy:v0.21.1
   - name: kommander-flux
     version: 2.8.5
     images:


### PR DESCRIPTION
**What problem does this PR solve?**:

**Problem 1:** Apps with .catalog-source.yaml incorrectly trigger the upgrade test
Any Helm-based app that has a .catalog-source.yaml file in its application directory (e.g. applications/milvus-operator/) was incorrectly entering the upgrade test path even when only one version exists.
```
• [FAILED] [84.680 seconds]
milvus-operator Tests Upgrading milvus-operator [It] should install the previous version successfully [milvus-operator, upgrade]
/home/ubuntu/go/pkg/mod/github.com/mesosphere/kommander-applications/apptests@v0.0.0-20260602203912-22d7748db63a/catalog/template.go:116

  [FAILED] Unexpected error:
      <*fmt.wrapError | 0x816a2383560>: 
      could not build kustomization manifest for path: /home/ubuntu/nkp-ai-applications-catalog/applications/milvus-operator/.catalog-source.yaml/helmrelease :must build at directory: not a valid directory: evalsymlink failure on '/home/ubuntu/nkp-ai-applications-catalog/applications/milvus-operator/.catalog-source.yaml/helmrelease' : not a directory
      {
          msg: "could not build kustomization manifest for path: /home/ubuntu/nkp-ai-applications-catalog/applications/milvus-operator/.catalog-source.yaml/helmrelease :must build at directory: not a valid directory: evalsymlink failure on '/home/ubuntu/nkp-ai-applications-catalog/applications/milvus-operator/.catalog-source.yaml/helmrelease' : not a directory",
          err: <*errors.Error | 0x816a16fd630>{
              Err: <*fmt.wrapError | 0x816a23834a0>{
                  msg: "evalsymlink failure on '/home/ubuntu/nkp-ai-applications-catalog/applications/milvus-operator/.catalog-source.yaml/helmrelease' : not a directory",
                  err: <syscall.Errno>0x14,
              },
              stack: [0x2cf0bcb, 0x2d71ce8, 0x2d9ec7a, 0x2fe7308, 0x3280bf3, 0x343b4ab, 0x343b565, 0x343d577, 0x33e1633, 0x33f8719, 0x1593521],
              frames: nil,
              prefix: "must build at directory: not a valid directory",
          },
      }
  occurred
  In [It] at: /home/ubuntu/go/pkg/mod/github.com/mesosphere/kommander-applications/apptests@v0.0.0-20260602203912-22d7748db63a/catalog/template.go:118 @ 06/22/26 09:04:35.714
```
_Root cause:_ HasPreviousVersion() used filepath.Glob(dir + "/*") which, unlike the shell *, matches dotfiles in Go. This caused .catalog-source.yaml to be included in the version list. Since . sorts before any digit, .catalog-source.yaml was treated as a "previous version", causing the upgrade test to run and fail:
_Fix:_ replaced filepath.Glob with os.ReadDir + IsDir() filter via a new versionDirs helper, which returns only subdirectories. This correctly skips any non-directory entries.

**Problem 2:** Cluster teardown fails when upgrade test is legitimately skipped
When HasPreviousVersion() returns false, BeforeAll calls Skip() before SetupKindCluster(). However, AfterAll still ran unconditionally and called TeardownCluster(), which tried to destroy a Kind cluster that was never created — resulting in a spurious AfterAll failure.
_Fix:_ added a skipped bool flag that is set before Skip() is called. AfterAll now returns early if skipped is true, avoiding teardown of a non-existent cluster.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
[NCN-114470](https://jira.nutanix.com/browse/NCN-114470)

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
