### PR TITLE
fix: bump flux to v0.3.2 

### DIFF
--- a/applications/kommander-flux/2.8.5/mirror/flux-oci-mirror.yaml
+++ b/applications/kommander-flux/2.8.5/mirror/flux-oci-mirror.yaml
@@ -37,11 +37,7 @@ spec:
         - args:
             - -config-dir
             - /config
-<<<<<<< HEAD:applications/kommander-flux/2.8.5/mirror/flux-oci-mirror.yaml
-          image: mesosphere/flux-oci-mirror:v0.3.1
-=======
           image: mesosphere/flux-oci-mirror:v0.3.2
->>>>>>> 5ecce7783 (fix: bump flux to v0.3.2 for NCN-116967 fix):applications/kommander-flux/2.7.2/mirror/flux-oci-mirror.yaml
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10

--- a/applications/kommander-flux/2.8.5/mirror/flux-oci-mirror.yaml
+++ b/applications/kommander-flux/2.8.5/mirror/flux-oci-mirror.yaml
@@ -37,7 +37,11 @@ spec:
         - args:
             - -config-dir
             - /config
+<<<<<<< HEAD:applications/kommander-flux/2.8.5/mirror/flux-oci-mirror.yaml
           image: mesosphere/flux-oci-mirror:v0.3.1
+=======
+          image: mesosphere/flux-oci-mirror:v0.3.2
+>>>>>>> 5ecce7783 (fix: bump flux to v0.3.2 for NCN-116967 fix):applications/kommander-flux/2.7.2/mirror/flux-oci-mirror.yaml
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10

--- a/artifacts_full.yaml
+++ b/artifacts_full.yaml
@@ -315,7 +315,7 @@ applications:
     version: 2.8.5
     images:
       - oci://ghcr.io/fluxcd-community/charts/flux2:2.18.3
-      - docker.io/mesosphere/flux-oci-mirror:v0.3.1
+      - docker.io/mesosphere/flux-oci-mirror:v0.3.2
       - ghcr.io/fluxcd/flux-cli:v2.8.5
       - ghcr.io/fluxcd/helm-controller:v1.5.4
       - ghcr.io/fluxcd/image-automation-controller:v1.1.1

--- a/hack/flux/update-flux-oci-mirror.sh
+++ b/hack/flux/update-flux-oci-mirror.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="v0.3.1"
+VERSION="v0.3.2"
 
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -4,7 +4,7 @@ ignore:
   #   sources:
   #     - url: https://github.com/nutanix-cloud-native/flux-oci-mirror
   #       ref: ${image_tag}
-  - docker.io/mesosphere/flux-oci-mirror:v0.3.1
+  - docker.io/mesosphere/flux-oci-mirror:v0.3.2
   - pullthrough.infra.nkp.sh/mesosphere/nkp-mcp:0.0.0-dev.0
 
 resources:


### PR DESCRIPTION
**What problem does this PR solve?**:
Backporting https://jira.nutanix.com/browse/NCN-116967 fix by bumping the flux-oci-mirror


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue below-->
https://jira.nutanix.com/browse/NCN-116967

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```

**Checklist**
<!--
For example, If a chart changes license from say Apache License to GNU AFFERO GENERAL PUBLIC LICENSE then
that would have legal repercussions (as we ship helm charts, image bundles for airgapped etc.,) and multiple
parties (Like Product, Legal for example) need to be notified when such a change happens.
-->

- [ ] If the PR adds a version bump, ensure there is no breaking change in Licensing model (or NA).
- [ ] If a chart is changed or app configuration is significantly changed, the chart version is correctly incremented (so that apps are not automatically upgraded from a previous version of DKP).
