### PR TITLE
feat: update k8s to 1.34.10 in 2.17.2

### DIFF
--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -3,7 +3,7 @@
 k8s_versions:
   - 1.32.8
   - 1.33.2
-  - 1.34.6
+  - 1.34.10
 
 # paths to load (in that order)
 paths:


### PR DESCRIPTION
**What problem does this PR solve?**:
update k8s to 1.34.10 in 2.17.2

**Which issue(s) does this PR fix?**:
(https://jira.nutanix.com/browse/NCN-116428)

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
