### PR TITLE
fix: ship the correct driver w.r.t OOTB image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,8 +36,3 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global  user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           devbox run -- just test-server
-
-      - name: Report Coveralls
-        uses: coverallsapp/github-action@v2
-        with:
-          file: hack/release/coverage.out

--- a/applications/nvidia-gpu-operator/25.3.3/helmrelease/extra-images.txt
+++ b/applications/nvidia-gpu-operator/25.3.3/helmrelease/extra-images.txt
@@ -7,6 +7,6 @@ nvcr.io/nvidia/k8s-device-plugin:{{ .Values.devicePlugin.version }}
 nvcr.io/nvidia/cloud-native/k8s-mig-manager:{{ .Values.migManager.version }}
 # This corresponds to the kernel version 5.15.0-139-generic that the ubuntu pro images that we ship.
 # When the kernel changes this should change too.
-nvcr.io/nvidia/driver:535-5.15.0-139-generic-ubuntu22.04
+nvcr.io/nvidia/driver:580-5.15.0-185-generic-ubuntu22.04
 nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0
 nvcr.io/nvidia/cloud-native/k8s-driver-manager:{{ .Values.driver.manager.version }}

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -492,7 +492,7 @@ resources:
       - license_path: LICENSE
         ref: ${image_tag%-ubuntu20.04}
         url: https://github.com/NVIDIA/mig-parted
-  - container_image: nvcr.io/nvidia/driver:535-5.15.0-139-generic-ubuntu22.04
+  - container_image: nvcr.io/nvidia/driver:580-5.15.0-185-generic-ubuntu22.04
     sources:
       - license_path: LICENSE
         ref: main


### PR DESCRIPTION
**What problem does this PR solve?**:
for release 2.16.2, shipping compatible pre-compiled driver w.r.t the OOTB ubuntu image that will be shipped.

for 2.16.2 release we are shipping Ubuntu22.04 CIS image with kernel [5.15.0-185-generic](http://nvcr.io/nvidia/driver:580-5.15.0-185-generic-ubuntu22.04)

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-115418

OOTB image changes: https://jira.nutanix.com/browse/NCN-117113


