### PR TITLE
fix(kps): Add metrics-auth service monitor

### DIFF
--- a/applications/kube-prometheus-stack/82.13.6/helmrelease/cm.yaml
+++ b/applications/kube-prometheus-stack/82.13.6/helmrelease/cm.yaml
@@ -74,6 +74,16 @@ data:
             # Service port for external-dns
             - targetPort: 7979
               interval: 30s
+        - name: dkp-service-monitor-metrics-auth
+          selector:
+            matchLabels:
+              servicemonitor.kommander.mesosphere.io/path: "metrics-auth"
+          namespaceSelector:
+            any: true
+          endpoints:
+            - port: metrics
+              interval: 30s
+              bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
         - name: dkp-service-monitor-dkp-logging-grafana-metrics
           selector:
             matchLabels:


### PR DESCRIPTION
**What problem does this PR solve?**:
goes with https://github.com/mesosphere/kommander/pull/7495 to backport https://github.com/mesosphere/kommander/pull/7490

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-115513

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
