### PR TITLE
chore: bumping versino of kps grafana in ui page

### DIFF
--- a/applications/kube-prometheus-stack/82.13.6/metadata.yaml
+++ b/applications/kube-prometheus-stack/82.13.6/metadata.yaml
@@ -32,7 +32,7 @@ overview: |-
 
   - [Prometheus Alertmanager Documentation - Overview](https://prometheus.io/docs/alerting/latest/alertmanager/)
 
-  ### Grafana (v11.6.1)
+  ### Grafana (v12.4.1)
   A monitoring dashboard from Grafana that can be used to visualize metrics collected by Prometheus.
 
   - [Grafana Documentation](https://grafana.com/docs/)


### PR DESCRIPTION
**What problem does this PR solve?**:
Wrong version of the Grafana Dashboard link used in KPS

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-115371

**Special notes for your reviewer**:
Grabbed from here:
https://github.com/mesosphere/kommander-applications/blob/release-2.18/applications/kube-prometheus-stack/82.13.6/helmrelease/kube-prometheus-stack.yaml#L89


**Does this PR introduce a user-facing change?**:
No