### PR TITLE
test: handle Kubernetes 409 Conflict

### DIFF
--- a/applications/project-grafana-loki/0.80.6/helmrelease/object-bucket-claims.yaml
+++ b/applications/project-grafana-loki/0.80.6/helmrelease/object-bucket-claims.yaml
@@ -41,18 +41,3 @@ spec:
       name: project-grafana-loki-overrides
       optional: true
   targetNamespace: ${releaseNamespace}
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              group: objectbucket.io
-              version: v1alpha1
-              kind: ObjectBucketClaim
-              name: proj-loki-${releaseNamespace}
-            patch: |
-              apiVersion: objectbucket.io/v1alpha1
-              kind: ObjectBucketClaim
-              metadata:
-                name: proj-loki-${releaseNamespace}
-                annotations:
-                  helm.sh/resource-policy: keep

--- a/applications/project-grafana-loki/0.80.6/helmrelease/object-bucket-claims.yaml
+++ b/applications/project-grafana-loki/0.80.6/helmrelease/object-bucket-claims.yaml
@@ -41,3 +41,18 @@ spec:
       name: project-grafana-loki-overrides
       optional: true
   targetNamespace: ${releaseNamespace}
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: objectbucket.io
+              version: v1alpha1
+              kind: ObjectBucketClaim
+              name: proj-loki-${releaseNamespace}
+            patch: |
+              apiVersion: objectbucket.io/v1alpha1
+              kind: ObjectBucketClaim
+              metadata:
+                name: proj-loki-${releaseNamespace}
+                annotations:
+                  helm.sh/resource-policy: keep

--- a/apptests/appscenarios/grafana_loki_v3.go
+++ b/apptests/appscenarios/grafana_loki_v3.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/mesosphere/kommander-applications/apptests/constants"
@@ -160,17 +161,6 @@ func (g grafanaLokiV3) applyTestOverrides(ctx context.Context, env *environment.
 }
 
 func (g grafanaLokiV3) patchHelmReleaseWithOverrides(ctx context.Context, env *environment.Env) error {
-	hr := &fluxhelmv2.HelmRelease{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       fluxhelmv2.HelmReleaseKind,
-			APIVersion: fluxhelmv2.GroupVersion.Version,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      g.Name(),
-			Namespace: kommanderNamespace,
-		},
-	}
-
 	genericClient, err := ctrlClient.New(env.K8sClient.Config(), ctrlClient.Options{
 		Scheme: flux.NewScheme(),
 	})
@@ -178,21 +168,30 @@ func (g grafanaLokiV3) patchHelmReleaseWithOverrides(ctx context.Context, env *e
 		return fmt.Errorf("could not create the generic client: %w", err)
 	}
 
-	err = genericClient.Get(ctx, ctrlClient.ObjectKeyFromObject(hr), hr)
-	if err != nil {
-		return fmt.Errorf("could not get the HelmRelease: %w", err)
-	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		hr := &fluxhelmv2.HelmRelease{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       fluxhelmv2.HelmReleaseKind,
+				APIVersion: fluxhelmv2.GroupVersion.Version,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      g.Name(),
+				Namespace: kommanderNamespace,
+			},
+		}
 
-	hr.Spec.ValuesFrom = append(hr.Spec.ValuesFrom, fluxhelmv2.ValuesReference{
-		Kind: "ConfigMap",
-		Name: "grafana-loki-v3-test-overrides",
+		err := genericClient.Get(ctx, ctrlClient.ObjectKeyFromObject(hr), hr)
+		if err != nil {
+			return fmt.Errorf("could not get the HelmRelease: %w", err)
+		}
+
+		hr.Spec.ValuesFrom = append(hr.Spec.ValuesFrom, fluxhelmv2.ValuesReference{
+			Kind: "ConfigMap",
+			Name: "grafana-loki-v3-test-overrides",
+		})
+
+		return genericClient.Update(ctx, hr)
 	})
-	err = genericClient.Update(ctx, hr)
-	if err != nil {
-		return fmt.Errorf("could not update the HelmRelease: %w", err)
-	}
-
-	return nil
 }
 
 func (g grafanaLokiV3) waitForMinIOReady(ctx context.Context, env *environment.Env) error {

--- a/apptests/appscenarios/project_grafana_loki_v3.go
+++ b/apptests/appscenarios/project_grafana_loki_v3.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/mesosphere/kommander-applications/apptests/constants"
@@ -160,17 +161,6 @@ func (p projectGrafanaLokiV3) applyTestOverrides(ctx context.Context, env *envir
 }
 
 func (p projectGrafanaLokiV3) patchHelmReleaseWithOverrides(ctx context.Context, env *environment.Env) error {
-	hr := &fluxhelmv2.HelmRelease{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       fluxhelmv2.HelmReleaseKind,
-			APIVersion: fluxhelmv2.GroupVersion.Version,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      p.Name(),
-			Namespace: kommanderNamespace,
-		},
-	}
-
 	genericClient, err := ctrlClient.New(env.K8sClient.Config(), ctrlClient.Options{
 		Scheme: flux.NewScheme(),
 	})
@@ -178,21 +168,30 @@ func (p projectGrafanaLokiV3) patchHelmReleaseWithOverrides(ctx context.Context,
 		return fmt.Errorf("could not create the generic client: %w", err)
 	}
 
-	err = genericClient.Get(ctx, ctrlClient.ObjectKeyFromObject(hr), hr)
-	if err != nil {
-		return fmt.Errorf("could not get the HelmRelease: %w", err)
-	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		hr := &fluxhelmv2.HelmRelease{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       fluxhelmv2.HelmReleaseKind,
+				APIVersion: fluxhelmv2.GroupVersion.Version,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      p.Name(),
+				Namespace: kommanderNamespace,
+			},
+		}
 
-	hr.Spec.ValuesFrom = append(hr.Spec.ValuesFrom, fluxhelmv2.ValuesReference{
-		Kind: "ConfigMap",
-		Name: "project-grafana-loki-v3-test-overrides",
+		err := genericClient.Get(ctx, ctrlClient.ObjectKeyFromObject(hr), hr)
+		if err != nil {
+			return fmt.Errorf("could not get the HelmRelease: %w", err)
+		}
+
+		hr.Spec.ValuesFrom = append(hr.Spec.ValuesFrom, fluxhelmv2.ValuesReference{
+			Kind: "ConfigMap",
+			Name: "project-grafana-loki-v3-test-overrides",
+		})
+
+		return genericClient.Update(ctx, hr)
 	})
-	err = genericClient.Update(ctx, hr)
-	if err != nil {
-		return fmt.Errorf("could not update the HelmRelease: %w", err)
-	}
-
-	return nil
 }
 
 func (p projectGrafanaLokiV3) waitForMinIOReady(ctx context.Context, env *environment.Env) error {

--- a/apptests/appscenarios/project_grafana_loki_v3.go
+++ b/apptests/appscenarios/project_grafana_loki_v3.go
@@ -10,6 +10,7 @@ import (
 	fluxhelmv2 "github.com/fluxcd/helm-controller/api/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -60,6 +61,12 @@ func (p projectGrafanaLokiV3) InstallPreviousVersion(ctx context.Context, env *e
 }
 
 func (p projectGrafanaLokiV3) install(ctx context.Context, env *environment.Env, appPath string) error {
+	// The project HelmRelease uses serviceAccountName for Flux impersonation.
+	// Create the SA and grant it cluster-admin so helm-controller can install the chart.
+	if err := p.createHelmServiceAccount(ctx, env); err != nil {
+		return fmt.Errorf("creating helm service account: %w", err)
+	}
+
 	// Create the project-level OBC secret for S3 credentials.
 	if err := p.createOBCSecret(ctx, env); err != nil {
 		return fmt.Errorf("creating OBC secret: %w", err)
@@ -97,6 +104,46 @@ func (p projectGrafanaLokiV3) install(ctx context.Context, env *environment.Env,
 	// Patch the HelmRelease to include the test overrides ConfigMap
 	if err := p.patchHelmReleaseWithOverrides(ctx, env); err != nil {
 		return fmt.Errorf("patching HelmRelease with overrides: %w", err)
+	}
+
+	return nil
+}
+
+func (p projectGrafanaLokiV3) createHelmServiceAccount(ctx context.Context, env *environment.Env) error {
+	client, err := ctrlClient.New(env.K8sClient.Config(), ctrlClient.Options{})
+	if err != nil {
+		return err
+	}
+
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kommanderNamespace,
+			Namespace: kommanderNamespace,
+		},
+	}
+	if err := ctrlClient.IgnoreAlreadyExists(client.Create(ctx, sa)); err != nil {
+		return fmt.Errorf("creating ServiceAccount: %w", err)
+	}
+
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-cluster-admin", kommanderNamespace),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      kommanderNamespace,
+				Namespace: kommanderNamespace,
+			},
+		},
+	}
+	if err := ctrlClient.IgnoreAlreadyExists(client.Create(ctx, crb)); err != nil {
+		return fmt.Errorf("creating ClusterRoleBinding: %w", err)
 	}
 
 	return nil

--- a/artifacts_full.yaml
+++ b/artifacts_full.yaml
@@ -302,7 +302,6 @@ applications:
       - docker.io/mesosphere/kommander2-licensing-controller-manager:v2.19.0-dev
       - docker.io/mesosphere/kommander2-licensing-webhook:v2.19.0-dev
       - ghcr.io/mesosphere/kommander-applications-server:v2.19.0-dev
-      - quay.io/brancz/kube-rbac-proxy:v0.21.1
   - name: kommander-appmanagement
     version: 0.19.0
     images:
@@ -310,7 +309,6 @@ applications:
       - docker.io/mesosphere/kommander2-appmanagement-webhook:v2.19.0-dev
       - docker.io/mesosphere/kommander2-appmanagement:v2.19.0-dev
       - docker.io/mesosphere/kommander2-kubetools:v2.19.0-dev
-      - quay.io/brancz/kube-rbac-proxy:v0.21.1
   - name: kommander-flux
     version: 2.8.5
     images:


### PR DESCRIPTION
**What problem does this PR solve?**:
error:
```
 patching HelmRelease with overrides: could not update the HelmRelease: Operation cannot be fulfilled on helmreleases.helm.toolkit.fluxcd.io "grafana-loki-v3": the object has been modified; please apply your changes to the latest version and try again
```
This is a classic Kubernetes 409 Conflict (optimistic concurrency) error. 

- for project-grafana-loki-v3, service account resource was missing, added that.

### The Fix
Wrap the get-modify-update cycle in retry.RetryOnConflict, which automatically re-fetches and retries on conflict errors. This is the same pattern already used in traefik_test.go in this repo.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-115383

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
